### PR TITLE
Rewrite the AST to be a bit more user-friendly

### DIFF
--- a/src/aster/ty.rs
+++ b/src/aster/ty.rs
@@ -1,4 +1,5 @@
 use {Generics, Lifetime, MutTy, Mutability, Path, QSelf, Ty, TyParamBound};
+use {TyPath, TySlice, TyNever, TyInfer, TyTup, TyRptr, TyImplTrait};
 use aster::ident::ToIdent;
 use aster::invoke::{Invoke, Identity};
 use aster::lifetime::IntoLifetime;
@@ -36,11 +37,11 @@ impl<F> TyBuilder<F>
     }
 
     pub fn build_path(self, path: Path) -> F::Result {
-        self.build(Ty::Path(None, path))
+        self.build(Ty::Path(TyPath { qself: None, path: path }))
     }
 
     pub fn build_qpath(self, qself: QSelf, path: Path) -> F::Result {
-        self.build(Ty::Path(Some(qself), path))
+        self.build(Ty::Path(TyPath { qself: Some(qself), path: path }))
     }
 
     pub fn path(self) -> PathBuilder<TyPathBuilder<F>> {
@@ -115,7 +116,7 @@ impl<F> TyBuilder<F>
     }
 
     pub fn build_slice(self, ty: Ty) -> F::Result {
-        self.build(Ty::Slice(Box::new(ty)))
+        self.build(Ty::Slice(TySlice { ty: Box::new(ty) }))
     }
 
     pub fn slice(self) -> TyBuilder<TySliceBuilder<F>> {
@@ -131,11 +132,11 @@ impl<F> TyBuilder<F>
     }
 
     pub fn never(self) -> F::Result {
-        self.build(Ty::Never)
+        self.build(Ty::Never(TyNever {}))
     }
 
     pub fn infer(self) -> F::Result {
-        self.build(Ty::Infer)
+        self.build(Ty::Infer(TyInfer {}))
     }
 
     pub fn option(self) -> TyBuilder<TyOptionBuilder<F>> {
@@ -236,7 +237,10 @@ impl<F> TyRefBuilder<F>
             ty: ty,
             mutability: self.mutability,
         };
-        self.builder.build(Ty::Rptr(self.lifetime, Box::new(ty)))
+        self.builder.build(Ty::Rptr(TyRptr {
+            lifetime: self.lifetime,
+            ty: Box::new(ty),
+        }))
     }
 
     pub fn ty(self) -> TyBuilder<Self> {
@@ -432,7 +436,9 @@ impl<F> TyImplTraitTyBuilder<F>
 
     pub fn build(self) -> F::Result {
         let bounds = self.bounds;
-        self.builder.build(Ty::ImplTrait(bounds))
+        self.builder.build(Ty::ImplTrait(TyImplTrait {
+            bounds: bounds,
+        }))
     }
 }
 
@@ -473,7 +479,7 @@ impl<F> TyTupleBuilder<F>
     }
 
     pub fn build(self) -> F::Result {
-        self.builder.build(Ty::Tup(self.tys))
+        self.builder.build(Ty::Tup(TyTup { tys: self.tys }))
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,32 +1,34 @@
 use super::*;
 
-/// An enum variant.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Variant {
-    /// Name of the variant.
-    pub ident: Ident,
+ast_struct! {
+    /// An enum variant.
+    pub struct Variant {
+        /// Name of the variant.
+        pub ident: Ident,
 
-    /// Attributes tagged on the variant.
-    pub attrs: Vec<Attribute>,
+        /// Attributes tagged on the variant.
+        pub attrs: Vec<Attribute>,
 
-    /// Type of variant.
-    pub data: VariantData,
+        /// Type of variant.
+        pub data: VariantData,
 
-    /// Explicit discriminant, e.g. `Foo = 1`
-    pub discriminant: Option<ConstExpr>,
+        /// Explicit discriminant, e.g. `Foo = 1`
+        pub discriminant: Option<ConstExpr>,
+    }
 }
 
-/// Data stored within an enum variant or struct.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum VariantData {
-    /// Struct variant, e.g. `Point { x: f64, y: f64 }`.
-    Struct(Vec<Field>),
+ast_enum! {
+    /// Data stored within an enum variant or struct.
+    pub enum VariantData {
+        /// Struct variant, e.g. `Point { x: f64, y: f64 }`.
+        Struct(Vec<Field>),
 
-    /// Tuple variant, e.g. `Some(T)`.
-    Tuple(Vec<Field>),
+        /// Tuple variant, e.g. `Some(T)`.
+        Tuple(Vec<Field>),
 
-    /// Unit variant, e.g. `None`.
-    Unit,
+        /// Unit variant, e.g. `None`.
+        Unit,
+    }
 }
 
 impl VariantData {
@@ -49,39 +51,40 @@ impl VariantData {
     }
 }
 
-/// A field of a struct or enum variant.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Field {
-    /// Name of the field, if any.
-    ///
-    /// Fields of tuple structs have no names.
-    pub ident: Option<Ident>,
+ast_struct! {
+    /// A field of a struct or enum variant.
+    pub struct Field {
+        /// Name of the field, if any.
+        ///
+        /// Fields of tuple structs have no names.
+        pub ident: Option<Ident>,
 
-    /// Visibility of the field.
-    pub vis: Visibility,
+        /// Visibility of the field.
+        pub vis: Visibility,
 
-    /// Attributes tagged on the field.
-    pub attrs: Vec<Attribute>,
+        /// Attributes tagged on the field.
+        pub attrs: Vec<Attribute>,
 
-    /// Type of the field.
-    pub ty: Ty,
+        /// Type of the field.
+        pub ty: Ty,
+    }
 }
 
+ast_enum! {
+    /// Visibility level of an item.
+    pub enum Visibility {
+        /// Public, i.e. `pub`.
+        Public,
 
-/// Visibility level of an item.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum Visibility {
-    /// Public, i.e. `pub`.
-    Public,
+        /// Crate-visible, i.e. `pub(crate)`.
+        Crate,
 
-    /// Crate-visible, i.e. `pub(crate)`.
-    Crate,
+        /// Restricted, e.g. `pub(self)` or `pub(super)` or `pub(in some::module)`.
+        Restricted(Box<Path>),
 
-    /// Restricted, e.g. `pub(self)` or `pub(super)` or `pub(in some::module)`.
-    Restricted(Box<Path>),
-
-    /// Inherited, i.e. private.
-    Inherited,
+        /// Inherited, i.e. private.
+        Inherited,
+    }
 }
 
 #[cfg(feature = "parsing")]

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,32 +1,35 @@
 use super::*;
 
-/// Struct or enum sent to a `proc_macro_derive` macro.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct DeriveInput {
-    /// Name of the struct or enum.
-    pub ident: Ident,
+ast_struct! {
+    /// Struct or enum sent to a `proc_macro_derive` macro.
+    pub struct DeriveInput {
+        /// Name of the struct or enum.
+        pub ident: Ident,
 
-    /// Visibility of the struct or enum.
-    pub vis: Visibility,
+        /// Visibility of the struct or enum.
+        pub vis: Visibility,
 
-    /// Attributes tagged on the whole struct or enum.
-    pub attrs: Vec<Attribute>,
+        /// Attributes tagged on the whole struct or enum.
+        pub attrs: Vec<Attribute>,
 
-    /// Generics required to complete the definition.
-    pub generics: Generics,
+        /// Generics required to complete the definition.
+        pub generics: Generics,
 
-    /// Data within the struct or enum.
-    pub body: Body,
+        /// Data within the struct or enum.
+        pub body: Body,
+    }
 }
 
-/// Body of a derived struct or enum.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum Body {
-    /// It's an enum.
-    Enum(Vec<Variant>),
 
-    /// It's a struct.
-    Struct(VariantData),
+ast_enum! {
+    /// Body of a derived struct or enum.
+    pub enum Body {
+        /// It's an enum.
+        Enum(Vec<Variant>),
+
+        /// It's a struct.
+        Struct(VariantData),
+    }
 }
 
 #[cfg(feature = "parsing")]

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,83 +1,129 @@
 use super::*;
 
-/// An item
-///
-/// The name might be a dummy name in case of anonymous items
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Item {
-    pub ident: Ident,
-    pub vis: Visibility,
-    pub attrs: Vec<Attribute>,
-    pub node: ItemKind,
+ast_struct! {
+    /// An item
+    ///
+    /// The name might be a dummy name in case of anonymous items
+    pub struct Item {
+        pub ident: Ident,
+        pub vis: Visibility,
+        pub attrs: Vec<Attribute>,
+        pub node: ItemKind,
+    }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum ItemKind {
-    /// An`extern crate` item, with optional original crate name.
-    ///
-    /// E.g. `extern crate foo` or `extern crate foo_bar as foo`
-    ExternCrate(Option<Ident>),
-    /// A use declaration (`use` or `pub use`) item.
-    ///
-    /// E.g. `use foo;`, `use foo::bar;` or `use foo::bar as FooBar;`
-    Use(Box<ViewPath>),
-    /// A static item (`static` or `pub static`).
-    ///
-    /// E.g. `static FOO: i32 = 42;` or `static FOO: &'static str = "bar";`
-    Static(Box<Ty>, Mutability, Box<Expr>),
-    /// A constant item (`const` or `pub const`).
-    ///
-    /// E.g. `const FOO: i32 = 42;`
-    Const(Box<Ty>, Box<Expr>),
-    /// A function declaration (`fn` or `pub fn`).
-    ///
-    /// E.g. `fn foo(bar: usize) -> usize { .. }`
-    Fn(Box<FnDecl>, Unsafety, Constness, Option<Abi>, Generics, Box<Block>),
-    /// A module declaration (`mod` or `pub mod`).
-    ///
-    /// E.g. `mod foo;` or `mod foo { .. }`
-    Mod(Option<Vec<Item>>),
-    /// An external module (`extern` or `pub extern`).
-    ///
-    /// E.g. `extern {}` or `extern "C" {}`
-    ForeignMod(ForeignMod),
-    /// A type alias (`type` or `pub type`).
-    ///
-    /// E.g. `type Foo = Bar<u8>;`
-    Ty(Box<Ty>, Generics),
-    /// An enum definition (`enum` or `pub enum`).
-    ///
-    /// E.g. `enum Foo<A, B> { C<A>, D<B> }`
-    Enum(Vec<Variant>, Generics),
-    /// A struct definition (`struct` or `pub struct`).
-    ///
-    /// E.g. `struct Foo<A> { x: A }`
-    Struct(VariantData, Generics),
-    /// A union definition (`union` or `pub union`).
-    ///
-    /// E.g. `union Foo<A, B> { x: A, y: B }`
-    Union(VariantData, Generics),
-    /// A Trait declaration (`trait` or `pub trait`).
-    ///
-    /// E.g. `trait Foo { .. }` or `trait Foo<T> { .. }`
-    Trait(Unsafety, Generics, Vec<TyParamBound>, Vec<TraitItem>),
-    /// Default trait implementation.
-    ///
-    /// E.g. `impl Trait for .. {}` or `impl<T> Trait<T> for .. {}`
-    DefaultImpl(Unsafety, Path),
-    /// An implementation.
-    ///
-    /// E.g. `impl<A> Foo<A> { .. }` or `impl<A> Trait for Foo<A> { .. }`
-    Impl(Unsafety,
-         ImplPolarity,
-         Generics,
-         Option<Path>, // (optional) trait this impl implements
-         Box<Ty>, // self
-         Vec<ImplItem>),
-    /// A macro invocation (which includes macro definition).
-    ///
-    /// E.g. `macro_rules! foo { .. }` or `foo!(..)`
-    Mac(Mac),
+ast_enum_of_structs! {
+    pub enum ItemKind {
+        /// An`extern crate` item, with optional original crate name.
+        ///
+        /// E.g. `extern crate foo` or `extern crate foo_bar as foo`
+        pub ExternCrate(ItemExternCrate {
+            pub original: Option<Ident>,
+        }),
+        /// A use declaration (`use` or `pub use`) item.
+        ///
+        /// E.g. `use foo;`, `use foo::bar;` or `use foo::bar as FooBar;`
+        pub Use(ItemUse {
+            pub path: Box<ViewPath>,
+        }),
+        /// A static item (`static` or `pub static`).
+        ///
+        /// E.g. `static FOO: i32 = 42;` or `static FOO: &'static str = "bar";`
+        pub Static(ItemStatic {
+            pub ty: Box<Ty>,
+            pub mutbl: Mutability,
+            pub expr: Box<Expr>,
+        }),
+        /// A constant item (`const` or `pub const`).
+        ///
+        /// E.g. `const FOO: i32 = 42;`
+        pub Const(ItemConst {
+            pub ty: Box<Ty>,
+            pub expr: Box<Expr>,
+        }),
+        /// A function declaration (`fn` or `pub fn`).
+        ///
+        /// E.g. `fn foo(bar: usize) -> usize { .. }`
+        pub Fn(ItemFn {
+            pub decl: Box<FnDecl>,
+            pub unsafety: Unsafety,
+            pub constness: Constness,
+            pub abi: Option<Abi>,
+            pub generics: Generics,
+            pub block: Box<Block>,
+        }),
+        /// A module declaration (`mod` or `pub mod`).
+        ///
+        /// E.g. `mod foo;` or `mod foo { .. }`
+        pub Mod(ItemMod {
+            pub items: Option<Vec<Item>>,
+        }),
+        /// An external module (`extern` or `pub extern`).
+        ///
+        /// E.g. `extern {}` or `extern "C" {}`
+        pub ForeignMod(ItemForeignMod),
+        /// A type alias (`type` or `pub type`).
+        ///
+        /// E.g. `type Foo = Bar<u8>;`
+        pub Ty(ItemTy {
+            pub ty: Box<Ty>,
+            pub generics: Generics,
+        }),
+        /// An enum definition (`enum` or `pub enum`).
+        ///
+        /// E.g. `enum Foo<A, B> { C<A>, D<B> }`
+        pub Enum(ItemEnum {
+            pub variants: Vec<Variant>,
+            pub generics: Generics,
+        }),
+        /// A struct definition (`struct` or `pub struct`).
+        ///
+        /// E.g. `struct Foo<A> { x: A }`
+        pub Struct(ItemStruct {
+            pub data: VariantData,
+            pub generics: Generics,
+        }),
+        /// A union definition (`union` or `pub union`).
+        ///
+        /// E.g. `union Foo<A, B> { x: A, y: B }`
+        pub Union(ItemUnion {
+            pub data: VariantData,
+            pub generics: Generics,
+        }),
+        /// A Trait declaration (`trait` or `pub trait`).
+        ///
+        /// E.g. `trait Foo { .. }` or `trait Foo<T> { .. }`
+        pub Trait(ItemTrait {
+            pub unsafety: Unsafety,
+            pub generics: Generics,
+            pub supertraits: Vec<TyParamBound>,
+            pub items: Vec<TraitItem>,
+        }),
+        /// Default trait implementation.
+        ///
+        /// E.g. `impl Trait for .. {}` or `impl<T> Trait<T> for .. {}`
+        pub DefaultImpl(ItemDefaultImpl {
+            pub unsafety: Unsafety,
+            pub path: Path,
+        }),
+        /// An implementation.
+        ///
+        /// E.g. `impl<A> Foo<A> { .. }` or `impl<A> Trait for Foo<A> { .. }`
+        pub Impl(ItemImpl {
+            pub unsafety: Unsafety,
+            pub polarity: ImplPolarity,
+            pub generics: Generics,
+            pub trait_: Option<Path>, // (optional) trait this impl implements
+            pub self_ty: Box<Ty>, // self
+            pub items: Vec<ImplItem>,
+        }),
+        /// A macro invocation (which includes macro definition).
+        ///
+        /// E.g. `macro_rules! foo { .. }` or `foo!(..)`
+        pub Mac(Mac),
+    }
+
+    do_not_generate_to_tokens
 }
 
 impl From<DeriveInput> for Item {
@@ -87,148 +133,221 @@ impl From<DeriveInput> for Item {
             vis: input.vis,
             attrs: input.attrs,
             node: match input.body {
-                Body::Enum(variants) => ItemKind::Enum(variants, input.generics),
-                Body::Struct(variant_data) => ItemKind::Struct(variant_data, input.generics),
+                Body::Enum(variants) => {
+                    ItemEnum {
+                        variants: variants,
+                        generics: input.generics,
+                    }.into()
+                }
+                Body::Struct(variant_data) => {
+                    ItemStruct {
+                        data: variant_data,
+                        generics: input.generics,
+                    }.into()
+                }
             },
         }
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum ViewPath {
-    /// `foo::bar::baz as quux`
+ast_enum_of_structs! {
+    pub enum ViewPath {
+        /// `foo::bar::baz as quux`
+        ///
+        /// or just
+        ///
+        /// `foo::bar::baz` (with `as baz` implicitly on the right)
+        pub Simple(PathSimple {
+            pub path: Path,
+            pub rename: Option<Ident>,
+        }),
+
+        /// `foo::bar::*`
+        pub Glob(PathGlob {
+            pub path: Path,
+        }),
+
+        /// `foo::bar::{a, b, c}`
+        pub List(PathList {
+            pub path: Path,
+            pub items: Vec<PathListItem>,
+        }),
+    }
+}
+
+ast_struct! {
+    pub struct PathListItem {
+        pub name: Ident,
+        /// renamed in list, e.g. `use foo::{bar as baz};`
+        pub rename: Option<Ident>,
+    }
+}
+
+ast_enum! {
+    #[derive(Copy)]
+    pub enum Constness {
+        Const,
+        NotConst,
+    }
+}
+
+ast_enum! {
+    #[derive(Copy)]
+    pub enum Defaultness {
+        Default,
+        Final,
+    }
+}
+
+ast_struct! {
+    /// Foreign module declaration.
     ///
-    /// or just
+    /// E.g. `extern { .. }` or `extern "C" { .. }`
+    pub struct ItemForeignMod {
+        pub abi: Abi,
+        pub items: Vec<ForeignItem>,
+    }
+}
+
+ast_struct! {
+    pub struct ForeignItem {
+        pub ident: Ident,
+        pub attrs: Vec<Attribute>,
+        pub node: ForeignItemKind,
+        pub vis: Visibility,
+    }
+}
+
+ast_enum_of_structs! {
+    /// An item within an `extern` block
+    pub enum ForeignItemKind {
+        /// A foreign function
+        pub Fn(ForeignItemFn {
+            pub decl: Box<FnDecl>,
+            pub generics: Generics,
+        }),
+        /// A foreign static item (`static ext: u8`)
+        pub Static(ForeignItemStatic {
+            pub ty: Box<Ty>,
+            pub mutbl: Mutability,
+        }),
+    }
+
+    do_not_generate_to_tokens
+}
+
+ast_struct! {
+    /// Represents an item declaration within a trait declaration,
+    /// possibly including a default implementation. A trait item is
+    /// either required (meaning it doesn't have an implementation, just a
+    /// signature) or provided (meaning it has a default implementation).
+    pub struct TraitItem {
+        pub ident: Ident,
+        pub attrs: Vec<Attribute>,
+        pub node: TraitItemKind,
+    }
+}
+
+ast_enum_of_structs! {
+    pub enum TraitItemKind {
+        pub Const(TraitItemConst {
+            pub ty: Ty,
+            pub default: Option<Expr>,
+        }),
+        pub Method(TraitItemMethod {
+            pub sig: MethodSig,
+            pub default: Option<Block>,
+        }),
+        pub Type(TraitItemType {
+            pub bounds: Vec<TyParamBound>,
+            pub default: Option<Ty>,
+        }),
+        pub Macro(Mac),
+    }
+
+    do_not_generate_to_tokens
+}
+
+ast_enum! {
+    #[derive(Copy)]
+    pub enum ImplPolarity {
+        /// `impl Trait for Type`
+        Positive,
+        /// `impl !Trait for Type`
+        Negative,
+    }
+}
+
+ast_struct! {
+    pub struct ImplItem {
+        pub ident: Ident,
+        pub vis: Visibility,
+        pub defaultness: Defaultness,
+        pub attrs: Vec<Attribute>,
+        pub node: ImplItemKind,
+    }
+}
+
+ast_enum_of_structs! {
+    pub enum ImplItemKind {
+        pub Const(ImplItemConst {
+            pub ty: Ty,
+            pub expr: Expr,
+        }),
+        pub Method(ImplItemMethod {
+            pub sig: MethodSig,
+            pub block: Block,
+        }),
+        pub Type(ImplItemType {
+            pub ty: Ty,
+        }),
+        pub Macro(Mac),
+    }
+
+    do_not_generate_to_tokens
+}
+
+ast_struct! {
+    /// Represents a method's signature in a trait declaration,
+    /// or in an implementation.
+    pub struct MethodSig {
+        pub unsafety: Unsafety,
+        pub constness: Constness,
+        pub abi: Option<Abi>,
+        pub decl: FnDecl,
+        pub generics: Generics,
+    }
+}
+
+ast_struct! {
+    /// Header (not the body) of a function declaration.
     ///
-    /// `foo::bar::baz` (with `as baz` implicitly on the right)
-    Simple(Path, Option<Ident>),
-
-    /// `foo::bar::*`
-    Glob(Path),
-
-    /// `foo::bar::{a, b, c}`
-    List(Path, Vec<PathListItem>),
+    /// E.g. `fn foo(bar: baz)`
+    pub struct FnDecl {
+        pub inputs: Vec<FnArg>,
+        pub output: FunctionRetTy,
+        pub variadic: bool,
+    }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct PathListItem {
-    pub name: Ident,
-    /// renamed in list, e.g. `use foo::{bar as baz};`
-    pub rename: Option<Ident>,
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Constness {
-    Const,
-    NotConst,
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Defaultness {
-    Default,
-    Final,
-}
-
-/// Foreign module declaration.
-///
-/// E.g. `extern { .. }` or `extern "C" { .. }`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct ForeignMod {
-    pub abi: Abi,
-    pub items: Vec<ForeignItem>,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct ForeignItem {
-    pub ident: Ident,
-    pub attrs: Vec<Attribute>,
-    pub node: ForeignItemKind,
-    pub vis: Visibility,
-}
-
-/// An item within an `extern` block
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum ForeignItemKind {
-    /// A foreign function
-    Fn(Box<FnDecl>, Generics),
-    /// A foreign static item (`static ext: u8`)
-    Static(Box<Ty>, Mutability),
-}
-
-/// Represents an item declaration within a trait declaration,
-/// possibly including a default implementation. A trait item is
-/// either required (meaning it doesn't have an implementation, just a
-/// signature) or provided (meaning it has a default implementation).
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct TraitItem {
-    pub ident: Ident,
-    pub attrs: Vec<Attribute>,
-    pub node: TraitItemKind,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum TraitItemKind {
-    Const(Ty, Option<Expr>),
-    Method(MethodSig, Option<Block>),
-    Type(Vec<TyParamBound>, Option<Ty>),
-    Macro(Mac),
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum ImplPolarity {
-    /// `impl Trait for Type`
-    Positive,
-    /// `impl !Trait for Type`
-    Negative,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct ImplItem {
-    pub ident: Ident,
-    pub vis: Visibility,
-    pub defaultness: Defaultness,
-    pub attrs: Vec<Attribute>,
-    pub node: ImplItemKind,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum ImplItemKind {
-    Const(Ty, Expr),
-    Method(MethodSig, Block),
-    Type(Ty),
-    Macro(Mac),
-}
-
-/// Represents a method's signature in a trait declaration,
-/// or in an implementation.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct MethodSig {
-    pub unsafety: Unsafety,
-    pub constness: Constness,
-    pub abi: Option<Abi>,
-    pub decl: FnDecl,
-    pub generics: Generics,
-}
-
-/// Header (not the body) of a function declaration.
-///
-/// E.g. `fn foo(bar: baz)`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct FnDecl {
-    pub inputs: Vec<FnArg>,
-    pub output: FunctionRetTy,
-    pub variadic: bool,
-}
-
-/// An argument in a function header.
-///
-/// E.g. `bar: usize` as in `fn foo(bar: usize)`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum FnArg {
-    SelfRef(Option<Lifetime>, Mutability),
-    SelfValue(Mutability),
-    Captured(Pat, Ty),
-    Ignored(Ty),
+ast_enum_of_structs! {
+    /// An argument in a function header.
+    ///
+    /// E.g. `bar: usize` as in `fn foo(bar: usize)`
+    pub enum FnArg {
+        pub SelfRef(ArgSelfRef {
+            pub lifetime: Option<Lifetime>,
+            pub mutbl: Mutability,
+        }),
+        pub SelfValue(ArgSelf {
+            pub mutbl: Mutability,
+        }),
+        pub Captured(ArgCaptured {
+            pub pat: Pat,
+            pub ty: Ty,
+        }),
+        pub Ignored(Ty),
+    }
 }
 
 #[cfg(feature = "parsing")]
@@ -319,7 +438,7 @@ pub mod parsing {
                 ident: name,
                 vis: vis,
                 attrs: attrs,
-                node: ItemKind::ExternCrate(original_name),
+                node: ItemExternCrate { original: original_name }.into(),
             }
         })
     ));
@@ -334,7 +453,7 @@ pub mod parsing {
             ident: "".into(),
             vis: vis,
             attrs: attrs,
-            node: ItemKind::Use(Box::new(what)),
+            node: ItemUse { path: Box::new(what) }.into(),
         })
     ));
 
@@ -352,14 +471,14 @@ pub mod parsing {
     named!(view_path_simple -> ViewPath, do_parse!(
         path: path >>
         rename: option!(preceded!(keyword!("as"), ident)) >>
-        (ViewPath::Simple(path, rename))
+        (PathSimple { path: path, rename: rename }.into())
     ));
 
     named!(view_path_glob -> ViewPath, do_parse!(
         path: path >>
         punct!("::") >>
         punct!("*") >>
-        (ViewPath::Glob(path))
+        (PathGlob { path: path }.into())
     ));
 
     named!(view_path_list -> ViewPath, do_parse!(
@@ -368,7 +487,7 @@ pub mod parsing {
         punct!("{") >>
         items: terminated_list!(punct!(","), path_list_item) >>
         punct!("}") >>
-        (ViewPath::List(path, items))
+        (PathList { path: path, items: items }.into())
     ));
 
     named!(view_path_list_root -> ViewPath, do_parse!(
@@ -376,10 +495,13 @@ pub mod parsing {
         punct!("{") >>
         items: terminated_list!(punct!(","), path_list_item) >>
         punct!("}") >>
-        (ViewPath::List(Path {
-            global: global.is_some(),
-            segments: Vec::new(),
-        }, items))
+        (PathList {
+            path: Path {
+                global: global.is_some(),
+                segments: Vec::new(),
+            },
+            items: items,
+        }.into())
     ));
 
     named!(path_list_item -> PathListItem, do_parse!(
@@ -410,7 +532,11 @@ pub mod parsing {
             ident: id,
             vis: vis,
             attrs: attrs,
-            node: ItemKind::Static(Box::new(ty), mutability, Box::new(value)),
+            node: ItemStatic {
+                ty: Box::new(ty),
+                mutbl: mutability,
+                expr: Box::new(value),
+            }.into(),
         })
     ));
 
@@ -428,7 +554,7 @@ pub mod parsing {
             ident: id,
             vis: vis,
             attrs: attrs,
-            node: ItemKind::Const(Box::new(ty), Box::new(value)),
+            node: ItemConst { ty: Box::new(ty), expr: Box::new(value) }.into(),
         })
     ));
 
@@ -458,23 +584,23 @@ pub mod parsing {
                 attrs.extend(inner_attrs);
                 attrs
             },
-            node: ItemKind::Fn(
-                Box::new(FnDecl {
+            node: ItemFn {
+                decl: Box::new(FnDecl {
                     inputs: inputs,
                     output: ret.map(FunctionRetTy::Ty).unwrap_or(FunctionRetTy::Default),
                     variadic: false,
                 }),
-                unsafety,
-                constness,
-                abi,
-                Generics {
+                unsafety: unsafety,
+                constness: constness,
+                abi: abi,
+                generics: Generics {
                     where_clause: where_clause,
                     .. generics
                 },
-                Box::new(Block {
+                block: Box::new(Block {
                     stmts: stmts,
                 }),
-            ),
+            }.into(),
         })
     ));
 
@@ -485,21 +611,21 @@ pub mod parsing {
             mutability: mutability >>
             keyword!("self") >>
             not!(punct!(":")) >>
-            (FnArg::SelfRef(lt, mutability))
+            (ArgSelfRef { lifetime: lt, mutbl: mutability }.into())
         )
         |
         do_parse!(
             mutability: mutability >>
             keyword!("self") >>
             not!(punct!(":")) >>
-            (FnArg::SelfValue(mutability))
+            (ArgSelf { mutbl: mutability }.into())
         )
         |
         do_parse!(
             pat: pat >>
             punct!(":") >>
             ty: ty >>
-            (FnArg::Captured(pat, ty))
+            (ArgCaptured { pat: pat, ty: ty }.into())
         )
         |
         ty => { FnArg::Ignored }
@@ -531,13 +657,13 @@ pub mod parsing {
                     attrs.extend(inner_attrs);
                     attrs
                 },
-                node: ItemKind::Mod(Some(items)),
+                node: ItemMod { items: Some(items) }.into(),
             },
             None => Item {
                 ident: id,
                 vis: vis,
                 attrs: outer_attrs,
-                node: ItemKind::Mod(None),
+                node: ItemMod { items: None }.into(),
             },
         })
     ));
@@ -552,10 +678,10 @@ pub mod parsing {
             ident: "".into(),
             vis: Visibility::Inherited,
             attrs: attrs,
-            node: ItemKind::ForeignMod(ForeignMod {
+            node: ItemForeignMod {
                 abi: abi,
                 items: items,
-            }),
+            }.into(),
         })
     ));
 
@@ -582,17 +708,17 @@ pub mod parsing {
         (ForeignItem {
             ident: name,
             attrs: attrs,
-            node: ForeignItemKind::Fn(
-                Box::new(FnDecl {
+            node: ForeignItemFn {
+                decl: Box::new(FnDecl {
                     inputs: inputs,
                     output: ret.map(FunctionRetTy::Ty).unwrap_or(FunctionRetTy::Default),
                     variadic: variadic.is_some(),
                 }),
-                Generics {
+                generics: Generics {
                     where_clause: where_clause,
                     .. generics
                 },
-            ),
+            }.into(),
             vis: vis,
         })
     ));
@@ -609,7 +735,7 @@ pub mod parsing {
         (ForeignItem {
             ident: id,
             attrs: attrs,
-            node: ForeignItemKind::Static(Box::new(ty), mutability),
+            node: ForeignItemStatic { ty: Box::new(ty), mutbl: mutability }.into(),
             vis: vis,
         })
     ));
@@ -628,13 +754,13 @@ pub mod parsing {
             ident: id,
             vis: vis,
             attrs: attrs,
-            node: ItemKind::Ty(
-                Box::new(ty),
-                Generics {
+            node: ItemTy {
+                ty: Box::new(ty),
+                generics: Generics {
                     where_clause: where_clause,
                     ..generics
                 },
-            ),
+            }.into(),
         })
     ));
 
@@ -646,10 +772,10 @@ pub mod parsing {
             attrs: def.attrs,
             node: match def.body {
                 Body::Enum(variants) => {
-                    ItemKind::Enum(variants, def.generics)
+                    ItemEnum { variants: variants, generics: def.generics }.into()
                 }
                 Body::Struct(variant_data) => {
-                    ItemKind::Struct(variant_data, def.generics)
+                    ItemStruct { data: variant_data, generics: def.generics }.into()
                 }
             }
         }
@@ -667,13 +793,13 @@ pub mod parsing {
             ident: id,
             vis: vis,
             attrs: attrs,
-            node: ItemKind::Union(
-                VariantData::Struct(fields),
-                Generics {
+            node: ItemUnion {
+                data: VariantData::Struct(fields),
+                generics: Generics {
                     where_clause: where_clause,
                     .. generics
                 },
-            ),
+            }.into(),
         })
     ));
 
@@ -696,15 +822,15 @@ pub mod parsing {
             ident: id,
             vis: vis,
             attrs: attrs,
-            node: ItemKind::Trait(
-                unsafety,
-                Generics {
+            node: ItemTrait {
+                unsafety: unsafety,
+                generics: Generics {
                     where_clause: where_clause,
                     .. generics
                 },
-                bounds,
-                body,
-            ),
+                supertraits: bounds,
+                items: body,
+            }.into(),
         })
     ));
 
@@ -721,7 +847,7 @@ pub mod parsing {
             ident: "".into(),
             vis: Visibility::Inherited,
             attrs: attrs,
-            node: ItemKind::DefaultImpl(unsafety, path),
+            node: ItemDefaultImpl { unsafety: unsafety, path: path }.into(),
         })
     ));
 
@@ -746,7 +872,7 @@ pub mod parsing {
         (TraitItem {
             ident: id,
             attrs: attrs,
-            node: TraitItemKind::Const(ty, value),
+            node: TraitItemConst { ty: ty, default: value }.into(),
         })
     ));
 
@@ -781,8 +907,8 @@ pub mod parsing {
                     attrs.extend(inner_attrs);
                     attrs
                 },
-                node: TraitItemKind::Method(
-                    MethodSig {
+                node: TraitItemMethod {
+                    sig: MethodSig {
                         unsafety: unsafety,
                         constness: constness,
                         abi: abi,
@@ -796,8 +922,8 @@ pub mod parsing {
                             .. generics
                         },
                     },
-                    stmts.map(|stmts| Block { stmts: stmts }),
-                ),
+                    default: stmts.map(|stmts| Block { stmts: stmts }),
+                }.into(),
             }
         })
     ));
@@ -815,7 +941,7 @@ pub mod parsing {
         (TraitItem {
             ident: id,
             attrs: attrs,
-            node: TraitItemKind::Type(bounds, default),
+            node: TraitItemType { bounds: bounds, default: default }.into(),
         })
     ));
 
@@ -862,17 +988,17 @@ pub mod parsing {
             ident: "".into(),
             vis: Visibility::Inherited,
             attrs: attrs,
-            node: ItemKind::Impl(
-                unsafety,
-                polarity_path.0,
-                Generics {
+            node: ItemImpl {
+                unsafety: unsafety,
+                polarity: polarity_path.0,
+                generics: Generics {
                     where_clause: where_clause,
                     .. generics
                 },
-                polarity_path.1,
-                Box::new(self_ty),
-                body,
-            ),
+                trait_: polarity_path.1,
+                self_ty: Box::new(self_ty),
+                items: body,
+            }.into(),
         })
     ));
 
@@ -902,7 +1028,7 @@ pub mod parsing {
             vis: vis,
             defaultness: defaultness,
             attrs: attrs,
-            node: ImplItemKind::Const(ty, value),
+            node: ImplItemConst { ty: ty, expr: value}.into(),
         })
     ));
 
@@ -934,8 +1060,8 @@ pub mod parsing {
                 attrs.extend(inner_attrs);
                 attrs
             },
-            node: ImplItemKind::Method(
-                MethodSig {
+            node: ImplItemMethod {
+                sig: MethodSig {
                     unsafety: unsafety,
                     constness: constness,
                     abi: abi,
@@ -949,10 +1075,10 @@ pub mod parsing {
                         .. generics
                     },
                 },
-                Block {
+                block: Block {
                     stmts: stmts,
                 },
-            ),
+            }.into(),
         })
     ));
 
@@ -970,7 +1096,7 @@ pub mod parsing {
             vis: vis,
             defaultness: defaultness,
             attrs: attrs,
-            node: ImplItemKind::Type(ty),
+            node: ImplItemType { ty: ty }.into(),
         })
     ));
 
@@ -1026,70 +1152,70 @@ mod printing {
         fn to_tokens(&self, tokens: &mut Tokens) {
             tokens.append_all(self.attrs.outer());
             match self.node {
-                ItemKind::ExternCrate(ref original) => {
+                ItemKind::ExternCrate(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("extern");
                     tokens.append("crate");
-                    if let Some(ref original) = *original {
+                    if let Some(ref original) = item.original {
                         original.to_tokens(tokens);
                         tokens.append("as");
                     }
                     self.ident.to_tokens(tokens);
                     tokens.append(";");
                 }
-                ItemKind::Use(ref view_path) => {
+                ItemKind::Use(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("use");
-                    view_path.to_tokens(tokens);
+                    item.path.to_tokens(tokens);
                     tokens.append(";");
                 }
-                ItemKind::Static(ref ty, ref mutability, ref expr) => {
+                ItemKind::Static(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("static");
-                    mutability.to_tokens(tokens);
+                    item.mutbl.to_tokens(tokens);
                     self.ident.to_tokens(tokens);
                     tokens.append(":");
-                    ty.to_tokens(tokens);
+                    item.ty.to_tokens(tokens);
                     tokens.append("=");
-                    expr.to_tokens(tokens);
+                    item.expr.to_tokens(tokens);
                     tokens.append(";");
                 }
-                ItemKind::Const(ref ty, ref expr) => {
+                ItemKind::Const(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("const");
                     self.ident.to_tokens(tokens);
                     tokens.append(":");
-                    ty.to_tokens(tokens);
+                    item.ty.to_tokens(tokens);
                     tokens.append("=");
-                    expr.to_tokens(tokens);
+                    item.expr.to_tokens(tokens);
                     tokens.append(";");
                 }
-                ItemKind::Fn(ref decl, unsafety, constness, ref abi, ref generics, ref block) => {
+                ItemKind::Fn(ref item) => {
                     self.vis.to_tokens(tokens);
-                    constness.to_tokens(tokens);
-                    unsafety.to_tokens(tokens);
-                    abi.to_tokens(tokens);
+                    item.constness.to_tokens(tokens);
+                    item.unsafety.to_tokens(tokens);
+                    item.abi.to_tokens(tokens);
                     tokens.append("fn");
                     self.ident.to_tokens(tokens);
-                    generics.to_tokens(tokens);
+                    item.generics.to_tokens(tokens);
                     tokens.append("(");
-                    tokens.append_separated(&decl.inputs, ",");
+                    tokens.append_separated(&item.decl.inputs, ",");
                     tokens.append(")");
-                    if let FunctionRetTy::Ty(ref ty) = decl.output {
+                    if let FunctionRetTy::Ty(ref ty) = item.decl.output {
                         tokens.append("->");
                         ty.to_tokens(tokens);
                     }
-                    generics.where_clause.to_tokens(tokens);
+                    item.generics.where_clause.to_tokens(tokens);
                     tokens.append("{");
                     tokens.append_all(self.attrs.inner());
-                    tokens.append_all(&block.stmts);
+                    tokens.append_all(&item.block.stmts);
                     tokens.append("}");
                 }
-                ItemKind::Mod(ref items) => {
+                ItemKind::Mod(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("mod");
                     self.ident.to_tokens(tokens);
-                    match *items {
+                    match item.items {
                         Some(ref items) => {
                             tokens.append("{");
                             tokens.append_all(self.attrs.inner());
@@ -1106,96 +1232,96 @@ mod printing {
                     tokens.append_all(&foreign_mod.items);
                     tokens.append("}");
                 }
-                ItemKind::Ty(ref ty, ref generics) => {
+                ItemKind::Ty(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("type");
                     self.ident.to_tokens(tokens);
-                    generics.to_tokens(tokens);
-                    generics.where_clause.to_tokens(tokens);
+                    item.generics.to_tokens(tokens);
+                    item.generics.where_clause.to_tokens(tokens);
                     tokens.append("=");
-                    ty.to_tokens(tokens);
+                    item.ty.to_tokens(tokens);
                     tokens.append(";");
                 }
-                ItemKind::Enum(ref variants, ref generics) => {
+                ItemKind::Enum(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("enum");
                     self.ident.to_tokens(tokens);
-                    generics.to_tokens(tokens);
-                    generics.where_clause.to_tokens(tokens);
+                    item.generics.to_tokens(tokens);
+                    item.generics.where_clause.to_tokens(tokens);
                     tokens.append("{");
-                    for variant in variants {
+                    for variant in &item.variants {
                         variant.to_tokens(tokens);
                         tokens.append(",");
                     }
                     tokens.append("}");
                 }
-                ItemKind::Struct(ref variant_data, ref generics) => {
+                ItemKind::Struct(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("struct");
                     self.ident.to_tokens(tokens);
-                    generics.to_tokens(tokens);
-                    match *variant_data {
+                    item.generics.to_tokens(tokens);
+                    match item.data {
                         VariantData::Struct(_) => {
-                            generics.where_clause.to_tokens(tokens);
-                            variant_data.to_tokens(tokens);
+                            item.generics.where_clause.to_tokens(tokens);
+                            item.data.to_tokens(tokens);
                             // no semicolon
                         }
                         VariantData::Tuple(_) => {
-                            variant_data.to_tokens(tokens);
-                            generics.where_clause.to_tokens(tokens);
+                            item.data.to_tokens(tokens);
+                            item.generics.where_clause.to_tokens(tokens);
                             tokens.append(";");
                         }
                         VariantData::Unit => {
-                            generics.where_clause.to_tokens(tokens);
+                            item.generics.where_clause.to_tokens(tokens);
                             tokens.append(";");
                         }
                     }
                 }
-                ItemKind::Union(ref variant_data, ref generics) => {
+                ItemKind::Union(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("union");
                     self.ident.to_tokens(tokens);
-                    generics.to_tokens(tokens);
-                    generics.where_clause.to_tokens(tokens);
-                    variant_data.to_tokens(tokens);
+                    item.generics.to_tokens(tokens);
+                    item.generics.where_clause.to_tokens(tokens);
+                    item.data.to_tokens(tokens);
                 }
-                ItemKind::Trait(unsafety, ref generics, ref bound, ref items) => {
+                ItemKind::Trait(ref item) => {
                     self.vis.to_tokens(tokens);
-                    unsafety.to_tokens(tokens);
+                    item.unsafety.to_tokens(tokens);
                     tokens.append("trait");
                     self.ident.to_tokens(tokens);
-                    generics.to_tokens(tokens);
-                    if !bound.is_empty() {
+                    item.generics.to_tokens(tokens);
+                    if !item.supertraits.is_empty() {
                         tokens.append(":");
-                        tokens.append_separated(bound, "+");
+                        tokens.append_separated(&item.supertraits, "+");
                     }
-                    generics.where_clause.to_tokens(tokens);
+                    item.generics.where_clause.to_tokens(tokens);
                     tokens.append("{");
-                    tokens.append_all(items);
+                    tokens.append_all(&item.items);
                     tokens.append("}");
                 }
-                ItemKind::DefaultImpl(unsafety, ref path) => {
-                    unsafety.to_tokens(tokens);
+                ItemKind::DefaultImpl(ref item) => {
+                    item.unsafety.to_tokens(tokens);
                     tokens.append("impl");
-                    path.to_tokens(tokens);
+                    item.path.to_tokens(tokens);
                     tokens.append("for");
                     tokens.append("..");
                     tokens.append("{");
                     tokens.append("}");
                 }
-                ItemKind::Impl(unsafety, polarity, ref generics, ref path, ref ty, ref items) => {
-                    unsafety.to_tokens(tokens);
+                ItemKind::Impl(ref item) => {
+                    item.unsafety.to_tokens(tokens);
                     tokens.append("impl");
-                    generics.to_tokens(tokens);
-                    if let Some(ref path) = *path {
-                        polarity.to_tokens(tokens);
+                    item.generics.to_tokens(tokens);
+                    if let Some(ref path) = item.trait_ {
+                        item.polarity.to_tokens(tokens);
                         path.to_tokens(tokens);
                         tokens.append("for");
                     }
-                    ty.to_tokens(tokens);
-                    generics.where_clause.to_tokens(tokens);
+                    item.self_ty.to_tokens(tokens);
+                    item.generics.where_clause.to_tokens(tokens);
                     tokens.append("{");
-                    tokens.append_all(items);
+                    tokens.append_all(&item.items);
                     tokens.append("}");
                 }
                 ItemKind::Mac(ref mac) => {
@@ -1216,31 +1342,33 @@ mod printing {
         }
     }
 
-    impl ToTokens for ViewPath {
+    impl ToTokens for PathSimple {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            match *self {
-                ViewPath::Simple(ref path, ref rename) => {
-                    path.to_tokens(tokens);
-                    if let Some(ref rename) = *rename {
-                        tokens.append("as");
-                        rename.to_tokens(tokens);
-                    }
-                }
-                ViewPath::Glob(ref path) => {
-                    path.to_tokens(tokens);
-                    tokens.append("::");
-                    tokens.append("*");
-                }
-                ViewPath::List(ref path, ref items) => {
-                    path.to_tokens(tokens);
-                    if path.global || !path.segments.is_empty() {
-                        tokens.append("::");
-                    }
-                    tokens.append("{");
-                    tokens.append_separated(items, ",");
-                    tokens.append("}");
-                }
+            self.path.to_tokens(tokens);
+            if let Some(ref rename) = self.rename {
+                tokens.append("as");
+                rename.to_tokens(tokens);
             }
+        }
+    }
+
+    impl ToTokens for PathGlob {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            self.path.to_tokens(tokens);
+            tokens.append("::");
+            tokens.append("*");
+        }
+    }
+
+    impl ToTokens for PathList {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            self.path.to_tokens(tokens);
+            if self.path.global || !self.path.segments.is_empty() {
+                tokens.append("::");
+            }
+            tokens.append("{");
+            tokens.append_separated(&self.items, ",");
+            tokens.append("}");
         }
     }
 
@@ -1258,33 +1386,33 @@ mod printing {
         fn to_tokens(&self, tokens: &mut Tokens) {
             tokens.append_all(self.attrs.outer());
             match self.node {
-                TraitItemKind::Const(ref ty, ref expr) => {
+                TraitItemKind::Const(ref item) => {
                     tokens.append("const");
                     self.ident.to_tokens(tokens);
                     tokens.append(":");
-                    ty.to_tokens(tokens);
-                    if let Some(ref expr) = *expr {
+                    item.ty.to_tokens(tokens);
+                    if let Some(ref expr) = item.default {
                         tokens.append("=");
                         expr.to_tokens(tokens);
                     }
                     tokens.append(";");
                 }
-                TraitItemKind::Method(ref sig, ref block) => {
-                    sig.constness.to_tokens(tokens);
-                    sig.unsafety.to_tokens(tokens);
-                    sig.abi.to_tokens(tokens);
+                TraitItemKind::Method(ref item) => {
+                    item.sig.constness.to_tokens(tokens);
+                    item.sig.unsafety.to_tokens(tokens);
+                    item.sig.abi.to_tokens(tokens);
                     tokens.append("fn");
                     self.ident.to_tokens(tokens);
-                    sig.generics.to_tokens(tokens);
+                    item.sig.generics.to_tokens(tokens);
                     tokens.append("(");
-                    tokens.append_separated(&sig.decl.inputs, ",");
+                    tokens.append_separated(&item.sig.decl.inputs, ",");
                     tokens.append(")");
-                    if let FunctionRetTy::Ty(ref ty) = sig.decl.output {
+                    if let FunctionRetTy::Ty(ref ty) = item.sig.decl.output {
                         tokens.append("->");
                         ty.to_tokens(tokens);
                     }
-                    sig.generics.where_clause.to_tokens(tokens);
-                    match *block {
+                    item.sig.generics.where_clause.to_tokens(tokens);
+                    match item.default {
                         Some(ref block) => {
                             tokens.append("{");
                             tokens.append_all(self.attrs.inner());
@@ -1294,14 +1422,14 @@ mod printing {
                         None => tokens.append(";"),
                     }
                 }
-                TraitItemKind::Type(ref bound, ref default) => {
+                TraitItemKind::Type(ref item) => {
                     tokens.append("type");
                     self.ident.to_tokens(tokens);
-                    if !bound.is_empty() {
+                    if !item.bounds.is_empty() {
                         tokens.append(":");
-                        tokens.append_separated(bound, "+");
+                        tokens.append_separated(&item.bounds, "+");
                     }
-                    if let Some(ref default) = *default {
+                    if let Some(ref default) = item.default {
                         tokens.append("=");
                         default.to_tokens(tokens);
                     }
@@ -1324,46 +1452,46 @@ mod printing {
         fn to_tokens(&self, tokens: &mut Tokens) {
             tokens.append_all(self.attrs.outer());
             match self.node {
-                ImplItemKind::Const(ref ty, ref expr) => {
+                ImplItemKind::Const(ref item) => {
                     self.vis.to_tokens(tokens);
                     self.defaultness.to_tokens(tokens);
                     tokens.append("const");
                     self.ident.to_tokens(tokens);
                     tokens.append(":");
-                    ty.to_tokens(tokens);
+                    item.ty.to_tokens(tokens);
                     tokens.append("=");
-                    expr.to_tokens(tokens);
+                    item.expr.to_tokens(tokens);
                     tokens.append(";");
                 }
-                ImplItemKind::Method(ref sig, ref block) => {
+                ImplItemKind::Method(ref item) => {
                     self.vis.to_tokens(tokens);
                     self.defaultness.to_tokens(tokens);
-                    sig.constness.to_tokens(tokens);
-                    sig.unsafety.to_tokens(tokens);
-                    sig.abi.to_tokens(tokens);
+                    item.sig.constness.to_tokens(tokens);
+                    item.sig.unsafety.to_tokens(tokens);
+                    item.sig.abi.to_tokens(tokens);
                     tokens.append("fn");
                     self.ident.to_tokens(tokens);
-                    sig.generics.to_tokens(tokens);
+                    item.sig.generics.to_tokens(tokens);
                     tokens.append("(");
-                    tokens.append_separated(&sig.decl.inputs, ",");
+                    tokens.append_separated(&item.sig.decl.inputs, ",");
                     tokens.append(")");
-                    if let FunctionRetTy::Ty(ref ty) = sig.decl.output {
+                    if let FunctionRetTy::Ty(ref ty) = item.sig.decl.output {
                         tokens.append("->");
                         ty.to_tokens(tokens);
                     }
-                    sig.generics.where_clause.to_tokens(tokens);
+                    item.sig.generics.where_clause.to_tokens(tokens);
                     tokens.append("{");
                     tokens.append_all(self.attrs.inner());
-                    tokens.append_all(&block.stmts);
+                    tokens.append_all(&item.block.stmts);
                     tokens.append("}");
                 }
-                ImplItemKind::Type(ref ty) => {
+                ImplItemKind::Type(ref item) => {
                     self.vis.to_tokens(tokens);
                     self.defaultness.to_tokens(tokens);
                     tokens.append("type");
                     self.ident.to_tokens(tokens);
                     tokens.append("=");
-                    ty.to_tokens(tokens);
+                    item.ty.to_tokens(tokens);
                     tokens.append(";");
                 }
                 ImplItemKind::Macro(ref mac) => {
@@ -1383,62 +1511,61 @@ mod printing {
         fn to_tokens(&self, tokens: &mut Tokens) {
             tokens.append_all(self.attrs.outer());
             match self.node {
-                ForeignItemKind::Fn(ref decl, ref generics) => {
+                ForeignItemKind::Fn(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("fn");
                     self.ident.to_tokens(tokens);
-                    generics.to_tokens(tokens);
+                    item.generics.to_tokens(tokens);
                     tokens.append("(");
-                    tokens.append_separated(&decl.inputs, ",");
-                    if decl.variadic {
-                        if !decl.inputs.is_empty() {
+                    tokens.append_separated(&item.decl.inputs, ",");
+                    if item.decl.variadic {
+                        if !item.decl.inputs.is_empty() {
                             tokens.append(",");
                         }
                         tokens.append("...");
                     }
                     tokens.append(")");
-                    if let FunctionRetTy::Ty(ref ty) = decl.output {
+                    if let FunctionRetTy::Ty(ref ty) = item.decl.output {
                         tokens.append("->");
                         ty.to_tokens(tokens);
                     }
-                    generics.where_clause.to_tokens(tokens);
+                    item.generics.where_clause.to_tokens(tokens);
                     tokens.append(";");
                 }
-                ForeignItemKind::Static(ref ty, mutability) => {
+                ForeignItemKind::Static(ref item) => {
                     self.vis.to_tokens(tokens);
                     tokens.append("static");
-                    mutability.to_tokens(tokens);
+                    item.mutbl.to_tokens(tokens);
                     self.ident.to_tokens(tokens);
                     tokens.append(":");
-                    ty.to_tokens(tokens);
+                    item.ty.to_tokens(tokens);
                     tokens.append(";");
                 }
             }
         }
     }
 
-    impl ToTokens for FnArg {
+    impl ToTokens for ArgSelfRef {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            match *self {
-                FnArg::SelfRef(ref lifetime, mutability) => {
-                    tokens.append("&");
-                    lifetime.to_tokens(tokens);
-                    mutability.to_tokens(tokens);
-                    tokens.append("self");
-                }
-                FnArg::SelfValue(mutability) => {
-                    mutability.to_tokens(tokens);
-                    tokens.append("self");
-                }
-                FnArg::Captured(ref pat, ref ty) => {
-                    pat.to_tokens(tokens);
-                    tokens.append(":");
-                    ty.to_tokens(tokens);
-                }
-                FnArg::Ignored(ref ty) => {
-                    ty.to_tokens(tokens);
-                }
-            }
+            tokens.append("&");
+            self.lifetime.to_tokens(tokens);
+            self.mutbl.to_tokens(tokens);
+            tokens.append("self");
+        }
+    }
+
+    impl ToTokens for ArgSelf {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            self.mutbl.to_tokens(tokens);
+            tokens.append("self");
+        }
+    }
+
+    impl ToTokens for ArgCaptured {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            self.pat.to_tokens(tokens);
+            tokens.append(":");
+            self.ty.to_tokens(tokens);
         }
     }
 

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1,10 +1,11 @@
 use super::*;
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Crate {
-    pub shebang: Option<String>,
-    pub attrs: Vec<Attribute>,
-    pub items: Vec<Item>,
+ast_struct! {
+    pub struct Crate {
+        pub shebang: Option<String>,
+        pub attrs: Vec<Attribute>,
+        pub items: Vec<Item>,
+    }
 }
 
 #[cfg(feature = "parsing")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,16 @@ extern crate synom;
 #[cfg(feature = "aster")]
 pub mod aster;
 
+#[macro_use]
+mod macros;
+
 mod attr;
-pub use attr::{Attribute, AttrStyle, MetaItem, NestedMetaItem};
+pub use attr::{Attribute, AttrStyle, MetaItem, NestedMetaItem, MetaItemList,
+               MetaNameValue};
 
 mod constant;
-pub use constant::ConstExpr;
+pub use constant::{ConstExpr, ConstCall, ConstBinary, ConstUnary, ConstCast,
+                   ConstIndex, ConstParen};
 
 mod data;
 pub use data::{Field, Variant, VariantData, Visibility};
@@ -31,7 +36,13 @@ mod escape;
 mod expr;
 #[cfg(feature = "full")]
 pub use expr::{Arm, BindingMode, Block, CaptureBy, Expr, ExprKind, FieldPat, FieldValue, Local,
-               MacStmtStyle, Pat, RangeLimits, Stmt};
+               MacStmtStyle, Pat, RangeLimits, Stmt, ExprBox, ExprInPlace,
+               ExprArray, ExprCall, ExprMethodCall, ExprTup, ExprBinary, ExprUnary,
+               ExprCast, ExprType, ExprIf, ExprIfLet, ExprWhile, ExprWhileLet,
+               ExprForLoop, ExprLoop, ExprMatch, ExprClosure, ExprBlock,
+               ExprAssign, ExprAssignOp, ExprField, ExprTupField, ExprIndex,
+               ExprRange, ExprPath, ExprAddrOf, ExprBreak, ExprContinue,
+               ExprRet, ExprStruct, ExprRepeat, ExprParen, ExprTry, ExprCatch};
 
 mod generics;
 pub use generics::{Generics, Lifetime, LifetimeDef, TraitBoundModifier, TyParam, TyParamBound,
@@ -46,9 +57,15 @@ pub use ident::Ident;
 #[cfg(feature = "full")]
 mod item;
 #[cfg(feature = "full")]
-pub use item::{Constness, Defaultness, FnArg, FnDecl, ForeignItemKind, ForeignItem, ForeignMod,
+pub use item::{Constness, Defaultness, FnArg, FnDecl, ForeignItemKind, ForeignItem, ItemForeignMod,
                ImplItem, ImplItemKind, ImplPolarity, Item, ItemKind, MethodSig, PathListItem,
-               TraitItem, TraitItemKind, ViewPath};
+               TraitItem, TraitItemKind, ViewPath, ItemExternCrate, ItemUse,
+               ItemStatic, ItemConst, ItemFn, ItemMod, ItemTy, ItemEnum,
+               ItemStruct, ItemUnion, ItemTrait, ItemDefaultImpl, ItemImpl,
+               PathSimple, PathGlob, PathList, ForeignItemFn, ForeignItemStatic,
+               TraitItemConst, TraitItemMethod, TraitItemType,
+               ImplItemConst, ImplItemMethod, ImplItemType, ArgSelfRef,
+               ArgSelf, ArgCaptured};
 
 #[cfg(feature = "full")]
 mod krate;
@@ -75,7 +92,9 @@ pub use op::{BinOp, UnOp};
 mod ty;
 pub use ty::{Abi, AngleBracketedParameterData, BareFnArg, BareFnTy, FunctionRetTy, MutTy,
              Mutability, ParenthesizedParameterData, Path, PathParameters, PathSegment,
-             PolyTraitRef, QSelf, Ty, TypeBinding, Unsafety};
+             PolyTraitRef, QSelf, Ty, TypeBinding, Unsafety, TySlice, TyArray,
+             TyPtr, TyRptr, TyBareFn, TyNever, TyTup, TyPath, TyTraitObject,
+             TyImplTrait, TyParen, TyInfer};
 
 #[cfg(feature = "visit")]
 pub mod visit;

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -1,32 +1,34 @@
-/// Literal kind.
-///
-/// E.g. `"foo"`, `42`, `12.34` or `bool`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum Lit {
-    /// A string literal (`"foo"`)
-    Str(String, StrStyle),
-    /// A byte string (`b"foo"`)
-    ByteStr(Vec<u8>, StrStyle),
-    /// A byte char (`b'f'`)
-    Byte(u8),
-    /// A character literal (`'a'`)
-    Char(char),
-    /// An integer literal (`1`)
-    Int(u64, IntTy),
-    /// A float literal (`1f64` or `1E10f64` or `1.0E10`)
-    Float(String, FloatTy),
-    /// A boolean literal
-    Bool(bool),
+ast_enum! {
+    /// Literal kind.
+    ///
+    /// E.g. `"foo"`, `42`, `12.34` or `bool`
+    pub enum Lit {
+        /// A string literal (`"foo"`)
+        Str(String, StrStyle),
+        /// A byte string (`b"foo"`)
+        ByteStr(Vec<u8>, StrStyle),
+        /// A byte char (`b'f'`)
+        Byte(u8),
+        /// A character literal (`'a'`)
+        Char(char),
+        /// An integer literal (`1`)
+        Int(u64, IntTy),
+        /// A float literal (`1f64` or `1E10f64` or `1.0E10`)
+        Float(String, FloatTy),
+        /// A boolean literal
+        Bool(bool),
+    }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum StrStyle {
-    /// A regular string, like `"foo"`
-    Cooked,
-    /// A raw string, like `r##"foo"##`
-    ///
-    /// The uint is the number of `#` symbols used
-    Raw(usize),
+ast_enum! {
+    pub enum StrStyle {
+        /// A regular string, like `"foo"`
+        Cooked,
+        /// A raw string, like `r##"foo"##`
+        ///
+        /// The uint is the number of `#` symbols used
+        Raw(usize),
+    }
 }
 
 impl From<String> for Lit {
@@ -65,26 +67,30 @@ impl From<bool> for Lit {
     }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum IntTy {
-    Isize,
-    I8,
-    I16,
-    I32,
-    I64,
-    Usize,
-    U8,
-    U16,
-    U32,
-    U64,
-    Unsuffixed,
+ast_enum! {
+    #[derive(Copy)]
+    pub enum IntTy {
+        Isize,
+        I8,
+        I16,
+        I32,
+        I64,
+        Usize,
+        U8,
+        U16,
+        U32,
+        U64,
+        Unsuffixed,
+    }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum FloatTy {
-    F32,
-    F64,
-    Unsuffixed,
+ast_enum! {
+    #[derive(Copy)]
+    pub enum FloatTy {
+        F32,
+        F64,
+        Unsuffixed,
+    }
 }
 
 macro_rules! impl_from_for_lit {

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,112 +1,120 @@
 use super::*;
 
-/// Represents a macro invocation. The Path indicates which macro
-/// is being invoked, and the vector of token-trees contains the source
-/// of the macro invocation.
-///
-/// NB: the additional ident for a `macro_rules`-style macro is actually
-/// stored in the enclosing item. Oog.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Mac {
-    pub path: Path,
-    pub tts: Vec<TokenTree>,
+ast_struct! {
+    /// Represents a macro invocation. The Path indicates which macro
+    /// is being invoked, and the vector of token-trees contains the source
+    /// of the macro invocation.
+    ///
+    /// NB: the additional ident for a `macro_rules`-style macro is actually
+    /// stored in the enclosing item. Oog.
+    pub struct Mac {
+        pub path: Path,
+        pub tts: Vec<TokenTree>,
+    }
 }
 
-/// When the main rust parser encounters a syntax-extension invocation, it
-/// parses the arguments to the invocation as a token-tree. This is a very
-/// loose structure, such that all sorts of different AST-fragments can
-/// be passed to syntax extensions using a uniform type.
-///
-/// If the syntax extension is an MBE macro, it will attempt to match its
-/// LHS token tree against the provided token tree, and if it finds a
-/// match, will transcribe the RHS token tree, splicing in any captured
-/// `macro_parser::matched_nonterminals` into the `SubstNt`s it finds.
-///
-/// The RHS of an MBE macro is the only place `SubstNt`s are substituted.
-/// Nothing special happens to misnamed or misplaced `SubstNt`s.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum TokenTree {
-    /// A single token
-    Token(Token),
-    /// A delimited sequence of token trees
-    Delimited(Delimited),
+ast_enum! {
+    /// When the main rust parser encounters a syntax-extension invocation, it
+    /// parses the arguments to the invocation as a token-tree. This is a very
+    /// loose structure, such that all sorts of different AST-fragments can
+    /// be passed to syntax extensions using a uniform type.
+    ///
+    /// If the syntax extension is an MBE macro, it will attempt to match its
+    /// LHS token tree against the provided token tree, and if it finds a
+    /// match, will transcribe the RHS token tree, splicing in any captured
+    /// `macro_parser::matched_nonterminals` into the `SubstNt`s it finds.
+    ///
+    /// The RHS of an MBE macro is the only place `SubstNt`s are substituted.
+    /// Nothing special happens to misnamed or misplaced `SubstNt`s.
+    pub enum TokenTree {
+        /// A single token
+        Token(Token),
+        /// A delimited sequence of token trees
+        Delimited(Delimited),
+    }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct Delimited {
-    /// The type of delimiter
-    pub delim: DelimToken,
-    /// The delimited sequence of token trees
-    pub tts: Vec<TokenTree>,
+ast_struct! {
+    pub struct Delimited {
+        /// The type of delimiter
+        pub delim: DelimToken,
+        /// The delimited sequence of token trees
+        pub tts: Vec<TokenTree>,
+    }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub enum Token {
-    // Expression-operator symbols.
-    Eq,
-    Lt,
-    Le,
-    EqEq,
-    Ne,
-    Ge,
-    Gt,
-    AndAnd,
-    OrOr,
-    Not,
-    Tilde,
-    BinOp(BinOpToken),
-    BinOpEq(BinOpToken),
+ast_enum! {
+    pub enum Token {
+        // Expression-operator symbols.
+        Eq,
+        Lt,
+        Le,
+        EqEq,
+        Ne,
+        Ge,
+        Gt,
+        AndAnd,
+        OrOr,
+        Not,
+        Tilde,
+        BinOp(BinOpToken),
+        BinOpEq(BinOpToken),
 
-    // Structural symbols
-    At,
-    Dot,
-    DotDot,
-    DotDotDot,
-    Comma,
-    Semi,
-    Colon,
-    ModSep,
-    RArrow,
-    LArrow,
-    FatArrow,
-    Pound,
-    Dollar,
-    Question,
+        // Structural symbols
+        At,
+        Dot,
+        DotDot,
+        DotDotDot,
+        Comma,
+        Semi,
+        Colon,
+        ModSep,
+        RArrow,
+        LArrow,
+        FatArrow,
+        Pound,
+        Dollar,
+        Question,
 
-    // Literals
-    Literal(Lit),
+        // Literals
+        Literal(Lit),
 
-    // Name components
-    Ident(Ident),
-    Underscore,
-    Lifetime(Ident),
+        // Name components
+        Ident(Ident),
+        Underscore,
+        Lifetime(Ident),
 
-    DocComment(String),
+        DocComment(String),
+    }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum BinOpToken {
-    Plus,
-    Minus,
-    Star,
-    Slash,
-    Percent,
-    Caret,
-    And,
-    Or,
-    Shl,
-    Shr,
+ast_enum! {
+    #[derive(Copy)]
+    pub enum BinOpToken {
+        Plus,
+        Minus,
+        Star,
+        Slash,
+        Percent,
+        Caret,
+        And,
+        Or,
+        Shl,
+        Shr,
+    }
 }
 
-/// A delimiter token
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum DelimToken {
-    /// A round parenthesis: `(` or `)`
-    Paren,
-    /// A square bracket: `[` or `]`
-    Bracket,
-    /// A curly brace: `{` or `}`
-    Brace,
+ast_enum! {
+    /// A delimiter token
+    #[derive(Copy)]
+    pub enum DelimToken {
+        /// A round parenthesis: `(` or `)`
+        Paren,
+        /// A square bracket: `[` or `]`
+        Bracket,
+        /// A curly brace: `{` or `}`
+        Brace,
+    }
 }
 
 #[cfg(feature = "parsing")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,101 @@
+macro_rules! ast_struct {
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident {
+            $(
+                $(#[$field_attr:meta])*
+                pub $field:ident: $ty:ty,
+            )*
+        }
+    ) => {
+        $(#[$attr])*
+        #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+        pub struct $name {
+            $(
+                $(#[$field_attr])*
+                pub $field: $ty,
+            )*
+        }
+    }
+}
+
+macro_rules! ast_enum {
+    (
+        $(#[$enum_attr:meta])*
+        pub enum $name:ident { $($variants:tt)* }
+    ) => (
+        $(#[$enum_attr])*
+        #[derive(Debug, Clone, Eq, PartialEq, Hash)]
+        pub enum $name {
+            $($variants)*
+        }
+    )
+}
+
+macro_rules! ast_enum_of_structs {
+    (
+        $(#[$enum_attr:meta])*
+        pub enum $name:ident {
+            $(
+                $(#[$variant_attr:meta])*
+                pub $variant:ident($member:ident $($rest:tt)*),
+            )*
+        }
+
+        $($remaining:tt)*
+    ) => (
+        ast_enum! {
+            $(#[$enum_attr])*
+            pub enum $name {
+                $(
+                    $(#[$variant_attr])*
+                    $variant($member),
+                )*
+            }
+        }
+
+        $(
+            maybe_ast_struct! {
+                $(#[$variant_attr])*
+                pub struct $member $($rest)*
+            }
+
+            impl From<$member> for $name {
+                fn from(e: $member) -> $name {
+                    $name::$variant(e)
+                }
+            }
+        )*
+
+        generate_to_tokens! {
+            $($remaining)*
+            enum $name { $($variant,)* }
+        }
+    )
+}
+
+macro_rules! generate_to_tokens {
+    (do_not_generate_to_tokens $($foo:tt)*) => ();
+
+    (enum $name:ident { $($variant:ident,)* }) => (
+        #[cfg(feature = "printing")]
+        impl ::quote::ToTokens for $name {
+            fn to_tokens(&self, tokens: &mut ::quote::Tokens) {
+                match *self {
+                    $(
+                        $name::$variant(ref e) => e.to_tokens(tokens),
+                    )*
+                }
+            }
+        }
+    )
+}
+
+macro_rules! maybe_ast_struct {
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident
+    ) => ();
+
+    ($($rest:tt)*) => (ast_struct! { $($rest)* });
+}

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,51 +1,55 @@
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum BinOp {
-    /// The `+` operator (addition)
-    Add,
-    /// The `-` operator (subtraction)
-    Sub,
-    /// The `*` operator (multiplication)
-    Mul,
-    /// The `/` operator (division)
-    Div,
-    /// The `%` operator (modulus)
-    Rem,
-    /// The `&&` operator (logical and)
-    And,
-    /// The `||` operator (logical or)
-    Or,
-    /// The `^` operator (bitwise xor)
-    BitXor,
-    /// The `&` operator (bitwise and)
-    BitAnd,
-    /// The `|` operator (bitwise or)
-    BitOr,
-    /// The `<<` operator (shift left)
-    Shl,
-    /// The `>>` operator (shift right)
-    Shr,
-    /// The `==` operator (equality)
-    Eq,
-    /// The `<` operator (less than)
-    Lt,
-    /// The `<=` operator (less than or equal to)
-    Le,
-    /// The `!=` operator (not equal to)
-    Ne,
-    /// The `>=` operator (greater than or equal to)
-    Ge,
-    /// The `>` operator (greater than)
-    Gt,
+ast_enum! {
+    #[derive(Copy)]
+    pub enum BinOp {
+        /// The `+` operator (addition)
+        Add,
+        /// The `-` operator (subtraction)
+        Sub,
+        /// The `*` operator (multiplication)
+        Mul,
+        /// The `/` operator (division)
+        Div,
+        /// The `%` operator (modulus)
+        Rem,
+        /// The `&&` operator (logical and)
+        And,
+        /// The `||` operator (logical or)
+        Or,
+        /// The `^` operator (bitwise xor)
+        BitXor,
+        /// The `&` operator (bitwise and)
+        BitAnd,
+        /// The `|` operator (bitwise or)
+        BitOr,
+        /// The `<<` operator (shift left)
+        Shl,
+        /// The `>>` operator (shift right)
+        Shr,
+        /// The `==` operator (equality)
+        Eq,
+        /// The `<` operator (less than)
+        Lt,
+        /// The `<=` operator (less than or equal to)
+        Le,
+        /// The `!=` operator (not equal to)
+        Ne,
+        /// The `>=` operator (greater than or equal to)
+        Ge,
+        /// The `>` operator (greater than)
+        Gt,
+    }
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum UnOp {
-    /// The `*` operator for dereferencing
-    Deref,
-    /// The `!` operator for logical inversion
-    Not,
-    /// The `-` operator for negation
-    Neg,
+ast_enum! {
+    #[derive(Copy)]
+    pub enum UnOp {
+        /// The `*` operator for dereferencing
+        Deref,
+        /// The `!` operator for logical inversion
+        Not,
+        /// The `-` operator for negation
+        Neg,
+    }
 }
 
 #[cfg(feature = "parsing")]

--- a/synom/src/helper.rs
+++ b/synom/src/helper.rs
@@ -227,14 +227,17 @@ macro_rules! epsilon {
 /// extern crate syn;
 /// #[macro_use] extern crate synom;
 ///
-/// use syn::{Expr, ExprKind};
+/// use syn::{Expr, ExprCall};
 /// use syn::parse::expr;
 ///
 /// named!(expr_with_arrow_call -> Expr, do_parse!(
 ///     mut e: expr >>
 ///     many0!(tap!(arg: tuple!(punct!("=>"), expr) => {
 ///         e = Expr {
-///             node: ExprKind::Call(Box::new(e), vec![arg.1]),
+///             node: ExprCall {
+///                 func: Box::new(e),
+///                 args: vec![arg.1],
+///             }.into(),
 ///             attrs: Vec::new(),
 ///         };
 ///     })) >>

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -90,45 +90,45 @@ fn test_catch_expr() {
 
     assert_let!(ItemKind::Struct(..) = actual.items[0].node);
 
-    assert_let!(Item { node: ItemKind::Fn(_, _, _, _, _, ref body), .. } = actual.items[1]; {
-        assert_let!(Stmt::Local(ref local) = body.stmts[0]; {
+    assert_let!(Item { node: ItemKind::Fn(ItemFn { ref block, .. }), .. } = actual.items[1]; {
+        assert_let!(Stmt::Local(ref local) = block.stmts[0]; {
             assert_let!(Local { init: Some(ref init_expr), .. } = **local; {
                 assert_let!(Expr { node: ExprKind::Catch(..), .. } = **init_expr);
             });
         });
 
-        assert_let!(Stmt::Local(ref local) = body.stmts[2]; {
+        assert_let!(Stmt::Local(ref local) = block.stmts[2]; {
             assert_let!(Pat::Ident(BindingMode::ByValue(Mutability::Mutable), ref ident, None) = *local.pat; {
                 assert_eq!(ident, "catch");
             });
         });
 
-        assert_let!(Stmt::Expr(ref expr) = body.stmts[3]; {
-            assert_let!(Expr { node: ExprKind::While(ref loop_expr, _, None), .. } = **expr; {
-                assert_let!(Expr { node: ExprKind::Path(None, ref loop_var), .. } = **loop_expr; {
-                    assert_eq!(*loop_var, "catch".into());
+        assert_let!(Stmt::Expr(ref expr) = block.stmts[3]; {
+            assert_let!(Expr { node: ExprKind::While(ExprWhile { ref cond, .. }), .. } = **expr; {
+                assert_let!(Expr { node: ExprKind::Path(ExprPath { qself: None, ref path }), .. } = **cond; {
+                    assert_eq!(*path, "catch".into());
                 });
             });
         });
 
-        assert_let!(Stmt::Semi(ref expr) = body.stmts[5]; {
-            assert_let!(Expr { node: ExprKind::Assign(ref left, ref right), .. } = **expr; {
-                assert_let!(Expr { node: ExprKind::Path(None, ref loop_var), .. } = **left; {
-                    assert_eq!(*loop_var, "catch".into());
+        assert_let!(Stmt::Semi(ref expr) = block.stmts[5]; {
+            assert_let!(Expr { node: ExprKind::Assign(ExprAssign { ref left, ref right }), .. } = **expr; {
+                assert_let!(Expr { node: ExprKind::Path(ExprPath { qself: None, ref path }), .. } = **left; {
+                    assert_eq!(*path, "catch".into());
                 });
 
-                assert_let!(Expr { node: ExprKind::If(ref if_expr, _, _), .. } = **right; {
-                    assert_let!(Expr { node: ExprKind::Path(None, ref if_var), .. } = **if_expr; {
-                        assert_eq!(*if_var, "catch".into());
+                assert_let!(Expr { node: ExprKind::If(ExprIf { ref cond, .. }), .. } = **right; {
+                    assert_let!(Expr { node: ExprKind::Path(ExprPath { qself: None, ref path }), .. } = **cond; {
+                        assert_eq!(*path, "catch".into());
                     });
                 });
             });
         });
 
-        assert_let!(Stmt::Semi(ref expr) = body.stmts[7]; {
-            assert_let!(Expr { node: ExprKind::Match(ref match_expr, _), .. } = **expr; {
-                assert_let!(Expr { node: ExprKind::Path(None, ref match_var), .. } = **match_expr; {
-                    assert_eq!(*match_var, "catch".into());
+        assert_let!(Stmt::Semi(ref expr) = block.stmts[7]; {
+            assert_let!(Expr { node: ExprKind::Match(ExprMatch { ref expr, .. }), .. } = **expr; {
+                assert_let!(Expr { node: ExprKind::Path(ExprPath { qself: None, ref path }), .. } = **expr; {
+                    assert_eq!(*path, "catch".into());
                 });
             });
         });

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -27,13 +27,15 @@ fn test_split_for_impl() {
                                         }],
                             ident: Ident::new("T"),
                             bounds: vec![TyParamBound::Region(Lifetime::new("'a"))],
-                            default: Some(Ty::Tup(Vec::new())),
+                            default: Some(TyTup { tys: Vec::new() }.into()),
                         }],
         where_clause: WhereClause {
             predicates: vec![WherePredicate::BoundPredicate(WhereBoundPredicate {
                                                                 bound_lifetimes: Vec::new(),
-                                                                bounded_ty:
-                                                                    Ty::Path(None, "T".into()),
+                                                                bounded_ty: TyPath {
+                                                                    qself: None,
+                                                                    path: "T".into(),
+                                                                }.into(),
                                                                 bounds: vec![
                         TyParamBound::Trait(
                             PolyTraitRef {

--- a/tests/test_macro_input.rs
+++ b/tests/test_macro_input.rs
@@ -1,4 +1,4 @@
-//! Test the now-deprecated `parse_macro_input` function. 
+//! Test the now-deprecated `parse_macro_input` function.
 //!
 //! Deprecation warnings are suppressed to keep the output clean.
 #![allow(deprecated)]
@@ -47,43 +47,56 @@ fn test_struct() {
             is_sugared_doc: false,
         }],
         generics: Generics::default(),
-        body: Body::Struct(VariantData::Struct(vec![Field {
-                                                        ident: Some("ident".into()),
-                                                        vis: Visibility::Public,
-                                                        attrs: Vec::new(),
-                                                        ty: Ty::Path(None, "Ident".into()),
-                                                    },
-                                                    Field {
-                                                        ident: Some("attrs".into()),
-                                                        vis: Visibility::Public,
-                                                        attrs: Vec::new(),
-                                                        ty: Ty::Path(None,
-                                                                     Path {
-                                                                         global: false,
-                                                                         segments: vec![
-                        PathSegment {
-                            ident: "Vec".into(),
-                            parameters: PathParameters::AngleBracketed(
-                                AngleBracketedParameterData {
-                                    lifetimes: Vec::new(),
-                                    types: vec![Ty::Path(None, "Attribute".into())],
-                                    bindings: Vec::new(),
-                                },
-                            ),
-                        }
-                    ],
-                                                                     }),
-                                                    }])),
+        body: Body::Struct(VariantData::Struct(vec![
+            Field {
+                ident: Some("ident".into()),
+                vis: Visibility::Public,
+                attrs: Vec::new(),
+                ty: TyPath {
+                    qself: None,
+                    path: "Ident".into(),
+                }.into(),
+            },
+            Field {
+                ident: Some("attrs".into()),
+                vis: Visibility::Public,
+                attrs: Vec::new(),
+                ty: TyPath {
+                    qself: None,
+                    path: Path {
+                        global: false,
+                        segments: vec![
+                            PathSegment {
+                                ident: "Vec".into(),
+                                parameters: PathParameters::AngleBracketed(
+                                    AngleBracketedParameterData {
+                                        lifetimes: Vec::new(),
+                                        types: vec![TyPath {
+                                            qself: None,
+                                            path: "Attribute".into(),
+                                        }.into()],
+                                        bindings: Vec::new(),
+                                    },
+                                ),
+                            }
+                        ],
+                    },
+                }.into(),
+            },
+        ]))
     };
 
     let actual = parse_macro_input(raw).unwrap();
 
     assert_eq!(expected, actual);
 
-    let expected_meta_item = MetaItem::List("derive".into(), vec![
-        NestedMetaItem::MetaItem(MetaItem::Word("Debug".into())),
-        NestedMetaItem::MetaItem(MetaItem::Word("Clone".into())),
-    ]);
+    let expected_meta_item: MetaItem = MetaItemList {
+        ident: "derive".into(),
+        nested: vec![
+            NestedMetaItem::MetaItem(MetaItem::Word("Debug".into())),
+            NestedMetaItem::MetaItem(MetaItem::Word("Clone".into())),
+        ],
+    }.into();
 
     assert_eq!(expected_meta_item, actual.attrs[0].meta_item().unwrap());
 }
@@ -153,7 +166,7 @@ fn test_enum() {
                         ident: None,
                         vis: Visibility::Inherited,
                         attrs: Vec::new(),
-                        ty: Ty::Path(None, "T".into()),
+                        ty: TyPath { qself: None, path: "T".into() }.into(),
                     },
                 ]),
                 discriminant: None,
@@ -166,7 +179,7 @@ fn test_enum() {
                         ident: None,
                         vis: Visibility::Inherited,
                         attrs: Vec::new(),
-                        ty: Ty::Path(None, "E".into()),
+                        ty: TyPath { qself: None, path: "E".into() }.into(),
                     },
                 ]),
                 discriminant: None,
@@ -182,22 +195,24 @@ fn test_enum() {
                 attrs: Vec::new(),
                 data: VariantData::Unit,
                 discriminant: Some(ConstExpr::Other(Expr {
-                    node: ExprKind::TupField(
-                        Box::new(Expr {
-                            node: ExprKind::Tup(vec![
-                                Expr {
-                                    node: ExprKind::Lit(Lit::Int(0, IntTy::Unsuffixed)),
-                                    attrs: Vec::new(),
-                                },
-                                Expr {
-                                    node: ExprKind::Lit(Lit::Str("data".into(), StrStyle::Cooked)),
-                                    attrs: Vec::new(),
-                                },
-                            ]),
+                    node: ExprTupField {
+                        expr: Box::new(Expr {
+                            node: ExprTup {
+                                args: vec![
+                                    Expr {
+                                        node: ExprKind::Lit(Lit::Int(0, IntTy::Unsuffixed)),
+                                        attrs: Vec::new(),
+                                    },
+                                    Expr {
+                                        node: ExprKind::Lit(Lit::Str("data".into(), StrStyle::Cooked)),
+                                        attrs: Vec::new(),
+                                    },
+                                ],
+                            }.into(),
                             attrs: Vec::new(),
                         }),
-                        0
-                    ),
+                        field: 0
+                    }.into(),
                     attrs: Vec::new(),
                 })),
             },
@@ -209,10 +224,13 @@ fn test_enum() {
     assert_eq!(expected, actual);
 
     let expected_meta_items = vec![
-        MetaItem::NameValue("doc".into(), Lit::Str(
-            "/// See the std::result module documentation for details.".into(),
-            StrStyle::Cooked,
-        )),
+        MetaNameValue {
+            ident: "doc".into(),
+            lit: Lit::Str(
+                "/// See the std::result module documentation for details.".into(),
+                StrStyle::Cooked,
+            ),
+        }.into(),
         MetaItem::Word("must_use".into()),
     ];
 
@@ -338,7 +356,7 @@ fn test_pub_restricted() {
             ident: None,
             vis: Visibility::Restricted(Box::new(Path { global: false, segments: vec!["m".into(), "n".into()] })),
             attrs: vec![],
-            ty: Ty::Path(None, "u8".into()),
+            ty: TyPath { qself: None, path: "u8".into() }.into(),
         }])),
     };
 

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -3,52 +3,75 @@ use syn::*;
 
 #[test]
 fn test_meta_item_word() {
-    run_test("#[foo]", &MetaItem::Word("foo".into()))
+    run_test("#[foo]", MetaItem::Word("foo".into()))
 }
 
 #[test]
 fn test_meta_item_name_value() {
-    run_test("#[foo = 5]", &MetaItem::NameValue("foo".into(),
-        Lit::Int(5, IntTy::Unsuffixed)))
+    run_test("#[foo = 5]", MetaNameValue {
+        ident: "foo".into(),
+        lit: Lit::Int(5, IntTy::Unsuffixed),
+    })
 }
 
 #[test]
 fn test_meta_item_list_lit() {
-    run_test("#[foo(5)]", &MetaItem::List("foo".into(), vec![
-        NestedMetaItem::Literal(Lit::Int(5, IntTy::Unsuffixed)),
-    ]))
+    run_test("#[foo(5)]", MetaItemList {
+        ident: "foo".into(),
+        nested: vec![
+            NestedMetaItem::Literal(Lit::Int(5, IntTy::Unsuffixed)),
+        ],
+    })
 }
 
 #[test]
 fn test_meta_item_list_word() {
-    run_test("#[foo(bar)]", &MetaItem::List("foo".into(), vec![
-        NestedMetaItem::MetaItem(MetaItem::Word("bar".into())),
-    ]))
+    run_test("#[foo(bar)]", MetaItemList {
+        ident: "foo".into(),
+        nested: vec![
+            NestedMetaItem::MetaItem(MetaItem::Word("bar".into())),
+        ],
+    })
 }
 
 #[test]
 fn test_meta_item_list_name_value() {
-    run_test("#[foo(bar = 5)]", &MetaItem::List("foo".into(), vec![
-        NestedMetaItem::MetaItem(MetaItem::NameValue("bar".into(),
-            Lit::Int(5, IntTy::Unsuffixed))),
-    ]))
+    run_test("#[foo(bar = 5)]", MetaItemList {
+        ident: "foo".into(),
+        nested: vec![
+            NestedMetaItem::MetaItem(MetaNameValue {
+                ident: "bar".into(),
+                lit: Lit::Int(5, IntTy::Unsuffixed),
+            }.into()),
+        ],
+    })
 }
 
 #[test]
 fn test_meta_item_multiple() {
-    run_test("#[foo(word, name = 5, list(name2 = 6), word2)]", &MetaItem::List("foo".into(), vec![
-        NestedMetaItem::MetaItem(MetaItem::Word("word".into())),
-        NestedMetaItem::MetaItem(MetaItem::NameValue("name".into(),
-            Lit::Int(5, IntTy::Unsuffixed))),
-        NestedMetaItem::MetaItem(MetaItem::List("list".into(), vec![
-            NestedMetaItem::MetaItem(MetaItem::NameValue("name2".into(),
-                Lit::Int(6, IntTy::Unsuffixed)))
-        ])),
-        NestedMetaItem::MetaItem(MetaItem::Word("word2".into())),
-    ]))
+    run_test("#[foo(word, name = 5, list(name2 = 6), word2)]", MetaItemList {
+        ident: "foo".into(),
+        nested: vec![
+            NestedMetaItem::MetaItem(MetaItem::Word("word".into())),
+            NestedMetaItem::MetaItem(MetaNameValue {
+                ident: "name".into(),
+                lit: Lit::Int(5, IntTy::Unsuffixed),
+            }.into()),
+            NestedMetaItem::MetaItem(MetaItemList {
+                ident: "list".into(),
+                nested: vec![
+                    NestedMetaItem::MetaItem(MetaNameValue {
+                        ident: "name2".into(),
+                        lit: Lit::Int(6, IntTy::Unsuffixed),
+                    }.into())
+                ],
+            }.into()),
+            NestedMetaItem::MetaItem(MetaItem::Word("word2".into())),
+        ],
+    })
 }
 
-fn run_test(input: &str, expected: &MetaItem) {
+fn run_test<T: Into<MetaItem>>(input: &str, expected: T) {
     let attr = parse_outer_attr(input).unwrap();
-    assert_eq!(expected, &attr.meta_item().unwrap());
+    assert_eq!(expected.into(), attr.meta_item().unwrap());
 }


### PR DESCRIPTION
This commit is a relatively large rewrite of the AST that `syn` exposes. The
main change is to expose enums-of-structs rather than
enums-with-huge-tuple-variants. The best example of this is `ItemKind::Fn` which
changed from:

    enum ItemKind {
        Fn(Box<FnDecl>, Unsafety, Constness, Option<Abi>, Generics, Box<Block>),
        ...
    }

to

    enum ItemKind {
        Fn(ItemFn),
        ...
    }

    struct ItemFn {
        decl: Box<FnDecl>,
        unsafety: Unsafety,
        constness: Constness,
        abi: Option<Abi>,
        generics: Generics,
        block: Box<Block>,
    }

This change serves a few purposes:

* It's now much easier to add fields to each variant of the ast, ast struct
  fields tend to be "by default ignored" in most contexts.
* It's much easier to document what each field is, as each field can have
  dedicated documentation.
* There's now canonicalized names for each field (the name of the field) which
  can help match `match` statements more consistent across a codebase.

A downside of this representation is that it can be a little more verbose to
work with in `match` statements and during constructions. Overall though I'd
feel at least that the readability improved significantly despite the extra
words required to do various operations.

Closes #136