### PR TITLE
Support parsing attributes with arbitrary tokens.

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -182,6 +182,8 @@ impl<'a, T> FilterAttrs<'a> for T
 pub mod parsing {
     use super::*;
     use ident::parsing::ident;
+    use lit::{Lit, StrStyle};
+    use mac::{Token, TokenTree};
     use mac::parsing::token_trees;
     use synom::space::{block_comment, whitespace};
 
@@ -293,6 +295,7 @@ pub mod parsing {
 mod printing {
     use super::*;
     use lit::{Lit, StrStyle};
+    use mac::{Token, TokenTree};
     use quote::{Tokens, ToTokens};
 
     impl ToTokens for Attribute {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -6,13 +6,99 @@ use std::iter;
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Attribute {
     pub style: AttrStyle,
-    pub value: MetaItem,
+    pub name: Ident,
+    pub tts: Vec<TokenTree>,
     pub is_sugared_doc: bool,
 }
 
 impl Attribute {
-    pub fn name(&self) -> &str {
-        self.value.name()
+    pub fn meta_item(&self) -> Option<MetaItem> {
+        if self.tts.is_empty() {
+            return Some(MetaItem::Word);
+        }
+
+        if self.tts.len() == 1 {
+            if let TokenTree::Delimited(Delimited { delim: DelimToken::Paren, ref tts }) = self.tts[0] {
+                fn nested_meta_item_from_tokens(tts: &[TokenTree]) -> Option<(NestedMetaItem, &[TokenTree])> {
+                    assert!(!tts.is_empty());
+
+                    match tts[0] {
+                        TokenTree::Token(Token::Literal(ref lit)) => {
+                            Some((NestedMetaItem::Literal(lit.clone()), &tts[1..]))
+                        }
+
+                        TokenTree::Token(Token::Ident(ref ident)) => {
+                            if tts.len() >= 3 {
+                                match (&tts[1], &tts[2]) {
+                                    (&TokenTree::Token(Token::Eq), &TokenTree::Token(Token::Literal(ref lit))) => {
+                                        return Some((NestedMetaItem::MetaItem(ident.clone(), MetaItem::NameValue(lit.clone())), &tts[3..]));
+                                    }
+
+                                    _ => {}
+                                }
+                            }
+
+                            if tts.len() >= 2 {
+                                if let TokenTree::Delimited(Delimited { delim: DelimToken::Paren, tts: ref inner_tts }) = tts[1] {
+                                    return match list_of_nested_meta_items_from_tokens(vec![], inner_tts) {
+                                        Some(nested_meta_items) => {
+                                            Some((NestedMetaItem::MetaItem(ident.clone(), MetaItem::List(nested_meta_items)), &tts[2..]))
+                                        }
+
+                                        None => None
+                                    };
+                                }
+                            }
+
+                            Some((NestedMetaItem::MetaItem(ident.clone(), MetaItem::Word), &tts[1..]))
+                        }
+
+                        _ => None
+                    }
+                }
+
+                fn list_of_nested_meta_items_from_tokens(mut result: Vec<NestedMetaItem>, tts: &[TokenTree]) -> Option<Vec<NestedMetaItem>> {
+                    if tts.is_empty() {
+                        return Some(result);
+                    }
+
+                    match nested_meta_item_from_tokens(tts) {
+                        Some((nested_meta_item, rest)) => {
+                            result.push(nested_meta_item);
+                            if rest.is_empty() {
+                                list_of_nested_meta_items_from_tokens(result, rest)
+                            }
+                            else {
+                                if let TokenTree::Token(Token::Comma) = rest[0] {
+                                    list_of_nested_meta_items_from_tokens(result, &rest[1..])
+                                }
+                                else {
+                                   None
+                                }
+                            }
+                        }
+
+                        None => None
+                    }
+                }
+
+                if let Some(nested_meta_items) = list_of_nested_meta_items_from_tokens(vec![], tts) {
+                    return Some(MetaItem::List(nested_meta_items));
+                }
+            }
+        }
+
+        if self.tts.len() == 2 {
+            match (&self.tts[0], &self.tts[1]) {
+                (&TokenTree::Token(Token::Eq), &TokenTree::Token(Token::Literal(ref lit))) => {
+                    return Some(MetaItem::NameValue(lit.clone()));
+                }
+
+                _ => {}
+            }
+        }
+
+        None
     }
 }
 
@@ -36,37 +122,17 @@ pub enum MetaItem {
     /// Word meta item.
     ///
     /// E.g. `test` as in `#[test]`
-    Word(Ident),
+    Word,
 
     /// List meta item.
     ///
     /// E.g. `derive(..)` as in `#[derive(..)]`
-    List(Ident, Vec<NestedMetaItem>),
+    List(Vec<NestedMetaItem>),
 
     /// Name-value meta item.
     ///
     /// E.g. `feature = "foo"` as in `#[feature = "foo"]`
-    NameValue(Ident, Lit),
-
-    /// Tokens meta item.
-    ///
-    /// E.g. `test foo bar` as in `#[test foo bar]`
-    Tokens(Ident, Vec<TokenTree>),
-}
-
-impl MetaItem {
-    /// Name of the item.
-    ///
-    /// E.g. `test` as in `#[test]`, `derive` as in `#[derive(..)]`, and
-    /// `feature` as in `#[feature = "foo"]`.
-    pub fn name(&self) -> &str {
-        match *self {
-            MetaItem::Word(ref name) |
-            MetaItem::List(ref name, _) |
-            MetaItem::NameValue(ref name, _) |
-            MetaItem::Tokens(ref name, _) => name.as_ref(),
-        }
-    }
+    NameValue(Lit),
 }
 
 /// Possible values inside of compile-time attribute lists.
@@ -76,8 +142,8 @@ impl MetaItem {
 pub enum NestedMetaItem {
     /// A full `MetaItem`.
     ///
-    /// E.g. `Copy` in `#[derive(Copy)]` would be a `MetaItem::Word(Ident::from("Copy"))`.
-    MetaItem(MetaItem),
+    /// E.g. `Copy` in `#[derive(Copy)]` would be a `(Ident::from("Copy"), MetaItem::Word)`.
+    MetaItem(Ident, MetaItem),
 
     /// A Rust literal.
     ///
@@ -116,7 +182,6 @@ impl<'a, T> FilterAttrs<'a> for T
 pub mod parsing {
     use super::*;
     use ident::parsing::ident;
-    use lit::parsing::lit;
     use mac::parsing::token_trees;
     use synom::space::{block_comment, whitespace};
 
@@ -125,13 +190,20 @@ pub mod parsing {
         do_parse!(
             punct!("#") >>
             punct!("!") >>
-            punct!("[") >>
-            meta_item: meta_item >>
-            punct!("]") >>
-            (Attribute {
-                style: AttrStyle::Inner,
-                value: meta_item,
-                is_sugared_doc: false,
+            name_and_tts: delimited!(
+                punct!("["),
+                tuple!(ident, token_trees),
+                punct!("]")
+            ) >>
+            ({
+                let (name, tts) = name_and_tts;
+
+                Attribute {
+                    style: AttrStyle::Inner,
+                    name: name,
+                    tts: tts,
+                    is_sugared_doc: false,
+                }
             })
         )
         |
@@ -140,10 +212,11 @@ pub mod parsing {
             content: take_until!("\n") >>
             (Attribute {
                 style: AttrStyle::Inner,
-                value: MetaItem::NameValue(
-                    "doc".into(),
-                    format!("//!{}", content).into(),
-                ),
+                name: "doc".into(),
+                tts: vec![
+                    TokenTree::Token(Token::Eq),
+                    TokenTree::Token(Token::Literal(Lit::Str(format!("//!{}", content).into(), StrStyle::Cooked))),
+                ],
                 is_sugared_doc: true,
             })
         )
@@ -154,10 +227,11 @@ pub mod parsing {
             com: block_comment >>
             (Attribute {
                 style: AttrStyle::Inner,
-                value: MetaItem::NameValue(
-                    "doc".into(),
-                    com.into(),
-                ),
+                name: "doc".into(),
+                tts: vec![
+                    TokenTree::Token(Token::Eq),
+                    TokenTree::Token(Token::Literal(Lit::Str(com.into(), StrStyle::Cooked))),
+                ],
                 is_sugared_doc: true,
             })
         )
@@ -166,32 +240,20 @@ pub mod parsing {
     named!(pub outer_attr -> Attribute, alt!(
         do_parse!(
             punct!("#") >>
-            punct!("[") >>
-            meta_item: meta_item >>
-            punct!("]") >>
-            (Attribute {
-                style: AttrStyle::Outer,
-                value: meta_item,
-                is_sugared_doc: false,
-            })
-        )
-        |
-        do_parse!(
-            name_and_token_trees: preceded!(
-                punct!("#"),
-                delimited!(
-                    punct!("["),
-                    tuple!(ident, token_trees),
-                    punct!("]")
-                )
+            name_and_tts: delimited!(
+                punct!("["),
+                tuple!(ident, token_trees),
+                punct!("]")
             ) >>
-            (Attribute {
-                style: AttrStyle::Outer,
-                value: {
-                    let (name, token_trees) = name_and_token_trees;
-                    MetaItem::Tokens(name, token_trees)
-                },
-                is_sugared_doc: false,
+            ({
+                let (name, tts) = name_and_tts;
+
+                Attribute {
+                    style: AttrStyle::Outer,
+                    name: name,
+                    tts: tts,
+                    is_sugared_doc: false,
+                }
             })
         )
         |
@@ -201,10 +263,11 @@ pub mod parsing {
             content: take_until!("\n") >>
             (Attribute {
                 style: AttrStyle::Outer,
-                value: MetaItem::NameValue(
-                    "doc".into(),
-                    format!("///{}", content).into(),
-                ),
+                name: "doc".into(),
+                tts: vec![
+                    TokenTree::Token(Token::Eq),
+                    TokenTree::Token(Token::Literal(Lit::Str(format!("///{}", content).into(), StrStyle::Cooked))),
+                ],
                 is_sugared_doc: true,
             })
         )
@@ -215,38 +278,14 @@ pub mod parsing {
             com: block_comment >>
             (Attribute {
                 style: AttrStyle::Outer,
-                value: MetaItem::NameValue(
-                    "doc".into(),
-                    com.into(),
-                ),
+                name: "doc".into(),
+                tts: vec![
+                    TokenTree::Token(Token::Eq),
+                    TokenTree::Token(Token::Literal(Lit::Str(com.into(), StrStyle::Cooked))),
+                ],
                 is_sugared_doc: true,
             })
         )
-    ));
-
-    named!(meta_item -> MetaItem, alt!(
-        do_parse!(
-            id: ident >>
-            punct!("(") >>
-            inner: terminated_list!(punct!(","), nested_meta_item) >>
-            punct!(")") >>
-            (MetaItem::List(id, inner))
-        )
-        |
-        do_parse!(
-            name: ident >>
-            punct!("=") >>
-            value: lit >>
-            (MetaItem::NameValue(name, value))
-        )
-        |
-        map!(ident, MetaItem::Word)
-    ));
-
-    named!(nested_meta_item -> NestedMetaItem, alt!(
-        meta_item => { NestedMetaItem::MetaItem }
-        |
-        lit => { NestedMetaItem::Literal }
     ));
 }
 
@@ -258,28 +297,32 @@ mod printing {
 
     impl ToTokens for Attribute {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            if let Attribute { style,
-                               value: MetaItem::NameValue(ref name,
-                                                   Lit::Str(ref value, StrStyle::Cooked)),
-                               is_sugared_doc: true } = *self {
-                if name == "doc" {
-                    match style {
-                        AttrStyle::Inner if value.starts_with("//!") => {
-                            tokens.append(&format!("{}\n", value));
-                            return;
+            if let Attribute { style, ref name, ref tts, is_sugared_doc: true } = *self {
+                if name == "doc" && tts.len() == 2 {
+                    match (&tts[0], &tts[1]) {
+                        (&TokenTree::Token(Token::Eq),
+                         &TokenTree::Token(Token::Literal(Lit::Str(ref value, StrStyle::Cooked)))) => {
+                            match style {
+                                AttrStyle::Inner if value.starts_with("//!") => {
+                                    tokens.append(&format!("{}\n", value));
+                                    return;
+                                }
+                                AttrStyle::Inner if value.starts_with("/*!") => {
+                                    tokens.append(value);
+                                    return;
+                                }
+                                AttrStyle::Outer if value.starts_with("///") => {
+                                    tokens.append(&format!("{}\n", value));
+                                    return;
+                                }
+                                AttrStyle::Outer if value.starts_with("/**") => {
+                                    tokens.append(value);
+                                    return;
+                                }
+                                _ => {}
+                            }
                         }
-                        AttrStyle::Inner if value.starts_with("/*!") => {
-                            tokens.append(value);
-                            return;
-                        }
-                        AttrStyle::Outer if value.starts_with("///") => {
-                            tokens.append(&format!("{}\n", value));
-                            return;
-                        }
-                        AttrStyle::Outer if value.starts_with("/**") => {
-                            tokens.append(value);
-                            return;
-                        }
+
                         _ => {}
                     }
                 }
@@ -290,7 +333,8 @@ mod printing {
                 tokens.append("!");
             }
             tokens.append("[");
-            self.value.to_tokens(tokens);
+            self.name.to_tokens(tokens);
+            tokens.append_all(&self.tts);
             tokens.append("]");
         }
     }
@@ -298,23 +342,15 @@ mod printing {
     impl ToTokens for MetaItem {
         fn to_tokens(&self, tokens: &mut Tokens) {
             match *self {
-                MetaItem::Word(ref ident) => {
-                    ident.to_tokens(tokens);
-                }
-                MetaItem::List(ref ident, ref inner) => {
-                    ident.to_tokens(tokens);
+                MetaItem::Word => {}
+                MetaItem::List(ref inner) => {
                     tokens.append("(");
                     tokens.append_separated(inner, ",");
                     tokens.append(")");
                 }
-                MetaItem::NameValue(ref name, ref value) => {
-                    name.to_tokens(tokens);
+                MetaItem::NameValue(ref value) => {
                     tokens.append("=");
                     value.to_tokens(tokens);
-                }
-                MetaItem::Tokens(ref name, ref token_trees) => {
-                    name.to_tokens(tokens);
-                    tokens.append_all(token_trees);
                 }
             }
         }
@@ -323,7 +359,8 @@ mod printing {
     impl ToTokens for NestedMetaItem {
         fn to_tokens(&self, tokens: &mut Tokens) {
             match *self {
-                NestedMetaItem::MetaItem(ref nested) => {
+                NestedMetaItem::MetaItem(ref ident, ref nested) => {
+                    ident.to_tokens(tokens);
                     nested.to_tokens(tokens);
                 }
                 NestedMetaItem::Literal(ref lit) => {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -68,13 +68,11 @@ impl Attribute {
                             if rest.is_empty() {
                                 list_of_nested_meta_items_from_tokens(result, rest)
                             }
+                            else if let TokenTree::Token(Token::Comma) = rest[0] {
+                                list_of_nested_meta_items_from_tokens(result, &rest[1..])
+                            }
                             else {
-                                if let TokenTree::Token(Token::Comma) = rest[0] {
-                                    list_of_nested_meta_items_from_tokens(result, &rest[1..])
-                                }
-                                else {
-                                   None
-                                }
+                                None
                             }
                         }
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -6,12 +6,24 @@ use std::iter;
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Attribute {
     pub style: AttrStyle,
+
+    /// The path of the attribute.
+    ///
+    /// E.g. `derive` in `#[derive(Copy)]`
+    /// E.g. `crate::precondition` in `#[crate::precondition x < 5]`
     pub path: Path,
+
+    /// Any tokens after the path.
+    ///
+    /// E.g. `( Copy )` in `#[derive(Copy)]`
+    /// E.g. `x < 5` in `#[crate::precondition x < 5]`
     pub tts: Vec<TokenTree>,
+
     pub is_sugared_doc: bool,
 }
 
 impl Attribute {
+    /// Parses the tokens after the path as a [`MetaItem`](enum.MetaItem.html) if possible.
     pub fn meta_item(&self) -> Option<MetaItem> {
         if self.tts.is_empty() {
             return Some(MetaItem::Word);
@@ -298,6 +310,7 @@ mod printing {
 
     impl ToTokens for Attribute {
         fn to_tokens(&self, tokens: &mut Tokens) {
+            // If this was a sugared doc, emit it in its original form instead of `#[doc = "..."]`
             match *self {
                 Attribute {
                     style,

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -307,6 +307,7 @@ mod printing {
     use lit::{Lit, StrStyle};
     use mac::{Token, TokenTree};
     use quote::{Tokens, ToTokens};
+    use ty::Path;
 
     impl ToTokens for Attribute {
         fn to_tokens(&self, tokens: &mut Tokens) {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -211,7 +211,7 @@ pub mod parsing {
     use mac::{Token, TokenTree};
     use mac::parsing::token_trees;
     use synom::space::{block_comment, whitespace};
-    use ty::parsing::path;
+    use ty::parsing::mod_style_path;
 
     #[cfg(feature = "full")]
     named!(pub inner_attr -> Attribute, alt!(
@@ -220,7 +220,7 @@ pub mod parsing {
             punct!("!") >>
             path_and_tts: delimited!(
                 punct!("["),
-                tuple!(path, token_trees),
+                tuple!(mod_style_path, token_trees),
                 punct!("]")
             ) >>
             ({
@@ -270,7 +270,7 @@ pub mod parsing {
             punct!("#") >>
             path_and_tts: delimited!(
                 punct!("["),
-                tuple!(path, token_trees),
+                tuple!(mod_style_path, token_trees),
                 punct!("]")
             ) >>
             ({

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -47,12 +47,10 @@ impl Attribute {
 
                         TokenTree::Token(Token::Ident(ref ident)) => {
                             if tts.len() >= 3 {
-                                match (&tts[1], &tts[2]) {
-                                    (&TokenTree::Token(Token::Eq), &TokenTree::Token(Token::Literal(ref lit))) => {
+                                if let TokenTree::Token(Token::Eq) = tts[1] {
+                                    if let TokenTree::Token(Token::Literal(ref lit)) = tts[2] {
                                         return Some((NestedMetaItem::MetaItem(MetaItem::NameValue(ident.clone(), lit.clone())), &tts[3..]));
                                     }
-
-                                    _ => {}
                                 }
                             }
 
@@ -105,12 +103,10 @@ impl Attribute {
         }
 
         if self.tts.len() == 2 {
-            match (&self.tts[0], &self.tts[1]) {
-                (&TokenTree::Token(Token::Eq), &TokenTree::Token(Token::Literal(ref lit))) => {
+            if let TokenTree::Token(Token::Eq) = self.tts[0] {
+                if let TokenTree::Token(Token::Literal(ref lit)) = self.tts[1] {
                     return Some(MetaItem::NameValue(name.clone(), lit.clone()));
                 }
-
-                _ => {}
             }
         }
 
@@ -343,10 +339,8 @@ mod printing {
                      segments[0].parameters.is_empty() &&
                      tts.len() == 2 =>
                 {
-                    match (&self.tts[0], &self.tts[1]) {
-                        (&TokenTree::Token(Token::Eq),
-                         &TokenTree::Token(Token::Literal(Lit::Str(ref value, StrStyle::Cooked)))) =>
-                        {
+                    if let TokenTree::Token(Token::Eq) = self.tts[0] {
+                        if let TokenTree::Token(Token::Literal(Lit::Str(ref value, StrStyle::Cooked))) = self.tts[1] {
                             match style {
                                 AttrStyle::Inner if value.starts_with("//!") => {
                                     tokens.append(&format!("{}\n", value));
@@ -367,8 +361,6 @@ mod printing {
                                 _ => {}
                             }
                         }
-
-                        _ => {}
                     }
                 }
 

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -519,6 +519,27 @@ pub mod parsing {
         ), Into::into)
     ));
 
+    named!(pub mod_style_path -> Path, do_parse!(
+        global: option!(punct!("::")) >>
+        segments: separated_nonempty_list!(punct!("::"), mod_style_path_segment) >>
+        (Path {
+            global: global.is_some(),
+            segments: segments,
+        })
+    ));
+
+    named!(mod_style_path_segment -> PathSegment, alt!(
+        map!(ident, Into::into)
+        |
+        map!(alt!(
+            keyword!("super")
+            |
+            keyword!("self")
+            |
+            keyword!("Self")
+        ), Into::into)
+    ));
+
     named!(type_binding -> TypeBinding, do_parse!(
         id: ident >>
         punct!("=") >>

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -21,7 +21,8 @@ fn test_split_for_impl() {
         ty_params: vec![TyParam {
                             attrs: vec![Attribute {
                                             style: AttrStyle::Outer,
-                                            value: MetaItem::Word("may_dangle".into()),
+                                            name: "may_dangle".into(),
+                                            tts: vec![],
                                             is_sugared_doc: false,
                                         }],
                             ident: Ident::new("T"),

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -21,7 +21,7 @@ fn test_split_for_impl() {
         ty_params: vec![TyParam {
                             attrs: vec![Attribute {
                                             style: AttrStyle::Outer,
-                                            name: "may_dangle".into(),
+                                            path: "may_dangle".into(),
                                             tts: vec![],
                                             is_sugared_doc: false,
                                         }],

--- a/tests/test_macro_input.rs
+++ b/tests/test_macro_input.rs
@@ -258,3 +258,61 @@ fn test_attr_with_path() {
 
     assert!(actual.attrs[0].meta_item().is_none());
 }
+
+#[test]
+fn test_attr_with_non_mod_style_path() {
+    let raw =r#"
+        #[inert <T>]
+        struct S;
+    "#;
+
+    let expected = MacroInput {
+        ident: "S".into(),
+        vis: Visibility::Inherited,
+        attrs: vec![Attribute {
+            style: AttrStyle::Outer,
+            path: Path { global: false, segments: vec!["inert".into()] },
+            tts: vec![
+                TokenTree::Token(Token::Lt),
+                TokenTree::Token(Token::Ident("T".into())),
+                TokenTree::Token(Token::Gt),
+            ],
+            is_sugared_doc: false,
+        }],
+        generics: Generics::default(),
+        body: Body::Struct(VariantData::Unit),
+    };
+
+    let actual = parse_macro_input(raw).unwrap();
+
+    assert_eq!(expected, actual);
+
+    assert!(actual.attrs[0].meta_item().is_none());
+}
+
+#[test]
+fn test_attr_with_mod_style_path_with_self() {
+    let raw =r#"
+        #[foo::self]
+        struct S;
+    "#;
+
+    let expected = MacroInput {
+        ident: "S".into(),
+        vis: Visibility::Inherited,
+        attrs: vec![Attribute {
+            style: AttrStyle::Outer,
+            path: Path { global: false, segments: vec!["foo".into(), "self".into()] },
+            tts: vec![],
+            is_sugared_doc: false,
+        }],
+        generics: Generics::default(),
+        body: Body::Struct(VariantData::Unit),
+    };
+
+    let actual = parse_macro_input(raw).unwrap();
+
+    assert_eq!(expected, actual);
+
+    assert!(actual.attrs[0].meta_item().is_none());
+}

--- a/tests/test_macro_input.rs
+++ b/tests/test_macro_input.rs
@@ -34,9 +34,9 @@ fn test_struct() {
             path: "derive".into(),
             tts: vec![
                 TokenTree::Delimited(Delimited { delim: DelimToken::Paren, tts: vec![
-                    TokenTree::Token(Token::Ident(Ident::from("Debug"))),
+                    TokenTree::Token(Token::Ident("Debug".into())),
                     TokenTree::Token(Token::Comma),
-                    TokenTree::Token(Token::Ident(Ident::from("Clone"))),
+                    TokenTree::Token(Token::Ident("Clone".into())),
                 ]})
             ],
             is_sugared_doc: false,
@@ -75,9 +75,9 @@ fn test_struct() {
 
     assert_eq!(expected, actual);
 
-    let expected_meta_item = MetaItem::List(vec![
-        NestedMetaItem::MetaItem(Ident::from("Debug"), MetaItem::Word),
-        NestedMetaItem::MetaItem(Ident::from("Clone"), MetaItem::Word),
+    let expected_meta_item = MetaItem::List("derive".into(), vec![
+        NestedMetaItem::MetaItem(MetaItem::Word("Debug".into())),
+        NestedMetaItem::MetaItem(MetaItem::Word("Clone".into())),
     ]);
 
     assert_eq!(expected_meta_item, actual.attrs[0].meta_item().unwrap());
@@ -204,11 +204,11 @@ fn test_enum() {
     assert_eq!(expected, actual);
 
     let expected_meta_items = vec![
-        MetaItem::NameValue(Lit::Str(
+        MetaItem::NameValue("doc".into(), Lit::Str(
             "/// See the std::result module documentation for details.".into(),
             StrStyle::Cooked,
         )),
-        MetaItem::Word,
+        MetaItem::Word("must_use".into()),
     ];
 
     let actual_meta_items: Vec<_> = actual.attrs.into_iter().map(|attr| attr.meta_item().unwrap()).collect();
@@ -231,14 +231,14 @@ fn test_attr_with_path() {
             style: AttrStyle::Outer,
             path: Path { global: true, segments: vec!["attr_args".into(), "identity".into()] },
             tts: vec![
-                TokenTree::Token(Token::Ident(Ident::from("fn"))),
-                TokenTree::Token(Token::Ident(Ident::from("main"))),
+                TokenTree::Token(Token::Ident("fn".into())),
+                TokenTree::Token(Token::Ident("main".into())),
                 TokenTree::Delimited(Delimited { delim: DelimToken::Paren, tts: vec![] }),
                 TokenTree::Delimited(Delimited { delim: DelimToken::Brace, tts: vec![
-                    TokenTree::Token(Token::Ident(Ident::from("assert_eq"))),
+                    TokenTree::Token(Token::Ident("assert_eq".into())),
                     TokenTree::Token(Token::Not),
                     TokenTree::Delimited(Delimited { delim: DelimToken::Paren, tts: vec![
-                        TokenTree::Token(Token::Ident(Ident::from("foo"))),
+                        TokenTree::Token(Token::Ident("foo".into())),
                         TokenTree::Delimited(Delimited { delim: DelimToken::Paren, tts: vec![] }),
                         TokenTree::Token(Token::Comma),
                         TokenTree::Token(Token::Literal(Lit::Str("Hello, world!".into(), StrStyle::Cooked))),

--- a/tests/test_macro_input.rs
+++ b/tests/test_macro_input.rs
@@ -31,7 +31,7 @@ fn test_struct() {
         vis: Visibility::Public,
         attrs: vec![Attribute {
             style: AttrStyle::Outer,
-            name: "derive".into(),
+            path: "derive".into(),
             tts: vec![
                 TokenTree::Delimited(Delimited { delim: DelimToken::Paren, tts: vec![
                     TokenTree::Token(Token::Ident(Ident::from("Debug"))),
@@ -106,7 +106,7 @@ fn test_enum() {
         attrs: vec![
             Attribute {
                 style: AttrStyle::Outer,
-                name: "doc".into(),
+                path: "doc".into(),
                 tts: vec![
                     TokenTree::Token(Token::Eq),
                     TokenTree::Token(Token::Literal(Lit::Str(
@@ -118,7 +118,7 @@ fn test_enum() {
             },
             Attribute {
                 style: AttrStyle::Outer,
-                name: "must_use".into(),
+                path: "must_use".into(),
                 tts: vec![],
                 is_sugared_doc: false,
             },

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -3,38 +3,48 @@ use syn::*;
 
 #[test]
 fn test_meta_item_word() {
-    run_test("#[foo]", MetaItem::Word)
+    run_test("#[foo]", MetaItem::Word("foo".into()))
 }
 
 #[test]
 fn test_meta_item_name_value() {
-    run_test("#[foo = 5]", MetaItem::NameValue(Lit::Int(5, IntTy::Unsuffixed)))
+    run_test("#[foo = 5]", MetaItem::NameValue("foo".into(),
+        Lit::Int(5, IntTy::Unsuffixed)))
 }
 
 #[test]
 fn test_meta_item_list_lit() {
-    run_test("#[foo(5)]", MetaItem::List(vec![NestedMetaItem::Literal(Lit::Int(5, IntTy::Unsuffixed))]))
+    run_test("#[foo(5)]", MetaItem::List("foo".into(), vec![
+        NestedMetaItem::Literal(Lit::Int(5, IntTy::Unsuffixed)),
+    ]))
 }
 
 #[test]
 fn test_meta_item_list_word() {
-    run_test("#[foo(bar)]", MetaItem::List(vec![NestedMetaItem::MetaItem(Ident::from("bar"), MetaItem::Word)]))
+    run_test("#[foo(bar)]", MetaItem::List("foo".into(), vec![
+        NestedMetaItem::MetaItem(MetaItem::Word("bar".into())),
+    ]))
 }
 
 #[test]
 fn test_meta_item_list_name_value() {
-    run_test("#[foo(bar = 5)]", MetaItem::List(vec![NestedMetaItem::MetaItem(Ident::from("bar"), MetaItem::NameValue(Lit::Int(5, IntTy::Unsuffixed)))]))
+    run_test("#[foo(bar = 5)]", MetaItem::List("foo".into(), vec![
+        NestedMetaItem::MetaItem(MetaItem::NameValue("bar".into(),
+            Lit::Int(5, IntTy::Unsuffixed))),
+    ]))
 }
 
 #[test]
 fn test_meta_item_multiple() {
-    run_test("#[foo(word, name = 5, list(name2 = 6), word2)]", MetaItem::List(vec![
-        NestedMetaItem::MetaItem(Ident::from("word"), MetaItem::Word),
-        NestedMetaItem::MetaItem(Ident::from("name"), MetaItem::NameValue(Lit::Int(5, IntTy::Unsuffixed))),
-        NestedMetaItem::MetaItem(Ident::from("list"), MetaItem::List(vec![
-            NestedMetaItem::MetaItem(Ident::from("name2"), MetaItem::NameValue(Lit::Int(6, IntTy::Unsuffixed)))
+    run_test("#[foo(word, name = 5, list(name2 = 6), word2)]", MetaItem::List("foo".into(), vec![
+        NestedMetaItem::MetaItem(MetaItem::Word("word".into())),
+        NestedMetaItem::MetaItem(MetaItem::NameValue("name".into(),
+            Lit::Int(5, IntTy::Unsuffixed))),
+        NestedMetaItem::MetaItem(MetaItem::List("list".into(), vec![
+            NestedMetaItem::MetaItem(MetaItem::NameValue("name2".into(),
+                Lit::Int(6, IntTy::Unsuffixed)))
         ])),
-        NestedMetaItem::MetaItem(Ident::from("word2"), MetaItem::Word),
+        NestedMetaItem::MetaItem(MetaItem::Word("word2".into())),
     ]))
 }
 

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -1,0 +1,44 @@
+extern crate syn;
+use syn::*;
+
+#[test]
+fn test_meta_item_word() {
+    run_test("#[foo]", MetaItem::Word)
+}
+
+#[test]
+fn test_meta_item_name_value() {
+    run_test("#[foo = 5]", MetaItem::NameValue(Lit::Int(5, IntTy::Unsuffixed)))
+}
+
+#[test]
+fn test_meta_item_list_lit() {
+    run_test("#[foo(5)]", MetaItem::List(vec![NestedMetaItem::Literal(Lit::Int(5, IntTy::Unsuffixed))]))
+}
+
+#[test]
+fn test_meta_item_list_word() {
+    run_test("#[foo(bar)]", MetaItem::List(vec![NestedMetaItem::MetaItem(Ident::from("bar"), MetaItem::Word)]))
+}
+
+#[test]
+fn test_meta_item_list_name_value() {
+    run_test("#[foo(bar = 5)]", MetaItem::List(vec![NestedMetaItem::MetaItem(Ident::from("bar"), MetaItem::NameValue(Lit::Int(5, IntTy::Unsuffixed)))]))
+}
+
+#[test]
+fn test_meta_item_multiple() {
+    run_test("#[foo(word, name = 5, list(name2 = 6), word2)]", MetaItem::List(vec![
+        NestedMetaItem::MetaItem(Ident::from("word"), MetaItem::Word),
+        NestedMetaItem::MetaItem(Ident::from("name"), MetaItem::NameValue(Lit::Int(5, IntTy::Unsuffixed))),
+        NestedMetaItem::MetaItem(Ident::from("list"), MetaItem::List(vec![
+            NestedMetaItem::MetaItem(Ident::from("name2"), MetaItem::NameValue(Lit::Int(6, IntTy::Unsuffixed)))
+        ])),
+        NestedMetaItem::MetaItem(Ident::from("word2"), MetaItem::Word),
+    ]))
+}
+
+fn run_test(input: &str, expected: MetaItem) {
+    let attr = parse_outer_attr(input).unwrap();
+    assert_eq!(expected, attr.meta_item().unwrap());
+}

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -3,32 +3,32 @@ use syn::*;
 
 #[test]
 fn test_meta_item_word() {
-    run_test("#[foo]", MetaItem::Word("foo".into()))
+    run_test("#[foo]", &MetaItem::Word("foo".into()))
 }
 
 #[test]
 fn test_meta_item_name_value() {
-    run_test("#[foo = 5]", MetaItem::NameValue("foo".into(),
+    run_test("#[foo = 5]", &MetaItem::NameValue("foo".into(),
         Lit::Int(5, IntTy::Unsuffixed)))
 }
 
 #[test]
 fn test_meta_item_list_lit() {
-    run_test("#[foo(5)]", MetaItem::List("foo".into(), vec![
+    run_test("#[foo(5)]", &MetaItem::List("foo".into(), vec![
         NestedMetaItem::Literal(Lit::Int(5, IntTy::Unsuffixed)),
     ]))
 }
 
 #[test]
 fn test_meta_item_list_word() {
-    run_test("#[foo(bar)]", MetaItem::List("foo".into(), vec![
+    run_test("#[foo(bar)]", &MetaItem::List("foo".into(), vec![
         NestedMetaItem::MetaItem(MetaItem::Word("bar".into())),
     ]))
 }
 
 #[test]
 fn test_meta_item_list_name_value() {
-    run_test("#[foo(bar = 5)]", MetaItem::List("foo".into(), vec![
+    run_test("#[foo(bar = 5)]", &MetaItem::List("foo".into(), vec![
         NestedMetaItem::MetaItem(MetaItem::NameValue("bar".into(),
             Lit::Int(5, IntTy::Unsuffixed))),
     ]))
@@ -36,7 +36,7 @@ fn test_meta_item_list_name_value() {
 
 #[test]
 fn test_meta_item_multiple() {
-    run_test("#[foo(word, name = 5, list(name2 = 6), word2)]", MetaItem::List("foo".into(), vec![
+    run_test("#[foo(word, name = 5, list(name2 = 6), word2)]", &MetaItem::List("foo".into(), vec![
         NestedMetaItem::MetaItem(MetaItem::Word("word".into())),
         NestedMetaItem::MetaItem(MetaItem::NameValue("name".into(),
             Lit::Int(5, IntTy::Unsuffixed))),
@@ -48,7 +48,7 @@ fn test_meta_item_multiple() {
     ]))
 }
 
-fn run_test(input: &str, expected: MetaItem) {
+fn run_test(input: &str, expected: &MetaItem) {
     let attr = parse_outer_attr(input).unwrap();
-    assert_eq!(expected, attr.meta_item().unwrap());
+    assert_eq!(expected, &attr.meta_item().unwrap());
 }


### PR DESCRIPTION
Ref https://github.com/rust-lang/rust/pull/40346

This is a nightly-only feature (gated by `proc_macro` feature). Maybe you'd prefer it behind a feature instead of enabled by default?