### PR TITLE
Rewrite tokenization with `proc-macro2` tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,22 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-
 default = ["parsing", "printing", "clone-impls"]
 aster = []
 full = []
-parsing = ["unicode-xid", "synom"]
-printing = ["quote"]
+parsing = ["unicode-xid", "synom/parsing"]
+printing = ["quote", "synom/printing"]
 visit = []
 fold = []
 clone-impls = []
 extra-traits = []
 
 [dependencies]
-quote = { version = "0.3.7", optional = true }
+proc-macro2 = { git = 'https://github.com/alexcrichton/proc-macro2' }
 unicode-xid = { version = "0.0.4", optional = true }
-synom = { version = "0.11", path = "synom", optional = true }
+synom = { version = "0.11", path = "synom", default-features = true }
+
+[dependencies.quote]
+git = 'https://github.com/alexcrichton/quote'
+branch = 'new-tokens'
+optional = true
 
 [dev-dependencies]
 syntex_pos = "0.58"

--- a/src/aster/lifetime.rs
+++ b/src/aster/lifetime.rs
@@ -1,5 +1,6 @@
 use {Ident, Lifetime, LifetimeDef};
 use aster::invoke::{Invoke, Identity};
+use delimited::Delimited;
 
 // ////////////////////////////////////////////////////////////////////////////
 
@@ -36,7 +37,8 @@ impl IntoLifetimeDef for Lifetime {
         LifetimeDef {
             attrs: vec![],
             lifetime: self,
-            bounds: vec![],
+            bounds: Delimited::new(),
+            colon_token: Default::default(),
         }
     }
 }
@@ -95,9 +97,10 @@ impl<F> LifetimeDefBuilder<F>
 
     pub fn build(self) -> F::Result {
         self.callback.invoke(LifetimeDef {
-                                 attrs: vec![],
-                                 lifetime: self.lifetime,
-                                 bounds: self.bounds,
-                             })
+            attrs: vec![],
+            lifetime: self.lifetime,
+            bounds: self.bounds.into(),
+            colon_token: Default::default(),
+        })
     }
 }

--- a/src/aster/qpath.rs
+++ b/src/aster/qpath.rs
@@ -3,6 +3,7 @@ use aster::ident::ToIdent;
 use aster::invoke::{Invoke, Identity};
 use aster::path::{PathBuilder, PathSegmentBuilder};
 use aster::ty::TyBuilder;
+use delimited::Delimited;
 
 // ////////////////////////////////////////////////////////////////////////////
 
@@ -74,7 +75,8 @@ impl<F> QPathTyBuilder<F>
     {
         let path = Path {
             global: false,
-            segments: vec![],
+            segments: Delimited::new(),
+            leading_colon: None,
         };
         self.as_().build(path).id(id)
     }
@@ -84,7 +86,8 @@ impl<F> QPathTyBuilder<F>
     {
         let path = Path {
             global: false,
-            segments: vec![],
+            segments: Delimited::new(),
+            leading_colon: None,
         };
         self.as_().build(path).segment(id)
     }
@@ -101,6 +104,9 @@ impl<F> Invoke<Path> for QPathTyBuilder<F>
             qself: QSelf {
                 ty: Box::new(self.ty),
                 position: path.segments.len(),
+                as_token: Default::default(),
+                gt_token: Default::default(),
+                lt_token: Default::default(),
             },
             path: path,
         }
@@ -137,7 +143,7 @@ impl<F> Invoke<PathSegment> for QPathQSelfBuilder<F>
     type Result = F::Result;
 
     fn invoke(mut self, segment: PathSegment) -> F::Result {
-        self.path.segments.push(segment);
+        self.path.segments.push_default(segment);
         self.builder.build(self.qself, self.path)
     }
 }

--- a/src/aster/ty.rs
+++ b/src/aster/ty.rs
@@ -116,7 +116,10 @@ impl<F> TyBuilder<F>
     }
 
     pub fn build_slice(self, ty: Ty) -> F::Result {
-        self.build(Ty::Slice(TySlice { ty: Box::new(ty) }))
+        self.build(Ty::Slice(TySlice {
+            ty: Box::new(ty),
+            bracket_token: Default::default(),
+        }))
     }
 
     pub fn slice(self) -> TyBuilder<TySliceBuilder<F>> {
@@ -132,11 +135,15 @@ impl<F> TyBuilder<F>
     }
 
     pub fn never(self) -> F::Result {
-        self.build(Ty::Never(TyNever {}))
+        self.build(Ty::Never(TyNever {
+            bang_token: Default::default(),
+        }))
     }
 
     pub fn infer(self) -> F::Result {
-        self.build(Ty::Infer(TyInfer {}))
+        self.build(Ty::Infer(TyInfer {
+            underscore_token: Default::default()
+        }))
     }
 
     pub fn option(self) -> TyBuilder<TyOptionBuilder<F>> {
@@ -221,7 +228,7 @@ impl<F> TyRefBuilder<F>
     where F: Invoke<Ty>
 {
     pub fn mut_(mut self) -> Self {
-        self.mutability = Mutability::Mutable;
+        self.mutability = Mutability::Mutable(Default::default());
         self
     }
 
@@ -240,6 +247,7 @@ impl<F> TyRefBuilder<F>
         self.builder.build(Ty::Rptr(TyRptr {
             lifetime: self.lifetime,
             ty: Box::new(ty),
+            and_token: Default::default(),
         }))
     }
 
@@ -414,7 +422,9 @@ impl<F> TyImplTraitTyBuilder<F>
     }
 
     pub fn with_generics(self, generics: Generics) -> Self {
-        self.with_lifetimes(generics.lifetimes.into_iter().map(|def| def.lifetime))
+        self.with_lifetimes(generics.lifetimes.iter().map(|def| {
+            Lifetime { ident: def.item().lifetime.ident.clone() }
+        }))
     }
 
     pub fn with_lifetimes<I, L>(mut self, lifetimes: I) -> Self
@@ -437,7 +447,8 @@ impl<F> TyImplTraitTyBuilder<F>
     pub fn build(self) -> F::Result {
         let bounds = self.bounds;
         self.builder.build(Ty::ImplTrait(TyImplTrait {
-            bounds: bounds,
+            bounds: bounds.into(),
+            impl_token: Default::default(),
         }))
     }
 }
@@ -479,7 +490,11 @@ impl<F> TyTupleBuilder<F>
     }
 
     pub fn build(self) -> F::Result {
-        self.builder.build(Ty::Tup(TyTup { tys: self.tys }))
+        self.builder.build(Ty::Tup(TyTup {
+            tys: self.tys.into(),
+            paren_token: Default::default(),
+            lone_comma: None,
+        }))
     }
 }
 

--- a/src/aster/ty_param.rs
+++ b/src/aster/ty_param.rs
@@ -1,4 +1,5 @@
 use {Ident, LifetimeDef, Path, PolyTraitRef, TraitBoundModifier, Ty, TyParam, TyParamBound};
+use BoundLifetimes;
 use aster::invoke::{Invoke, Identity};
 use aster::lifetime::{IntoLifetime, IntoLifetimeDef, LifetimeDefBuilder};
 use aster::path::{IntoPath, PathBuilder};
@@ -43,7 +44,7 @@ impl<F> TyParamBuilder<F>
         TyParamBuilder {
             callback: callback,
             id: ty_param.ident,
-            bounds: ty_param.bounds,
+            bounds: ty_param.bounds.into_vec(),
             default: ty_param.default,
         }
     }
@@ -87,11 +88,13 @@ impl<F> TyParamBuilder<F>
 
     pub fn build(self) -> F::Result {
         self.callback.invoke(TyParam {
-                                 attrs: vec![],
-                                 ident: self.id,
-                                 bounds: self.bounds,
-                                 default: self.default,
-                             })
+            attrs: vec![],
+            ident: self.id,
+            bounds: self.bounds.into(),
+            default: self.default,
+            colon_token: Default::default(),
+            eq_token: Default::default(),
+        })
     }
 }
 
@@ -165,7 +168,7 @@ impl<F> TyParamBoundBuilder<F>
     {
         let builder = TraitTyParamBoundBuilder {
             builder: self,
-            modifier: TraitBoundModifier::Maybe,
+            modifier: TraitBoundModifier::Maybe(Default::default()),
         };
 
         PolyTraitRefBuilder::with_callback(path, builder)
@@ -245,9 +248,12 @@ impl<F> PolyTraitRefBuilder<F>
 
     pub fn build(self) -> F::Result {
         self.callback.invoke(PolyTraitRef {
-                                 bound_lifetimes: self.lifetimes,
-                                 trait_ref: self.trait_ref,
-                             })
+            bound_lifetimes: Some(BoundLifetimes {
+                lifetimes: self.lifetimes.into(),
+                ..Default::default()
+            }),
+            trait_ref: self.trait_ref,
+        })
     }
 }
 

--- a/src/aster/where_predicate.rs
+++ b/src/aster/where_predicate.rs
@@ -1,5 +1,5 @@
 use {Ident, Lifetime, LifetimeDef, Ty, TyParamBound, WhereBoundPredicate, WherePredicate,
-     WhereRegionPredicate};
+     WhereRegionPredicate, BoundLifetimes};
 use aster::invoke::{Invoke, Identity};
 use aster::lifetime::{IntoLifetime, IntoLifetimeDef, LifetimeDefBuilder};
 use aster::path::IntoPath;
@@ -201,9 +201,13 @@ impl<F> WhereBoundPredicateTyBoundsBuilder<F>
 
     pub fn build(self) -> F::Result {
         let predicate = WhereBoundPredicate {
-            bound_lifetimes: self.bound_lifetimes,
+            bound_lifetimes: Some(BoundLifetimes {
+                lifetimes: self.bound_lifetimes.into(),
+                ..Default::default()
+            }),
             bounded_ty: self.ty,
-            bounds: self.bounds,
+            bounds: self.bounds.into(),
+            colon_token: Default::default(),
         };
 
         self.callback.invoke(WherePredicate::BoundPredicate(predicate))
@@ -251,7 +255,8 @@ impl<F> WhereRegionPredicateBuilder<F>
     pub fn build(self) -> F::Result {
         let predicate = WhereRegionPredicate {
             lifetime: self.lifetime,
-            bounds: self.bounds,
+            bounds: self.bounds.into(),
+            colon_token: Default::default(),
         };
 
         self.callback.invoke(WherePredicate::RegionPredicate(predicate))

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,5 @@
 use super::*;
+use delimited::Delimited;
 
 ast_struct! {
     /// An enum variant.
@@ -14,6 +15,8 @@ ast_struct! {
 
         /// Explicit discriminant, e.g. `Foo = 1`
         pub discriminant: Option<ConstExpr>,
+
+        pub eq_token: Option<tokens::Eq>,
     }
 }
 
@@ -21,10 +24,10 @@ ast_enum! {
     /// Data stored within an enum variant or struct.
     pub enum VariantData {
         /// Struct variant, e.g. `Point { x: f64, y: f64 }`.
-        Struct(Vec<Field>),
+        Struct(Delimited<Field, tokens::Comma>, tokens::Brace),
 
         /// Tuple variant, e.g. `Some(T)`.
-        Tuple(Vec<Field>),
+        Tuple(Delimited<Field, tokens::Comma>, tokens::Paren),
 
         /// Unit variant, e.g. `None`.
         Unit,
@@ -32,23 +35,24 @@ ast_enum! {
 }
 
 impl VariantData {
-    /// Slice containing the fields stored in the variant.
-    pub fn fields(&self) -> &[Field] {
-        match *self {
-            VariantData::Struct(ref fields) |
-            VariantData::Tuple(ref fields) => fields,
-            VariantData::Unit => &[],
-        }
-    }
-
-    /// Mutable slice containing the fields stored in the variant.
-    pub fn fields_mut(&mut self) -> &mut [Field] {
-        match *self {
-            VariantData::Struct(ref mut fields) |
-            VariantData::Tuple(ref mut fields) => fields,
-            VariantData::Unit => &mut [],
-        }
-    }
+    // TODO: expose this?
+    // /// Slice containing the fields stored in the variant.
+    // pub fn fields(&self) -> &Delimited<Field, tokens::Comma> {
+    //     match *self {
+    //         VariantData::Struct(ref fields, _) |
+    //         VariantData::Tuple(ref fields, _) => fields,
+    //         VariantData::Unit => &[],
+    //     }
+    // }
+    //
+    // /// Mutable slice containing the fields stored in the variant.
+    // pub fn fields_mut(&mut self) -> &mut Delimited<Field, tokens::Comma> {
+    //     match *self {
+    //         VariantData::Struct(ref mut fields, _) |
+    //         VariantData::Tuple(ref mut fields, _) => fields,
+    //         VariantData::Unit => &mut [],
+    //     }
+    // }
 }
 
 ast_struct! {
@@ -67,23 +71,36 @@ ast_struct! {
 
         /// Type of the field.
         pub ty: Ty,
+
+        pub colon_token: Option<tokens::Colon>,
     }
 }
 
-ast_enum! {
+ast_enum_of_structs! {
     /// Visibility level of an item.
     pub enum Visibility {
         /// Public, i.e. `pub`.
-        Public,
+        pub Public(VisPublic {
+            pub pub_token: tokens::Pub,
+        }),
 
         /// Crate-visible, i.e. `pub(crate)`.
-        Crate,
+        pub Crate(VisCrate {
+            pub pub_token: tokens::Pub,
+            pub paren_token: tokens::Paren,
+            pub crate_token: tokens::Crate,
+        }),
 
         /// Restricted, e.g. `pub(self)` or `pub(super)` or `pub(in some::module)`.
-        Restricted(Box<Path>),
+        pub Restricted(VisRestricted {
+            pub pub_token: tokens::Pub,
+            pub paren_token: tokens::Paren,
+            pub in_token: Option<tokens::In>,
+            pub path: Box<Path>,
+        }),
 
         /// Inherited, i.e. private.
-        Inherited,
+        pub Inherited(VisInherited {}),
     }
 }
 
@@ -102,42 +119,43 @@ pub mod parsing {
     use ident::parsing::ident;
     use ty::parsing::{mod_style_path, ty};
 
-    named!(pub struct_body -> (WhereClause, VariantData), alt!(
+    named!(pub struct_body -> (WhereClause, VariantData, Option<tokens::Semi>), alt!(
         do_parse!(
             wh: where_clause >>
             body: struct_like_body >>
-            (wh, VariantData::Struct(body))
+            (wh, VariantData::Struct(body.0, body.1), None)
         )
         |
         do_parse!(
             body: tuple_like_body >>
             wh: where_clause >>
             punct!(";") >>
-            (wh, VariantData::Tuple(body))
+            (wh, VariantData::Tuple(body.0, body.1), Some(tokens::Semi::default()))
         )
         |
         do_parse!(
             wh: where_clause >>
             punct!(";") >>
-            (wh, VariantData::Unit)
+            (wh, VariantData::Unit, Some(tokens::Semi::default()))
         )
     ));
 
-    named!(pub enum_body -> (WhereClause, Vec<Variant>), do_parse!(
+    named!(pub enum_body -> (WhereClause, Delimited<Variant, tokens::Comma>, tokens::Brace), do_parse!(
         wh: where_clause >>
         punct!("{") >>
-        variants: terminated_list!(punct!(","), variant) >>
+        variants: terminated_list!(map!(punct!(","), |_| tokens::Comma::default()),
+                                   variant) >>
         punct!("}") >>
-        (wh, variants)
+        (wh, variants, tokens::Brace::default())
     ));
 
     named!(variant -> Variant, do_parse!(
         attrs: many0!(outer_attr) >>
         id: ident >>
         data: alt!(
-            struct_like_body => { VariantData::Struct }
+            struct_like_body => { |(d, b)| VariantData::Struct(d, b) }
             |
-            tuple_like_body => { VariantData::Tuple }
+            tuple_like_body => { |(d, b)| VariantData::Tuple(d, b) }
             |
             epsilon!() => { |_| VariantData::Unit }
         ) >>
@@ -146,6 +164,7 @@ pub mod parsing {
             ident: id,
             attrs: attrs,
             data: data,
+            eq_token: disr.as_ref().map(|_| tokens::Eq::default()),
             discriminant: disr,
         })
     ));
@@ -163,18 +182,20 @@ pub mod parsing {
     #[cfg(feature = "full")]
     named!(after_discriminant -> &str, peek!(alt!(punct!(",") | punct!("}"))));
 
-    named!(pub struct_like_body -> Vec<Field>, do_parse!(
+    named!(pub struct_like_body -> (Delimited<Field, tokens::Comma>, tokens::Brace), do_parse!(
         punct!("{") >>
-        fields: terminated_list!(punct!(","), struct_field) >>
+        fields: terminated_list!(map!(punct!(","), |_| tokens::Comma::default()),
+                                 struct_field) >>
         punct!("}") >>
-        (fields)
+        (fields, tokens::Brace::default())
     ));
 
-    named!(tuple_like_body -> Vec<Field>, do_parse!(
+    named!(tuple_like_body -> (Delimited<Field, tokens::Comma>, tokens::Paren), do_parse!(
         punct!("(") >>
-        fields: terminated_list!(punct!(","), tuple_field) >>
+        fields: terminated_list!(map!(punct!(","), |_| tokens::Comma::default()),
+                                 tuple_field) >>
         punct!(")") >>
-        (fields)
+        (fields, tokens::Paren::default())
     ));
 
     named!(struct_field -> Field, do_parse!(
@@ -188,6 +209,7 @@ pub mod parsing {
             vis: vis,
             attrs: attrs,
             ty: ty,
+            colon_token: Some(tokens::Colon::default()),
         })
     ));
 
@@ -197,6 +219,7 @@ pub mod parsing {
         ty: ty >>
         (Field {
             ident: None,
+            colon_token: None,
             vis: vis,
             attrs: attrs,
             ty: ty,
@@ -209,7 +232,11 @@ pub mod parsing {
             punct!("(") >>
             keyword!("crate") >>
             punct!(")") >>
-            (Visibility::Crate)
+            (Visibility::Crate(VisCrate {
+                crate_token: tokens::Crate::default(),
+                paren_token: tokens::Paren::default(),
+                pub_token: tokens::Pub::default(),
+            }))
         )
         |
         do_parse!(
@@ -217,7 +244,12 @@ pub mod parsing {
             punct!("(") >>
             keyword!("self") >>
             punct!(")") >>
-            (Visibility::Restricted(Box::new("self".into())))
+            (Visibility::Restricted(VisRestricted {
+                path: Box::new("self".into()),
+                in_token: None,
+                paren_token: tokens::Paren::default(),
+                pub_token: tokens::Pub::default(),
+            }))
         )
         |
         do_parse!(
@@ -225,7 +257,12 @@ pub mod parsing {
             punct!("(") >>
             keyword!("super") >>
             punct!(")") >>
-            (Visibility::Restricted(Box::new("super".into())))
+            (Visibility::Restricted(VisRestricted {
+                path: Box::new("super".into()),
+                in_token: None,
+                paren_token: tokens::Paren::default(),
+                pub_token: tokens::Pub::default(),
+            }))
         )
         |
         do_parse!(
@@ -234,12 +271,21 @@ pub mod parsing {
             keyword!("in") >>
             restricted: mod_style_path >>
             punct!(")") >>
-            (Visibility::Restricted(Box::new(restricted)))
+            (Visibility::Restricted(VisRestricted {
+                path: Box::new(restricted),
+                in_token: Some(tokens::In::default()),
+                paren_token: tokens::Paren::default(),
+                pub_token: tokens::Pub::default(),
+            }))
         )
         |
-        keyword!("pub") => { |_| Visibility::Public }
+        keyword!("pub") => { |_| {
+            Visibility::Public(VisPublic {
+                pub_token: tokens::Pub::default(),
+            })
+        } }
         |
-        epsilon!() => { |_| Visibility::Inherited }
+        epsilon!() => { |_| Visibility::Inherited(VisInherited {}) }
     ));
 }
 
@@ -250,30 +296,26 @@ mod printing {
 
     impl ToTokens for Variant {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            for attr in &self.attrs {
-                attr.to_tokens(tokens);
-            }
+            tokens.append_all(&self.attrs);
             self.ident.to_tokens(tokens);
             self.data.to_tokens(tokens);
-            if let Some(ref disr) = self.discriminant {
-                tokens.append("=");
-                disr.to_tokens(tokens);
-            }
+            self.eq_token.to_tokens(tokens);
+            self.discriminant.to_tokens(tokens);
         }
     }
 
     impl ToTokens for VariantData {
         fn to_tokens(&self, tokens: &mut Tokens) {
             match *self {
-                VariantData::Struct(ref fields) => {
-                    tokens.append("{");
-                    tokens.append_separated(fields, ",");
-                    tokens.append("}");
+                VariantData::Struct(ref fields, ref brace) => {
+                    brace.surround(tokens, |tokens| {
+                        fields.to_tokens(tokens);
+                    });
                 }
-                VariantData::Tuple(ref fields) => {
-                    tokens.append("(");
-                    tokens.append_separated(fields, ",");
-                    tokens.append(")");
+                VariantData::Tuple(ref fields, ref paren) => {
+                    paren.surround(tokens, |tokens| {
+                        fields.to_tokens(tokens);
+                    });
                 }
                 VariantData::Unit => {}
             }
@@ -282,47 +324,41 @@ mod printing {
 
     impl ToTokens for Field {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            for attr in &self.attrs {
-                attr.to_tokens(tokens);
-            }
+            tokens.append_all(&self.attrs);
             self.vis.to_tokens(tokens);
-            if let Some(ref ident) = self.ident {
-                ident.to_tokens(tokens);
-                tokens.append(":");
-            }
+            self.ident.to_tokens(tokens);
+            self.colon_token.to_tokens(tokens);
             self.ty.to_tokens(tokens);
         }
     }
 
-    impl ToTokens for Visibility {
+    impl ToTokens for VisPublic {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            match *self {
-                Visibility::Public => tokens.append("pub"),
-                Visibility::Crate => {
-                    tokens.append("pub");
-                    tokens.append("(");
-                    tokens.append("crate");
-                    tokens.append(")");
-                }
-                Visibility::Restricted(ref path) => {
-                    tokens.append("pub");
-                    tokens.append("(");
+            self.pub_token.to_tokens(tokens)
+        }
+    }
 
-                    if !path.global &&
-                       path.segments.len() == 1 &&
-                       (path.segments[0].ident == "self" || path.segments[0].ident == "super") &&
-                       path.segments[0].parameters.is_empty() {
+    impl ToTokens for VisCrate {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            self.pub_token.to_tokens(tokens);
+            self.paren_token.surround(tokens, |tokens| {
+                self.crate_token.to_tokens(tokens);
+            })
+        }
+    }
 
-                        // Don't emit preceding `in` if path is `self` or `super`
-                    } else {
-                        tokens.append("in");
-                    }
+    impl ToTokens for VisRestricted {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            self.pub_token.to_tokens(tokens);
+            self.paren_token.surround(tokens, |tokens| {
+                self.in_token.to_tokens(tokens);
+                self.path.to_tokens(tokens);
+            });
+        }
+    }
 
-                    path.to_tokens(tokens);
-                    tokens.append(")");
-                }
-                Visibility::Inherited => {}
-            }
+    impl ToTokens for VisInherited {
+        fn to_tokens(&self, _tokens: &mut Tokens) {
         }
     }
 }

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -1,48 +1,66 @@
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::fmt::{self, Display};
+use std::hash::{Hash, Hasher};
 
-#[derive(Debug, Clone, Eq, Hash, Ord, PartialOrd)]
-pub struct Ident(String);
+use proc_macro2::Symbol;
+
+use Span;
+
+#[derive(Clone)]
+pub struct Ident {
+    pub sym: Symbol,
+    pub span: Span,
+}
 
 impl Ident {
-    pub fn new<T: Into<Ident>>(t: T) -> Self {
-        t.into()
+    pub fn new(sym: Symbol, span: Span) -> Self {
+        Ident {
+            sym: sym,
+            span: span,
+        }
     }
 }
 
 impl<'a> From<&'a str> for Ident {
     fn from(s: &str) -> Self {
-        Ident(s.to_owned())
+        Ident::new(s.into(), Span::default())
     }
 }
 
 impl<'a> From<Cow<'a, str>> for Ident {
     fn from(s: Cow<'a, str>) -> Self {
-        Ident(s.into_owned())
+        Ident::new(s[..].into(), Span::default())
     }
 }
 
 impl From<String> for Ident {
     fn from(s: String) -> Self {
-        Ident(s)
+        Ident::new(s[..].into(), Span::default())
     }
 }
 
 impl From<usize> for Ident {
     fn from(u: usize) -> Self {
-        Ident(u.to_string())
+        Ident::new(u.to_string()[..].into(), Span::default())
     }
 }
 
 impl AsRef<str> for Ident {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.sym.as_str()
     }
 }
 
 impl Display for Ident {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        self.0.fmt(formatter)
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.sym.as_str().fmt(formatter)
+    }
+}
+
+impl fmt::Debug for Ident {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self.sym.as_str(), formatter)
     }
 }
 
@@ -50,7 +68,27 @@ impl<T: ?Sized> PartialEq<T> for Ident
     where T: AsRef<str>
 {
     fn eq(&self, other: &T) -> bool {
-        self.0 == other.as_ref()
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl Eq for Ident {}
+
+impl PartialOrd for Ident {
+    fn partial_cmp(&self, other: &Ident) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Ident {
+    fn cmp(&self, other: &Ident) -> Ordering {
+        self.as_ref().cmp(other.as_ref())
+    }
+}
+
+impl Hash for Ident {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.as_ref().hash(h)
     }
 }
 
@@ -120,10 +158,14 @@ pub mod parsing {
 mod printing {
     use super::*;
     use quote::{Tokens, ToTokens};
+    use proc_macro2::{TokenTree, TokenKind};
 
     impl ToTokens for Ident {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            tokens.append(self.as_ref())
+            tokens.append(TokenTree {
+                span: self.span.0,
+                kind: TokenKind::Word(self.sym),
+            })
         }
     }
 }

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -44,15 +44,12 @@ mod printing {
 
     impl ToTokens for Crate {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            if let Some(ref shebang) = self.shebang {
-                tokens.append(&format!("{}\n", shebang));
-            }
-            for attr in self.attrs.inner() {
-                attr.to_tokens(tokens);
-            }
-            for item in &self.items {
-                item.to_tokens(tokens);
-            }
+            // TODO: how to handle shebang?
+            // if let Some(ref shebang) = self.shebang {
+            //     tokens.append(&format!("{}\n", shebang));
+            // }
+            tokens.append_all(self.attrs.inner());
+            tokens.append_all(&self.items);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,15 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(large_enum_variant))]
 
+extern crate proc_macro2;
+
 #[cfg(feature = "printing")]
 extern crate quote;
 
 #[cfg(feature = "parsing")]
 extern crate unicode_xid;
 
-#[cfg(feature = "parsing")]
-#[macro_use]
+#[cfg_attr(feature = "parsing", macro_use)]
 extern crate synom;
 
 #[cfg(feature = "aster")]
@@ -27,7 +28,8 @@ pub use constant::{ConstExpr, ConstCall, ConstBinary, ConstUnary, ConstCast,
                    ConstIndex, ConstParen};
 
 mod data;
-pub use data::{Field, Variant, VariantData, Visibility};
+pub use data::{Field, Variant, VariantData, Visibility, VisRestricted, VisCrate,
+               VisPublic, VisInherited};
 
 #[cfg(feature = "parsing")]
 mod escape;
@@ -42,12 +44,14 @@ pub use expr::{Arm, BindingMode, Block, CaptureBy, Expr, ExprKind, FieldPat, Fie
                ExprForLoop, ExprLoop, ExprMatch, ExprClosure, ExprBlock,
                ExprAssign, ExprAssignOp, ExprField, ExprTupField, ExprIndex,
                ExprRange, ExprPath, ExprAddrOf, ExprBreak, ExprContinue,
-               ExprRet, ExprStruct, ExprRepeat, ExprParen, ExprTry, ExprCatch};
+               ExprRet, ExprStruct, ExprRepeat, ExprParen, ExprTry, ExprCatch,
+               PatIdent, PatWild, PatStruct, PatTuple, PatTupleStruct, PatPath,
+               PatBox, PatRef, PatLit, PatRange, PatSlice};
 
 mod generics;
 pub use generics::{Generics, Lifetime, LifetimeDef, TraitBoundModifier, TyParam, TyParamBound,
                    WhereBoundPredicate, WhereClause, WhereEqPredicate, WherePredicate,
-                   WhereRegionPredicate};
+                   WhereRegionPredicate, BoundLifetimes};
 #[cfg(feature = "printing")]
 pub use generics::{ImplGenerics, Turbofish, TyGenerics};
 
@@ -73,15 +77,13 @@ mod krate;
 pub use krate::Crate;
 
 mod lit;
-pub use lit::{FloatTy, IntTy, Lit, StrStyle};
-#[cfg(feature = "parsing")]
-pub use lit::{ByteStrLit, FloatLit, IntLit, StrLit};
+pub use lit::{Lit, LitKind};
 
 mod mac;
-pub use mac::{BinOpToken, DelimToken, Delimited, Mac, Token, TokenTree};
+pub use mac::{Mac, TokenTree};
 
 mod derive;
-pub use derive::{Body, DeriveInput};
+pub use derive::{Body, DeriveInput, BodyEnum, BodyStruct};
 // Deprecated. Use `DeriveInput` instead.
 #[doc(hidden)]
 pub type MacroInput = DeriveInput;
@@ -95,6 +97,14 @@ pub use ty::{Abi, AngleBracketedParameterData, BareFnArg, BareFnTy, FunctionRetT
              PolyTraitRef, QSelf, Ty, TypeBinding, Unsafety, TySlice, TyArray,
              TyPtr, TyRptr, TyBareFn, TyNever, TyTup, TyPath, TyTraitObject,
              TyImplTrait, TyParen, TyInfer};
+#[cfg(feature = "printing")]
+pub use ty::PathTokens;
+
+mod span;
+pub use span::Span;
+
+pub mod tokens;
+pub use synom::delimited;
 
 #[cfg(feature = "visit")]
 pub mod visit;

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,42 +1,64 @@
+use tokens;
+
 ast_enum! {
     #[cfg_attr(feature = "clone-impls", derive(Copy))]
     pub enum BinOp {
         /// The `+` operator (addition)
-        Add,
+        Add(tokens::Add),
         /// The `-` operator (subtraction)
-        Sub,
+        Sub(tokens::Sub),
         /// The `*` operator (multiplication)
-        Mul,
+        Mul(tokens::Star),
         /// The `/` operator (division)
-        Div,
+        Div(tokens::Div),
         /// The `%` operator (modulus)
-        Rem,
+        Rem(tokens::Rem),
         /// The `&&` operator (logical and)
-        And,
+        And(tokens::AndAnd),
         /// The `||` operator (logical or)
-        Or,
+        Or(tokens::OrOr),
         /// The `^` operator (bitwise xor)
-        BitXor,
+        BitXor(tokens::Caret),
         /// The `&` operator (bitwise and)
-        BitAnd,
+        BitAnd(tokens::And),
         /// The `|` operator (bitwise or)
-        BitOr,
+        BitOr(tokens::Or),
         /// The `<<` operator (shift left)
-        Shl,
+        Shl(tokens::Shl),
         /// The `>>` operator (shift right)
-        Shr,
+        Shr(tokens::Shr),
         /// The `==` operator (equality)
-        Eq,
+        Eq(tokens::EqEq),
         /// The `<` operator (less than)
-        Lt,
+        Lt(tokens::Lt),
         /// The `<=` operator (less than or equal to)
-        Le,
+        Le(tokens::Le),
         /// The `!=` operator (not equal to)
-        Ne,
+        Ne(tokens::Ne),
         /// The `>=` operator (greater than or equal to)
-        Ge,
+        Ge(tokens::Ge),
         /// The `>` operator (greater than)
-        Gt,
+        Gt(tokens::Gt),
+        /// The `+=` operator
+        AddEq(tokens::AddEq),
+        /// The `-=` operator
+        SubEq(tokens::SubEq),
+        /// The `*=` operator
+        MulEq(tokens::MulEq),
+        /// The `/=` operator
+        DivEq(tokens::DivEq),
+        /// The `%=` operator
+        RemEq(tokens::RemEq),
+        /// The `^=` operator
+        BitXorEq(tokens::CaretEq),
+        /// The `&=` operator
+        BitAndEq(tokens::AndEq),
+        /// The `|=` operator
+        BitOrEq(tokens::OrEq),
+        /// The `<<=` operator
+        ShlEq(tokens::ShlEq),
+        /// The `>>=` operator
+        ShrEq(tokens::ShrEq),
     }
 }
 
@@ -44,11 +66,11 @@ ast_enum! {
     #[cfg_attr(feature = "clone-impls", derive(Copy))]
     pub enum UnOp {
         /// The `*` operator for dereferencing
-        Deref,
+        Deref(tokens::Star),
         /// The `!` operator for logical inversion
-        Not,
+        Not(tokens::Bang),
         /// The `-` operator for negation
-        Neg,
+        Neg(tokens::Sub),
     }
 }
 
@@ -57,72 +79,72 @@ pub mod parsing {
     use super::*;
 
     named!(pub binop -> BinOp, alt!(
-        punct!("&&") => { |_| BinOp::And }
+        punct!("&&") => { |_| BinOp::And(tokens::AndAnd::default()) }
         |
-        punct!("||") => { |_| BinOp::Or }
+        punct!("||") => { |_| BinOp::Or(tokens::OrOr::default()) }
         |
-        punct!("<<") => { |_| BinOp::Shl }
+        punct!("<<") => { |_| BinOp::Shl(tokens::Shl::default()) }
         |
-        punct!(">>") => { |_| BinOp::Shr }
+        punct!(">>") => { |_| BinOp::Shr(tokens::Shr::default()) }
         |
-        punct!("==") => { |_| BinOp::Eq }
+        punct!("==") => { |_| BinOp::Eq(tokens::EqEq::default()) }
         |
-        punct!("<=") => { |_| BinOp::Le }
+        punct!("<=") => { |_| BinOp::Le(tokens::Le::default()) }
         |
-        punct!("!=") => { |_| BinOp::Ne }
+        punct!("!=") => { |_| BinOp::Ne(tokens::Ne::default()) }
         |
-        punct!(">=") => { |_| BinOp::Ge }
+        punct!(">=") => { |_| BinOp::Ge(tokens::Ge::default()) }
         |
-        punct!("+") => { |_| BinOp::Add }
+        punct!("+") => { |_| BinOp::Add(tokens::Add::default()) }
         |
-        punct!("-") => { |_| BinOp::Sub }
+        punct!("-") => { |_| BinOp::Sub(tokens::Sub::default()) }
         |
-        punct!("*") => { |_| BinOp::Mul }
+        punct!("*") => { |_| BinOp::Mul(tokens::Star::default()) }
         |
-        punct!("/") => { |_| BinOp::Div }
+        punct!("/") => { |_| BinOp::Div(tokens::Div::default()) }
         |
-        punct!("%") => { |_| BinOp::Rem }
+        punct!("%") => { |_| BinOp::Rem(tokens::Rem::default()) }
         |
-        punct!("^") => { |_| BinOp::BitXor }
+        punct!("^") => { |_| BinOp::BitXor(tokens::Caret::default()) }
         |
-        punct!("&") => { |_| BinOp::BitAnd }
+        punct!("&") => { |_| BinOp::BitAnd(tokens::And::default()) }
         |
-        punct!("|") => { |_| BinOp::BitOr }
+        punct!("|") => { |_| BinOp::BitOr(tokens::Or::default()) }
         |
-        punct!("<") => { |_| BinOp::Lt }
+        punct!("<") => { |_| BinOp::Lt(tokens::Lt::default()) }
         |
-        punct!(">") => { |_| BinOp::Gt }
+        punct!(">") => { |_| BinOp::Gt(tokens::Gt::default()) }
     ));
 
     #[cfg(feature = "full")]
     named!(pub assign_op -> BinOp, alt!(
-        punct!("+=") => { |_| BinOp::Add }
+        punct!("+=") => { |_| BinOp::AddEq(tokens::AddEq::default()) }
         |
-        punct!("-=") => { |_| BinOp::Sub }
+        punct!("-=") => { |_| BinOp::SubEq(tokens::SubEq::default()) }
         |
-        punct!("*=") => { |_| BinOp::Mul }
+        punct!("*=") => { |_| BinOp::MulEq(tokens::MulEq::default()) }
         |
-        punct!("/=") => { |_| BinOp::Div }
+        punct!("/=") => { |_| BinOp::DivEq(tokens::DivEq::default()) }
         |
-        punct!("%=") => { |_| BinOp::Rem }
+        punct!("%=") => { |_| BinOp::RemEq(tokens::RemEq::default()) }
         |
-        punct!("^=") => { |_| BinOp::BitXor }
+        punct!("^=") => { |_| BinOp::BitXorEq(tokens::CaretEq::default()) }
         |
-        punct!("&=") => { |_| BinOp::BitAnd }
+        punct!("&=") => { |_| BinOp::BitAndEq(tokens::AndEq::default()) }
         |
-        punct!("|=") => { |_| BinOp::BitOr }
+        punct!("|=") => { |_| BinOp::BitOrEq(tokens::OrEq::default()) }
         |
-        punct!("<<=") => { |_| BinOp::Shl }
+        punct!("<<=") => { |_| BinOp::ShlEq(tokens::ShlEq::default()) }
         |
-        punct!(">>=") => { |_| BinOp::Shr }
+        punct!(">>=") => { |_| BinOp::ShrEq(tokens::ShrEq::default()) }
     ));
 
     named!(pub unop -> UnOp, alt!(
-        punct!("*") => { |_| UnOp::Deref }
+        punct!("*") => { |_| UnOp::Deref(tokens::Star::default()) }
         |
-        punct!("!") => { |_| UnOp::Not }
+        punct!("!") => { |_| UnOp::Not(tokens::Bang::default()) }
         |
-        punct!("-") => { |_| UnOp::Neg }
+        punct!("-") => { |_| UnOp::Neg(tokens::Sub::default()) }
     ));
 }
 
@@ -131,66 +153,48 @@ mod printing {
     use super::*;
     use quote::{Tokens, ToTokens};
 
-    impl BinOp {
-        pub fn op(&self) -> &'static str {
-            match *self {
-                BinOp::Add => "+",
-                BinOp::Sub => "-",
-                BinOp::Mul => "*",
-                BinOp::Div => "/",
-                BinOp::Rem => "%",
-                BinOp::And => "&&",
-                BinOp::Or => "||",
-                BinOp::BitXor => "^",
-                BinOp::BitAnd => "&",
-                BinOp::BitOr => "|",
-                BinOp::Shl => "<<",
-                BinOp::Shr => ">>",
-                BinOp::Eq => "==",
-                BinOp::Lt => "<",
-                BinOp::Le => "<=",
-                BinOp::Ne => "!=",
-                BinOp::Ge => ">=",
-                BinOp::Gt => ">",
-            }
-        }
-
-        pub fn assign_op(&self) -> Option<&'static str> {
-            match *self {
-                BinOp::Add => Some("+="),
-                BinOp::Sub => Some("-="),
-                BinOp::Mul => Some("*="),
-                BinOp::Div => Some("/="),
-                BinOp::Rem => Some("%="),
-                BinOp::BitXor => Some("^="),
-                BinOp::BitAnd => Some("&="),
-                BinOp::BitOr => Some("|="),
-                BinOp::Shl => Some("<<="),
-                BinOp::Shr => Some(">>="),
-                _ => None,
-            }
-        }
-    }
-
     impl ToTokens for BinOp {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            tokens.append(self.op());
-        }
-    }
-
-    impl UnOp {
-        pub fn op(&self) -> &'static str {
             match *self {
-                UnOp::Deref => "*",
-                UnOp::Not => "!",
-                UnOp::Neg => "-",
+                BinOp::Add(ref t) => t.to_tokens(tokens),
+                BinOp::Sub(ref t) => t.to_tokens(tokens),
+                BinOp::Mul(ref t) => t.to_tokens(tokens),
+                BinOp::Div(ref t) => t.to_tokens(tokens),
+                BinOp::Rem(ref t) => t.to_tokens(tokens),
+                BinOp::And(ref t) => t.to_tokens(tokens),
+                BinOp::Or(ref t) => t.to_tokens(tokens),
+                BinOp::BitXor(ref t) => t.to_tokens(tokens),
+                BinOp::BitAnd(ref t) => t.to_tokens(tokens),
+                BinOp::BitOr(ref t) => t.to_tokens(tokens),
+                BinOp::Shl(ref t) => t.to_tokens(tokens),
+                BinOp::Shr(ref t) => t.to_tokens(tokens),
+                BinOp::Eq(ref t) => t.to_tokens(tokens),
+                BinOp::Lt(ref t) => t.to_tokens(tokens),
+                BinOp::Le(ref t) => t.to_tokens(tokens),
+                BinOp::Ne(ref t) => t.to_tokens(tokens),
+                BinOp::Ge(ref t) => t.to_tokens(tokens),
+                BinOp::Gt(ref t) => t.to_tokens(tokens),
+                BinOp::AddEq(ref t) => t.to_tokens(tokens),
+                BinOp::SubEq(ref t) => t.to_tokens(tokens),
+                BinOp::MulEq(ref t) => t.to_tokens(tokens),
+                BinOp::DivEq(ref t) => t.to_tokens(tokens),
+                BinOp::RemEq(ref t) => t.to_tokens(tokens),
+                BinOp::BitXorEq(ref t) => t.to_tokens(tokens),
+                BinOp::BitAndEq(ref t) => t.to_tokens(tokens),
+                BinOp::BitOrEq(ref t) => t.to_tokens(tokens),
+                BinOp::ShlEq(ref t) => t.to_tokens(tokens),
+                BinOp::ShrEq(ref t) => t.to_tokens(tokens),
             }
         }
     }
 
     impl ToTokens for UnOp {
         fn to_tokens(&self, tokens: &mut Tokens) {
-            tokens.append(self.op());
+            match *self {
+                UnOp::Deref(ref t) => t.to_tokens(tokens),
+                UnOp::Not(ref t) => t.to_tokens(tokens),
+                UnOp::Neg(ref t) => t.to_tokens(tokens),
+            }
         }
     }
 }

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,0 +1,27 @@
+use std::hash::{Hash, Hasher};
+use std::fmt;
+
+use proc_macro2;
+
+#[derive(Clone, Copy, Default)]
+pub struct Span(pub proc_macro2::Span);
+
+impl PartialEq for Span {
+    fn eq(&self, _other: &Span) -> bool {
+        true
+    }
+}
+
+impl Eq for Span {}
+
+impl Hash for Span {
+    fn hash<H: Hasher>(&self, _hasher: &mut H) {
+    }
+}
+
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Span")
+         .finish()
+    }
+}

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,0 +1,205 @@
+use Span;
+
+macro_rules! tokens {
+    (
+        ops: {
+            $(($($op:tt)*),)*
+        }
+        delim: {
+            $(($($delim:tt)*),)*
+        }
+        syms: {
+            $(($($sym:tt)*),)*
+        }
+    ) => (
+        $(op! { $($op)* })*
+        $(delim! { $($delim)* })*
+        $(sym! { $($sym)* })*
+    )
+}
+
+macro_rules! op {
+    (pub struct $name:ident($($contents:tt)*) => $s:expr) => {
+        ast_struct! {
+            #[cfg_attr(feature = "clone-impls", derive(Copy))]
+            #[derive(Default)]
+            pub struct $name(pub $($contents)*);
+        }
+
+        #[cfg(feature = "printing")]
+        impl ::quote::ToTokens for $name {
+            fn to_tokens(&self, tokens: &mut ::quote::Tokens) {
+                printing::op($s, &self.0, tokens);
+            }
+        }
+    }
+}
+
+macro_rules! sym {
+    (pub struct $name:ident => $s:expr) => {
+        ast_struct! {
+            #[cfg_attr(feature = "clone-impls", derive(Copy))]
+            #[derive(Default)]
+            pub struct $name(pub Span);
+        }
+
+        #[cfg(feature = "printing")]
+        impl ::quote::ToTokens for $name {
+            fn to_tokens(&self, tokens: &mut ::quote::Tokens) {
+                printing::sym($s, &self.0, tokens);
+            }
+        }
+    }
+}
+
+macro_rules! delim {
+    (pub struct $name:ident => $s:expr) => {
+        ast_struct! {
+            #[cfg_attr(feature = "clone-impls", derive(Copy))]
+            #[derive(Default)]
+            pub struct $name(pub Span);
+        }
+
+        #[cfg(feature = "printing")]
+        impl $name {
+            pub fn surround<F>(&self,
+                               tokens: &mut ::quote::Tokens,
+                               f: F)
+                where F: FnOnce(&mut ::quote::Tokens)
+            {
+                printing::delim($s, &self.0, tokens, f);
+            }
+        }
+    }
+}
+
+tokens! {
+    ops: {
+        (pub struct Add([Span; 1])          => "+"),
+        (pub struct AddEq([Span; 2])        => "+="),
+        (pub struct And([Span; 1])          => "&"),
+        (pub struct AndAnd([Span; 2])       => "&&"),
+        (pub struct AndEq([Span; 2])        => "&="),
+        (pub struct At([Span; 1])           => "@"),
+        (pub struct Bang([Span; 1])         => "!"),
+        (pub struct Caret([Span; 1])        => "^"),
+        (pub struct CaretEq([Span; 2])      => "^="),
+        (pub struct Colon([Span; 1])        => ":"),
+        (pub struct Colon2([Span; 2])       => "::"),
+        (pub struct Comma([Span; 1])        => ","),
+        (pub struct Div([Span; 1])          => "/"),
+        (pub struct DivEq([Span; 2])        => "/="),
+        (pub struct Dot([Span; 1])          => "."),
+        (pub struct Dot2([Span; 2])         => ".."),
+        (pub struct Dot3([Span; 3])         => "..."),
+        (pub struct Eq([Span; 1])           => "="),
+        (pub struct EqEq([Span; 2])         => "=="),
+        (pub struct Ge([Span; 2])           => ">="),
+        (pub struct Gt([Span; 1])           => ">"),
+        (pub struct Le([Span; 2])           => "<="),
+        (pub struct Lt([Span; 1])           => "<"),
+        (pub struct MulEq([Span; 2])        => "*="),
+        (pub struct Ne([Span; 2])           => "!="),
+        (pub struct Or([Span; 1])           => "|"),
+        (pub struct OrEq([Span; 2])         => "|="),
+        (pub struct OrOr([Span; 2])         => "||"),
+        (pub struct Pound([Span; 1])        => "#"),
+        (pub struct Question([Span; 1])     => "?"),
+        (pub struct RArrow([Span; 2])       => "->"),
+        (pub struct Rem([Span; 1])          => "%"),
+        (pub struct RemEq([Span; 2])        => "%="),
+        (pub struct Rocket([Span; 2])       => "=>"),
+        (pub struct Semi([Span; 1])         => ";"),
+        (pub struct Shl([Span; 2])          => "<<"),
+        (pub struct ShlEq([Span; 3])        => "<<="),
+        (pub struct Shr([Span; 2])          => ">>"),
+        (pub struct ShrEq([Span; 3])        => ">>="),
+        (pub struct Star([Span; 1])         => "*"),
+        (pub struct Sub([Span; 1])          => "-"),
+        (pub struct SubEq([Span; 2])        => "-="),
+        (pub struct Underscore([Span; 1])   => "_"),
+    }
+    delim: {
+        (pub struct Brace                   => "{"),
+        (pub struct Bracket                 => "["),
+        (pub struct Paren                   => "("),
+    }
+    syms: {
+        (pub struct As                      => "as"),
+        (pub struct Box                     => "box"),
+        (pub struct Break                   => "break"),
+        (pub struct Catch                   => "catch"),
+        (pub struct Const                   => "const"),
+        (pub struct Continue                => "continue"),
+        (pub struct Crate                   => "crate"),
+        (pub struct Default                 => "default"),
+        (pub struct Do                      => "do"),
+        (pub struct Else                    => "else"),
+        (pub struct Enum                    => "enum"),
+        (pub struct Extern                  => "extern"),
+        (pub struct Fn                      => "fn"),
+        (pub struct For                     => "for"),
+        (pub struct If                      => "if"),
+        (pub struct Impl                    => "impl"),
+        (pub struct In                      => "in"),
+        (pub struct Let                     => "let"),
+        (pub struct Loop                    => "loop"),
+        (pub struct Match                   => "match"),
+        (pub struct Mod                     => "mod"),
+        (pub struct Move                    => "move"),
+        (pub struct Mut                     => "mut"),
+        (pub struct Pub                     => "pub"),
+        (pub struct Ref                     => "ref"),
+        (pub struct Return                  => "return"),
+        (pub struct Self_                   => "self"),
+        (pub struct Static                  => "static"),
+        (pub struct Struct                  => "struct"),
+        (pub struct Trait                   => "trait"),
+        (pub struct Type                    => "type"),
+        (pub struct Union                   => "union"),
+        (pub struct Unsafe                  => "unsafe"),
+        (pub struct Use                     => "use"),
+        (pub struct Where                   => "where"),
+        (pub struct While                   => "while"),
+    }
+}
+
+#[cfg(feature = "printing")]
+mod printing {
+    use Span;
+    use proc_macro2::{TokenTree, TokenKind, OpKind};
+    use quote::Tokens;
+
+    pub fn op(s: &str, spans: &[Span], tokens: &mut Tokens) {
+        assert_eq!(s.len(), spans.len());
+
+        let mut chars = s.chars();
+        let mut spans = spans.iter();
+        let ch = chars.next_back().unwrap();
+        let span = spans.next_back().unwrap();
+        for (ch, span) in chars.zip(spans) {
+            tokens.append(TokenTree {
+                span: span.0,
+                kind: TokenKind::Op(ch, OpKind::Joint),
+            });
+        }
+
+        tokens.append(TokenTree {
+            span: span.0,
+            kind: TokenKind::Op(ch, OpKind::Alone),
+        });
+    }
+
+    pub fn sym(s: &str, span: &Span, tokens: &mut Tokens) {
+        tokens.append(TokenTree {
+            span: span.0,
+            kind: TokenKind::Word(s.into()),
+        });
+    }
+
+    pub fn delim<F>(s: &str, span: &Span, tokens: &mut Tokens, f: F)
+        where F: FnOnce(&mut Tokens)
+    {
+        tokens.append_delimited(s, span.0, f)
+    }
+}

--- a/synom/Cargo.toml
+++ b/synom/Cargo.toml
@@ -13,6 +13,19 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-
 [dependencies]
 unicode-xid = "0.0.4"
 
+[dependencies.quote]
+git = 'https://github.com/alexcrichton/quote'
+branch = 'new-tokens'
+optional = true
+
+[features]
+printing = ["quote"]
+parsing = []
+default = ["parsing"]
+
+[dev-dependencies]
+proc-macro2 = { git = 'https://github.com/alexcrichton/proc-macro2' }
+
 [dev-dependencies.syn]
 version = "0.11"
 path = ".."

--- a/synom/src/delimited.rs
+++ b/synom/src/delimited.rs
@@ -1,0 +1,253 @@
+use std::iter::FromIterator;
+use std::slice;
+use std::vec;
+
+#[derive(Eq, PartialEq, Hash, Debug, Clone)]
+pub struct Delimited<T, D> {
+    inner: Vec<(T, Option<D>)>
+}
+
+impl<T, D> Delimited<T, D> {
+    pub fn new() -> Delimited<T, D> {
+        Delimited {
+            inner: Vec::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn get(&self, idx: usize) -> Element<&T, &D> {
+        let (ref t, ref d) = self.inner[idx];
+        match *d {
+            Some(ref d) => Element::Delimited(t, d),
+            None => Element::End(t),
+        }
+    }
+
+    pub fn get_mut(&mut self, idx: usize) -> Element<&mut T, &mut D> {
+        let (ref mut t, ref mut d) = self.inner[idx];
+        match *d {
+            Some(ref mut d) => Element::Delimited(t, d),
+            None => Element::End(t),
+        }
+    }
+
+    pub fn iter(&self) -> Iter<T, D> {
+        Iter { inner: self.inner.iter() }
+    }
+
+    pub fn into_iter(self) -> IntoIter<T, D> {
+        IntoIter { inner: self.inner.into_iter() }
+    }
+
+    pub fn items(&self) -> Items<T, D> {
+        Items { inner: self.inner.iter() }
+    }
+
+    pub fn push(&mut self, token: Element<T, D>) {
+        assert!(self.len() == 0 || self.trailing_delim());
+        match token {
+            Element::Delimited(t, d) => self.inner.push((t, Some(d))),
+            Element::End(t) => self.inner.push((t, None)),
+        }
+    }
+
+    pub fn push_first(&mut self, token: T) {
+        assert!(self.is_empty());
+        self.inner.push((token, None));
+    }
+
+    pub fn push_next(&mut self, token: T, delimiter: D) {
+        self.push_trailing(delimiter);
+        self.inner.push((token, None));
+    }
+
+    pub fn push_trailing(&mut self, delimiter: D) {
+        let len = self.len();
+        assert!(self.inner[len - 1].1.is_none());
+        self.inner[len - 1].1 = Some(delimiter);
+    }
+
+    pub fn push_default(&mut self, token: T) where D: Default {
+        if self.len() == 0 {
+            self.inner.push((token, None));
+        } else {
+            self.push_next(token, D::default());
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<Element<T, D>> {
+        self.inner.pop().map(|e| {
+            match e {
+                (t, Some(d)) => Element::Delimited(t, d),
+                (t, None) => Element::End(t),
+            }
+        })
+    }
+
+    pub fn into_vec(self) -> Vec<T> {
+        self.inner.into_iter().map(|t| t.0).collect()
+    }
+
+    pub fn trailing_delim(&self) -> bool {
+        self.inner[self.inner.len() - 1].1.is_some()
+    }
+}
+
+impl<T, D> From<Vec<(T, Option<D>)>> for Delimited<T, D> {
+    fn from(v: Vec<(T, Option<D>)>) -> Self {
+        Delimited {
+            inner: v,
+        }
+    }
+}
+
+impl<T, D> From<Vec<T>> for Delimited<T, D>
+    where D: Default,
+{
+    fn from(v: Vec<T>) -> Self {
+        let last = v.len() - 1;
+        Delimited {
+            inner: v.into_iter().enumerate().map(|(i, item)| {
+                (item, if i == last {None} else {Some(D::default())})
+            }).collect(),
+        }
+    }
+}
+
+impl<T, D> FromIterator<Element<T, D>> for Delimited<T, D> {
+    fn from_iter<I: IntoIterator<Item = Element<T, D>>>(i: I) -> Self {
+        let mut ret = Delimited::new();
+        for element in i {
+            match element {
+                Element::Delimited(a, b) => ret.inner.push((a, Some(b))),
+                Element::End(a) => ret.inner.push((a, None)),
+            }
+        }
+        return ret
+    }
+}
+
+impl<T, D> Default for Delimited<T, D> {
+    fn default() -> Self {
+        Delimited::new()
+    }
+}
+
+pub struct Iter<'a, T: 'a, D: 'a> {
+    inner: slice::Iter<'a, (T, Option<D>)>,
+}
+
+impl<'a, T, D> Iterator for Iter<'a, T, D> {
+    type Item = Element<&'a T, &'a D>;
+
+    fn next(&mut self) -> Option<Element<&'a T, &'a D>> {
+        self.inner.next().map(|pair| {
+            match pair.1 {
+                Some(ref delimited) => Element::Delimited(&pair.0, delimited),
+                None => Element::End(&pair.0),
+            }
+        })
+    }
+}
+
+pub struct Items<'a, T: 'a, D: 'a> {
+    inner: slice::Iter<'a, (T, Option<D>)>,
+}
+
+impl<'a, T, D> Iterator for Items<'a, T, D> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<&'a T> {
+        self.inner.next().map(|pair| &pair.0)
+    }
+}
+
+pub struct IntoIter<T, D> {
+    inner: vec::IntoIter<(T, Option<D>)>,
+}
+
+impl<T, D> Iterator for IntoIter<T, D> {
+    type Item = Element<T, D>;
+
+    fn next(&mut self) -> Option<Element<T, D>> {
+        self.inner.next().map(|pair| {
+            match pair.1 {
+                Some(v) => Element::Delimited(pair.0, v),
+                None => Element::End(pair.0)
+            }
+        })
+    }
+}
+
+pub enum Element<T, D> {
+    Delimited(T, D),
+    End(T),
+}
+
+impl<T, D> Element<T, D> {
+    pub fn into_item(self) -> T {
+        match self {
+            Element::Delimited(t, _) |
+            Element::End(t) => t,
+        }
+    }
+
+    pub fn item(&self) -> &T {
+        match *self {
+            Element::Delimited(ref t, _) |
+            Element::End(ref t) => t,
+        }
+    }
+
+    pub fn item_mut(&mut self) -> &mut T {
+        match *self {
+            Element::Delimited(ref mut t, _) |
+            Element::End(ref mut t) => t,
+        }
+    }
+
+    pub fn delimiter(&self) -> Option<&D> {
+        match *self {
+            Element::Delimited(_, ref d) => Some(d),
+            Element::End(_) => None,
+        }
+    }
+}
+
+#[cfg(feature = "printing")]
+mod printing {
+    use super::*;
+    use quote::{Tokens, ToTokens};
+
+
+    impl<T, D> ToTokens for Delimited<T, D>
+        where T: ToTokens,
+              D: ToTokens,
+    {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            tokens.append_all(self.iter())
+        }
+    }
+
+    impl<T, D> ToTokens for Element<T, D>
+        where T: ToTokens,
+              D: ToTokens,
+    {
+        fn to_tokens(&self, tokens: &mut Tokens) {
+            match *self {
+                Element::Delimited(ref a, ref b) => {
+                    a.to_tokens(tokens);
+                    b.to_tokens(tokens);
+                }
+                Element::End(ref a) => a.to_tokens(tokens),
+            }
+        }
+    }
+}

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "extra-traits")]
+
 extern crate syn;
 use syn::*;
 
@@ -98,7 +100,7 @@ fn test_catch_expr() {
         });
 
         assert_let!(Stmt::Local(ref local) = block.stmts[2]; {
-            assert_let!(Pat::Ident(BindingMode::ByValue(Mutability::Mutable), ref ident, None) = *local.pat; {
+            assert_let!(Pat::Ident(PatIdent { mode: BindingMode::ByValue(Mutability::Mutable(_)), ref ident, .. }) = *local.pat; {
                 assert_eq!(ident, "catch");
             });
         });
@@ -111,8 +113,8 @@ fn test_catch_expr() {
             });
         });
 
-        assert_let!(Stmt::Semi(ref expr) = block.stmts[5]; {
-            assert_let!(Expr { node: ExprKind::Assign(ExprAssign { ref left, ref right }), .. } = **expr; {
+        assert_let!(Stmt::Semi(ref expr, _) = block.stmts[5]; {
+            assert_let!(Expr { node: ExprKind::Assign(ExprAssign { ref left, ref right, .. }), .. } = **expr; {
                 assert_let!(Expr { node: ExprKind::Path(ExprPath { qself: None, ref path }), .. } = **left; {
                     assert_eq!(*path, "catch".into());
                 });
@@ -125,7 +127,7 @@ fn test_catch_expr() {
             });
         });
 
-        assert_let!(Stmt::Semi(ref expr) = block.stmts[7]; {
+        assert_let!(Stmt::Semi(ref expr, _) = block.stmts[7]; {
             assert_let!(Expr { node: ExprKind::Match(ExprMatch { ref expr, .. }), .. } = **expr; {
                 assert_let!(Expr { node: ExprKind::Path(ExprPath { qself: None, ref path }), .. } = **expr; {
                     assert_eq!(*path, "catch".into());

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -1,7 +1,17 @@
 #![cfg(feature = "extra-traits")]
 
 extern crate syn;
+extern crate proc_macro2;
+
 use syn::*;
+use proc_macro2::Literal;
+
+fn lit<T: Into<Literal>>(t: T) -> Lit {
+    Lit {
+        value: LitKind::Other(t.into()),
+        span: Default::default(),
+    }
+}
 
 #[test]
 fn test_meta_item_word() {
@@ -12,7 +22,8 @@ fn test_meta_item_word() {
 fn test_meta_item_name_value() {
     run_test("#[foo = 5]", MetaNameValue {
         ident: "foo".into(),
-        lit: Lit::Int(5, IntTy::Unsuffixed),
+        eq_token: Default::default(),
+        lit: lit(Literal::integer("5")),
     })
 }
 
@@ -20,9 +31,10 @@ fn test_meta_item_name_value() {
 fn test_meta_item_list_lit() {
     run_test("#[foo(5)]", MetaItemList {
         ident: "foo".into(),
+        paren_token: Default::default(),
         nested: vec![
-            NestedMetaItem::Literal(Lit::Int(5, IntTy::Unsuffixed)),
-        ],
+            NestedMetaItem::Literal(lit(Literal::integer("5"))),
+        ].into(),
     })
 }
 
@@ -30,9 +42,10 @@ fn test_meta_item_list_lit() {
 fn test_meta_item_list_word() {
     run_test("#[foo(bar)]", MetaItemList {
         ident: "foo".into(),
+        paren_token: Default::default(),
         nested: vec![
             NestedMetaItem::MetaItem(MetaItem::Word("bar".into())),
-        ],
+        ].into(),
     })
 }
 
@@ -40,12 +53,14 @@ fn test_meta_item_list_word() {
 fn test_meta_item_list_name_value() {
     run_test("#[foo(bar = 5)]", MetaItemList {
         ident: "foo".into(),
+        paren_token: Default::default(),
         nested: vec![
             NestedMetaItem::MetaItem(MetaNameValue {
                 ident: "bar".into(),
-                lit: Lit::Int(5, IntTy::Unsuffixed),
+                eq_token: Default::default(),
+                lit: lit(Literal::integer("5"))
             }.into()),
-        ],
+        ].into(),
     })
 }
 
@@ -53,23 +68,27 @@ fn test_meta_item_list_name_value() {
 fn test_meta_item_multiple() {
     run_test("#[foo(word, name = 5, list(name2 = 6), word2)]", MetaItemList {
         ident: "foo".into(),
+        paren_token: Default::default(),
         nested: vec![
             NestedMetaItem::MetaItem(MetaItem::Word("word".into())),
             NestedMetaItem::MetaItem(MetaNameValue {
                 ident: "name".into(),
-                lit: Lit::Int(5, IntTy::Unsuffixed),
+                eq_token: Default::default(),
+                lit: lit(Literal::integer("5")),
             }.into()),
             NestedMetaItem::MetaItem(MetaItemList {
                 ident: "list".into(),
+                paren_token: Default::default(),
                 nested: vec![
                     NestedMetaItem::MetaItem(MetaNameValue {
                         ident: "name2".into(),
-                        lit: Lit::Int(6, IntTy::Unsuffixed),
+                        eq_token: Default::default(),
+                        lit: lit(Literal::integer("6")),
                     }.into())
-                ],
+                ].into(),
             }.into()),
             NestedMetaItem::MetaItem(MetaItem::Word("word2".into())),
-        ],
+        ].into(),
     })
 }
 


### PR DESCRIPTION
This ended up being a bit larger of a commit than I intended! I imagine that
this'll be one of the larger of the commits working towards #142. The purpose of
this commit is to use an updated version of the `quote` crate which doesn't work
with strings but rather works with tokens form the `proc-macro2` crate. The
`proc-macro2` crate itself is based on the proposed API for `proc_macro` itself,
and will continue to mirror it. The hope is that we'll flip an easy switch
eventually to use compiler tokens, whereas for now we'll stick to string parsing
at the lowest layer.

The largest change here is the addition of span information to the AST. Building
on the previous PRs to refactor the AST this makes it relatively easy from a
user perspective to digest and use the AST still, it's just a few extra fields
on the side. The fallout from this was then quite large throughout the
`printing` feature of the crate. The `parsing`, `fold`, and `visit` features
then followed suit to get updated as well.

This commit also changes the the semantics of the AST somewhat as well.
Previously it was inferred what tokens should be printed, for example if you
have a closure argument `syn` would automatically not print the colon in `a: b`
if the type listed was "infer this type". Now the colon is a separate field and
must be in sync with the type listed as the colon/type will be printed
unconditionally (emitting no output if both are `None`).