### PR TITLE
public attribute parsers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub use parsing::*;
 #[cfg(feature = "parsing")]
 mod parsing {
     use super::*;
-    use {derive, generics, ident, mac, ty};
+    use {derive, generics, ident, mac, ty, attr};
     use synom::{space, IResult};
 
     #[cfg(feature = "full")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,15 @@ mod parsing {
         unwrap("type parameter bound", generics::parsing::ty_param_bound, input)
     }
 
+    pub fn parse_outer_attr(input: &str) -> Result<Attribute, String> {
+        unwrap("outer attribute", attr::parsing::outer_attr, input)
+    }
+
+    #[cfg(feature = "full")]
+    pub fn parse_inner_attr(input: &str) -> Result<Attribute, String> {
+        unwrap("inner attribute", attr::parsing::inner_attr, input)
+    }
+
     // Deprecated. Use `parse_derive_input` instead.
     #[doc(hidden)]
     pub fn parse_macro_input(input: &str) -> Result<MacroInput, String> {

--- a/tests/test_macro_input.rs
+++ b/tests/test_macro_input.rs
@@ -74,6 +74,7 @@ fn test_struct() {
 }
 
 #[test]
+#[cfg(feature = "full")]
 fn test_enum() {
     let raw = r#"
         /// See the std::result module documentation for details.


### PR DESCRIPTION
I would like to have access to attribute parsing.

My use case is this: I am writing unit tests for `derive_builder`.

```rust
#[test]
fn setter_enabled() {
    let attr = syn::Attribute{
        style: syn::AttrStyle::Outer,
        value: syn::MetaItem::Word(syn::Ident::new("foo")),
        is_sugared_doc: false,
    };

    let field = BuilderField {
        attrs: &vec![&attr],
        /* ... */
    };

    assert_eq!(quote!(#field), quote!(
        #[foo] pub foo: ::std::option::Option<String>,
    ));
}
```

would simplify to


```rust
#[test]
fn setter_enabled() {
    let attr = syn::parse_outer_attr("#[foo]").unwrap();

    let field = BuilderField {
        attrs: &vec![&attr],
        /* ... */
    };

    assert_eq!(quote!(#field), quote!(
        #[foo] pub foo: ::std::option::Option<String>,
    ));
}
```