### PR TITLE
Update unicode-xid dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ visit = []
 [dependencies]
 clippy = { version = "0.*", optional = true }
 quote = { version = "0.3.0", optional = true }
-unicode-xid = { version = "0.0.3", optional = true }
+unicode-xid = { version = "0.0.4", optional = true }
 
 [dev-dependencies]
 syntex_pos = "0.52.0"


### PR DESCRIPTION
This helps Servo avoid having two copies of it.