### PR TITLE
Add `VariantData#fields_mut`

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -24,6 +24,14 @@ impl VariantData {
             VariantData::Unit => &[],
         }
     }
+
+    pub fn fields_mut(&mut self) -> &mut [Field] {
+        match *self {
+            VariantData::Struct(ref mut fields) |
+            VariantData::Tuple(ref mut fields) => fields,
+            VariantData::Unit => &mut [],
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]


### PR DESCRIPTION
This adds the mutable equivalent to `VariantData#fields`, and can make
code which needs to mutate those fields a bit less verbose.