### PR TITLE
Added an infinite loop parser and tests.

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -361,7 +361,8 @@ pub mod parsing {
             // TODO: ForLoop
             // TODO: Loop
             // TODO: ForLoop
-            // TODO: Loop
+            |
+            expr_loop
             // TODO: Match
             // TODO: Closure
             |
@@ -546,6 +547,21 @@ pub mod parsing {
                 rules: BlockCheckMode::Default,
             }),
             else_block.map(Box::new),
+        ))
+    ));
+
+    named!(expr_loop -> Expr, do_parse!(
+        id: option!(
+            terminated!(
+                preceded!(
+                    punct!("'"),
+                    ident),
+                punct!(":"))) >>
+            punct!("loop") >>
+        loop_block: block >>
+        (Expr::Loop(
+            Box::new(loop_block),
+            id,
         ))
     ));
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -337,6 +337,7 @@ pub enum BindingMode {
 pub mod parsing {
     use super::*;
     use {Ident, Ty};
+    use generics::parsing::lifetime;
     use ident::parsing::ident;
     use lit::parsing::lit;
     use nom::multispace;
@@ -551,17 +552,12 @@ pub mod parsing {
     ));
 
     named!(expr_loop -> Expr, do_parse!(
-        id: option!(
-            terminated!(
-                preceded!(
-                    punct!("'"),
-                    ident),
-                punct!(":"))) >>
-            punct!("loop") >>
+        lt: option!(terminated!(lifetime, punct!(":"))) >>
+        punct!("loop") >>
         loop_block: block >>
         (Expr::Loop(
             Box::new(loop_block),
-            id,
+            lt.map(|lt| lt.ident),
         ))
     ));
 

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -13,3 +13,31 @@ fn test_box() {
 
     assert_eq!(expected, parse_expr(raw).unwrap());
 }
+
+#[test]
+fn test_unnamed_loop() {
+    let block = match parse_expr("{ ( 1, 3, 8 ) }").unwrap() {
+        Expr::Block(b) => b,
+        _ => panic!("Could not run test_unnamed_loop: error in block parse."),
+    };
+
+    let raw = "loop {(1, 3, 8 )}";
+
+    let expected = Expr::Loop(block, None);
+
+    assert_eq!(expected, parse_expr(raw).unwrap());
+}
+
+#[test]
+fn test_named_loop() {
+    let block = match parse_expr("{ ( 1, 5, 9, 11) }").unwrap() {
+        Expr::Block(b) => b,
+        _ => panic!("Could not run named_loop: error in block parse."),
+    };
+
+    let raw = "' test : loop{(1, 5, 9, 11)}";
+
+    let expected = Expr::Loop(block, Some("test".into()));
+
+    assert_eq!(expected, parse_expr(raw).unwrap());
+}

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -37,7 +37,7 @@ fn test_named_loop() {
 
     let raw = "' test : loop{(1, 5, 9, 11)}";
 
-    let expected = Expr::Loop(block, Some("test".into()));
+    let expected = Expr::Loop(block, Some("'test".into()));
 
     assert_eq!(expected, parse_expr(raw).unwrap());
 }


### PR DESCRIPTION
This pull request adds the ability to parse `loop{}`.

A couple things: 

I had trouble with emacs and nom's syntax, so if the spacing is off, I apologize. Do you know how to make an editor handle spacing and indentation well for nom macros?

For the tests, I used tuples as statements in the body of the loop, because that's what I could get to parse.

Let me know comments and changes and I'll be glad to make them!