### PR TITLE
Expose the nom parsers in a public `parsing::` submodule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ include = ["Cargo.toml", "src/**/*.rs"]
 default = ["parsing", "printing"]
 aster = []
 full = []
-parsing = ["unicode-xid"]
+parsing = ["unicode-xid", "syn_nom"]
 printing = ["quote"]
 visit = []
 
@@ -20,6 +20,7 @@ visit = []
 clippy = { version = "0.*", optional = true }
 quote = { version = "0.3.0", optional = true }
 unicode-xid = { version = "0.0.4", optional = true }
+syn_nom = { version = "0.1.0", path = "syn_nom/", optional = true }
 
 [dev-dependencies]
 syntex_pos = "0.52.0"

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -99,7 +99,7 @@ pub mod parsing {
     use super::*;
     use ident::parsing::ident;
     use lit::parsing::lit;
-    use space::{block_comment, whitespace};
+    use nom::space::{block_comment, whitespace};
 
     #[cfg(feature = "full")]
     named!(pub inner_attr -> Attribute, alt!(

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -58,7 +58,7 @@ impl<T: ?Sized> PartialEq<T> for Ident
 pub mod parsing {
     use super::*;
     use nom::IResult;
-    use space::skip_whitespace;
+    use nom::space::skip_whitespace;
     use unicode_xid::UnicodeXID;
 
     pub fn ident(input: &str) -> IResult<&str, Ident> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,7 @@ extern crate unicode_xid;
 
 #[cfg(feature = "parsing")]
 #[macro_use]
-mod nom;
-
-#[cfg(feature = "parsing")]
-#[macro_use]
-mod helper;
+extern crate syn_nom as nom;
 
 #[cfg(feature = "aster")]
 pub mod aster;
@@ -73,9 +69,6 @@ pub type MacroInput = DeriveInput;
 mod op;
 pub use op::{BinOp, UnOp};
 
-#[cfg(feature = "parsing")]
-mod space;
-
 mod ty;
 pub use ty::{Abi, AngleBracketedParameterData, BareFnArg, BareFnTy, FunctionRetTy, MutTy,
              Mutability, ParenthesizedParameterData, Path, PathParameters, PathSegment,
@@ -90,8 +83,8 @@ pub use parsing::*;
 #[cfg(feature = "parsing")]
 mod parsing {
     use super::*;
-    use {derive, generics, ident, mac, space, ty};
-    use nom::IResult;
+    use {derive, generics, ident, mac, ty};
+    use nom::{space, IResult};
 
     #[cfg(feature = "full")]
     use {expr, item, krate};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,3 +163,53 @@ mod parsing {
         }
     }
 }
+
+#[cfg(feature = "parsing")]
+pub mod parser {
+    //! This module contains a set of exported nom parsers which can be used to
+    //! build nom parsers for custom grammars when used alongside the `syn_nom`
+    //! crate.
+    //!
+    //! `syn` uses its own custom fork of `nom`, `syn_nom`, which is smaller, and
+    //! thus improves build speeds. This should be used instead of `nom` when
+    //! building parsers using these parsers.
+
+    #[cfg(feature = "full")]
+    pub use krate::parsing::krate;
+
+    #[cfg(feature = "full")]
+    pub use item::parsing::item;
+
+    #[cfg(feature = "full")]
+    pub use item::parsing::items;
+
+    #[cfg(feature = "full")]
+    pub use expr::parsing::expr;
+
+    pub use lit::parsing::lit;
+
+    pub use lit::parsing::string as str_lit;
+
+    pub use lit::parsing::byte_string as byte_str_lit;
+
+    pub use lit::parsing::byte as byte_lit;
+
+    pub use lit::parsing::character as char_lit;
+
+    pub use lit::parsing::float as float_lit;
+
+    pub use lit::parsing::int as int_lit;
+
+    pub use lit::parsing::boolean as bool_lit;
+
+    pub use ty::parsing::ty;
+
+    pub use ty::parsing::path;
+
+    pub use generics::parsing::where_clause;
+
+    #[cfg(feature = "full")]
+    pub use mac::parsing::token_trees;
+
+    pub use ident::parsing::ident;
+}

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -130,33 +130,33 @@ impl_from_for_lit! {Float, [
 pub mod parsing {
     use super::*;
     use escape::{cooked_byte, cooked_byte_string, cooked_char, cooked_string, raw_string};
-    use nom::IResult;
     use nom::space::skip_whitespace;
+    use nom::IResult;
     use unicode_xid::UnicodeXID;
 
     named!(pub lit -> Lit, alt!(
-        string
+        string => { |(value, style)| Lit::Str(value, style) }
         |
-        byte_string
+        byte_string => { |(value, style)| Lit::ByteStr(value, style) }
         |
-        byte
+        byte => { |b| Lit::Byte(b) }
         |
-        character
+        character => { |ch| Lit::Char(ch) }
         |
-        float // must be before int
+        float => { |(value, suffix)| Lit::Float(value, suffix) } // must be before int
         |
         int => { |(value, ty)| Lit::Int(value, ty) }
         |
-        boolean
+        boolean => { |value| Lit::Bool(value) }
     ));
 
-    named!(string -> Lit, alt!(
-        quoted_string => { |s| Lit::Str(s, StrStyle::Cooked) }
+    named!(pub string -> (String, StrStyle), alt!(
+        quoted_string => { |s| (s, StrStyle::Cooked) }
         |
         preceded!(
             punct!("r"),
             raw_string
-        ) => { |(s, n)| Lit::Str(s, StrStyle::Raw(n)) }
+        ) => { |(s, n)| (s, StrStyle::Raw(n)) }
     ));
 
     named!(pub quoted_string -> String, delimited!(
@@ -165,44 +165,43 @@ pub mod parsing {
         tag!("\"")
     ));
 
-    named!(byte_string -> Lit, alt!(
+    named!(pub byte_string -> (Vec<u8>, StrStyle), alt!(
         delimited!(
             punct!("b\""),
             cooked_byte_string,
             tag!("\"")
-        ) => { |vec| Lit::ByteStr(vec, StrStyle::Cooked) }
+        ) => { |vec| (vec, StrStyle::Cooked) }
         |
         preceded!(
             punct!("br"),
             raw_string
-        ) => { |(s, n): (String, _)| Lit::ByteStr(s.into_bytes(), StrStyle::Raw(n)) }
+        ) => { |(s, n): (String, _)| (s.into_bytes(), StrStyle::Raw(n)) }
     ));
 
-    named!(byte -> Lit, do_parse!(
+    named!(pub byte -> u8, do_parse!(
         punct!("b") >>
         tag!("'") >>
         b: cooked_byte >>
         tag!("'") >>
-        (Lit::Byte(b))
+        (b)
     ));
 
-    named!(character -> Lit, do_parse!(
+    named!(pub character -> char, do_parse!(
         punct!("'") >>
         ch: cooked_char >>
         tag!("'") >>
-        (Lit::Char(ch))
+        (ch)
     ));
 
-    named!(float -> Lit, do_parse!(
-        value: float_string >>
-        suffix: alt!(
+    named!(pub float -> (String, FloatTy), tuple!(
+        float_string,
+        alt!(
             tag!("f32") => { |_| FloatTy::F32 }
             |
             tag!("f64") => { |_| FloatTy::F64 }
             |
             epsilon!() => { |_| FloatTy::Unsuffixed }
-        ) >>
-        (Lit::Float(value, suffix))
+        )
     ));
 
     named!(pub int -> (u64, IntTy), tuple!(
@@ -232,10 +231,10 @@ pub mod parsing {
         )
     ));
 
-    named!(boolean -> Lit, alt!(
-        keyword!("true") => { |_| Lit::Bool(true) }
+    named!(pub boolean -> bool, alt!(
+        keyword!("true") => { |_| true }
         |
-        keyword!("false") => { |_| Lit::Bool(false) }
+        keyword!("false") => { |_| false }
     ));
 
     fn float_string(mut input: &str) -> IResult<&str, String> {

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -130,8 +130,8 @@ impl_from_for_lit! {Float, [
 pub mod parsing {
     use super::*;
     use escape::{cooked_byte, cooked_byte_string, cooked_char, cooked_string, raw_string};
-    use space::skip_whitespace;
     use nom::IResult;
+    use nom::space::skip_whitespace;
     use unicode_xid::UnicodeXID;
 
     named!(pub lit -> Lit, alt!(

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -116,7 +116,7 @@ pub mod parsing {
     use generics::parsing::lifetime;
     use ident::parsing::word;
     use lit::parsing::lit;
-    use space::{block_comment, whitespace};
+    use nom::space::{block_comment, whitespace};
     use ty::parsing::path;
 
     named!(pub mac -> Mac, do_parse!(

--- a/syn_nom/Cargo.toml
+++ b/syn_nom/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "syn_nom"
+version = "0.1.0"
+authors = ["David Tolnay <dtolnay@gmail.com>"]
+license = "MIT/Apache-2.0"
+description = "stripped-down Nom parser used by Syn"
+repository = "https://github.com/dtolnay/syn"
+documentation = "https://dtolnay.github.io/syn/syn_nom/"
+include = ["Cargo.toml", "src/**/*.rs"]
+
+[dependencies]
+unicode-xid = "0.0.4"

--- a/syn_nom/src/helper.rs
+++ b/syn_nom/src/helper.rs
@@ -1,9 +1,10 @@
-use nom::IResult;
+use IResult;
 use space::{skip_whitespace, word_break};
 
+#[macro_export]
 macro_rules! punct {
     ($i:expr, $punct:expr) => {
-        $crate::helper::punct($i, $punct)
+        $crate::punct($i, $punct)
     };
 }
 
@@ -16,9 +17,10 @@ pub fn punct<'a>(input: &'a str, token: &'static str) -> IResult<&'a str, &'a st
     }
 }
 
+#[macro_export]
 macro_rules! keyword {
     ($i:expr, $keyword:expr) => {
-        $crate::helper::keyword($i, $keyword)
+        $crate::keyword($i, $keyword)
     };
 }
 
@@ -34,11 +36,12 @@ pub fn keyword<'a>(input: &'a str, token: &'static str) -> IResult<&'a str, &'a 
     }
 }
 
+#[macro_export]
 macro_rules! option {
     ($i:expr, $submac:ident!( $($args:tt)* )) => {
         match $submac!($i, $($args)*) {
-            $crate::nom::IResult::Done(i, o) => $crate::nom::IResult::Done(i, Some(o)),
-            $crate::nom::IResult::Error => $crate::nom::IResult::Done($i, None),
+            $crate::IResult::Done(i, o) => $crate::IResult::Done(i, Some(o)),
+            $crate::IResult::Error => $crate::IResult::Done($i, None),
         }
     };
 
@@ -47,30 +50,33 @@ macro_rules! option {
     };
 }
 
+#[macro_export]
 macro_rules! opt_vec {
     ($i:expr, $submac:ident!( $($args:tt)* )) => {
         match $submac!($i, $($args)*) {
-            $crate::nom::IResult::Done(i, o) => $crate::nom::IResult::Done(i, o),
-            $crate::nom::IResult::Error => $crate::nom::IResult::Done($i, Vec::new()),
+            $crate::IResult::Done(i, o) => $crate::IResult::Done(i, o),
+            $crate::IResult::Error => $crate::IResult::Done($i, Vec::new()),
         }
     };
 }
 
+#[macro_export]
 macro_rules! epsilon {
     ($i:expr,) => {
-        $crate::nom::IResult::Done($i, ())
+        $crate::IResult::Done($i, ())
     };
 }
 
+#[macro_export]
 macro_rules! tap {
     ($i:expr, $name:ident : $submac:ident!( $($args:tt)* ) => $e:expr) => {
         match $submac!($i, $($args)*) {
-            $crate::nom::IResult::Done(i, o) => {
+            $crate::IResult::Done(i, o) => {
                 let $name = o;
                 $e;
-                $crate::nom::IResult::Done(i, ())
+                $crate::IResult::Done(i, ())
             }
-            $crate::nom::IResult::Error => $crate::nom::IResult::Error,
+            $crate::IResult::Error => $crate::IResult::Error,
         }
     };
 
@@ -79,15 +85,17 @@ macro_rules! tap {
     };
 }
 
+#[macro_export]
 macro_rules! separated_list {
     ($i:expr, punct!($sep:expr), $f:expr) => {
-        $crate::helper::separated_list($i, $sep, $f, false)
+        $crate::separated_list($i, $sep, $f, false)
     };
 }
 
+#[macro_export]
 macro_rules! terminated_list {
     ($i:expr, punct!($sep:expr), $f:expr) => {
-        $crate::helper::separated_list($i, $sep, $f, true)
+        $crate::separated_list($i, $sep, $f, true)
     };
 }
 

--- a/syn_nom/src/space.rs
+++ b/syn_nom/src/space.rs
@@ -1,4 +1,4 @@
-use nom::IResult;
+use IResult;
 use unicode_xid::UnicodeXID;
 
 pub fn whitespace(input: &str) -> IResult<&str, ()> {


### PR DESCRIPTION
I quickly threw this together, because this solution is super easy and straightforward.

Fixes #81.