### PR TITLE
Add defaults to several types

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// An enum variant.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash)]
 pub struct Variant {
     /// Name of the variant.
     pub ident: Ident,
@@ -27,6 +27,12 @@ pub enum VariantData {
 
     /// Unit variant, e.g. `None`.
     Unit,
+}
+
+impl Default for VariantData {
+    fn default() -> Self {
+        VariantData::Unit
+    }
 }
 
 impl VariantData {
@@ -82,6 +88,12 @@ pub enum Visibility {
 
     /// Inherited, i.e. private.
     Inherited,
+}
+
+impl Default for Visibility {
+    fn default() -> Self {
+        Visibility::Inherited
+    }
 }
 
 #[cfg(feature = "parsing")]

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::fmt::{self, Display};
 
-#[derive(Debug, Clone, Eq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Default, Clone, Eq, Hash, Ord, PartialOrd)]
 pub struct Ident(String);
 
 impl Ident {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -37,6 +37,12 @@ pub enum Ty {
     Mac(Mac),
 }
 
+impl Default for Ty {
+    fn default() -> Self {
+        Ty::Never
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct MutTy {
     pub ty: Ty,
@@ -47,6 +53,12 @@ pub struct MutTy {
 pub enum Mutability {
     Mutable,
     Immutable,
+}
+
+impl Default for Mutability {
+    fn default() -> Self {
+        Mutability::Immutable
+    }
 }
 
 /// A "Path" is essentially Rust's notion of a name.
@@ -128,6 +140,12 @@ impl PathParameters {
     }
 }
 
+impl Default for PathParameters {
+    fn default() -> Self {
+        PathParameters::none()
+    }
+}
+
 /// A path like `Foo<'a, T>`
 #[derive(Debug, Clone, Eq, PartialEq, Default, Hash)]
 pub struct AngleBracketedParameterData {
@@ -199,6 +217,12 @@ pub struct BareFnTy {
 pub enum Unsafety {
     Unsafe,
     Normal,
+}
+
+impl Default for Unsafety {
+    fn default() -> Self {
+        Unsafety::Normal
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]


### PR DESCRIPTION
The lack of `Default` impls on types such as `syn::Ident` prevents types with `Ident` fields from deriving `Default` themselves. This introduces considerable boilerplate for proc-macro crates such as my current project [darling](https://github.com/TedDriggs/darling).

This PR addresses that by providing defaults for a number of types within `syn`. Ideally, this would _not_ be blocked until 0.12 releases, and would go as a 0.11.x release.