### PR TITLE
Use nom macro to declare parse method inside Synom trait

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -16,18 +16,15 @@ pub mod parsing {
     use proc_macro2::TokenTree;
 
     impl Synom for Crate {
-        fn parse(input: &[TokenTree]) -> IResult<&[TokenTree], Self> {
-            do_parse! {
-                input,
-                attrs: many0!(call!(Attribute::parse_inner)) >>
-                items: many0!(syn!(Item)) >>
-                (Crate {
-                    shebang: None,
-                    attrs: attrs,
-                    items: items,
-                })
-            }
-        }
+        named!(parse -> Self, do_parse!(
+            attrs: many0!(call!(Attribute::parse_inner)) >>
+            items: many0!(syn!(Item)) >>
+            (Crate {
+                shebang: None,
+                attrs: attrs,
+                items: items,
+            })
+        ));
 
         fn description() -> Option<&'static str> {
             Some("crate")


### PR DESCRIPTION
In the `do_parse!(input, ...)` way of invoking nom-style macros, the "input" argument seems like a nom implementation detail that users aren't supposed to need to write.