### PR TITLE
Add method from 0.12 to syn::Attribute to minimize breaking change impact

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -6,11 +6,18 @@ use std::iter;
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Attribute {
     pub style: AttrStyle,
+    #[deprecated(since = "0.11.12", note = "Not all attributes have to be well-formed meta items. \
+        Use `Attribute::meta_item` to attempt parsing instead")]
     pub value: MetaItem,
     pub is_sugared_doc: bool,
 }
 
 impl Attribute {
+    /// Parses the tokens after the path as a [`MetaItem`](enum.MetaItem.html) if possible.
+    pub fn meta_item(&self) -> Option<MetaItem> {
+        Some(self.value.clone())
+    }
+
     pub fn name(&self) -> &str {
         self.value.name()
     }


### PR DESCRIPTION
This change preemptively adds `syn::Attribute::meta_item(&self) -> Option<syn::MetaItem>` to 0.11.x. At the moment, it always returns `Some`, but when 0.12 is released it may begin returning `None` in cases that `MetaItem` parsing fails. This is intended to go out as 0.11.12.