### PR TITLE
re-export ExprKind

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub use data::{Field, Variant, VariantData, Visibility};
 #[cfg(feature = "full")]
 mod expr;
 #[cfg(feature = "full")]
-pub use expr::{Arm, BindingMode, Block, BlockCheckMode, CaptureBy, Expr, FieldPat, Local,
+pub use expr::{Arm, BindingMode, Block, BlockCheckMode, CaptureBy, Expr, ExprKind, FieldPat, Local,
                MacStmtStyle, Pat, RangeLimits, Stmt};
 
 mod generics;


### PR DESCRIPTION
Super simple one, just re-exporting `ExprKind` in the root. Or is there a specific reason this wasn't included?