### PR TITLE
Switch from `IResult<I, O>` to `Result<(I, O), E>`

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -12,8 +12,7 @@ ast_struct! {
 pub mod parsing {
     use super::*;
 
-    use synom::{IResult, Synom, ParseError};
-    use proc_macro2::TokenTree;
+    use synom::{Synom, ParseError};
 
     impl Synom for Crate {
         named!(parse -> Self, do_parse!(

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -101,26 +101,25 @@ impl Hash for LitKind {
 #[cfg(feature = "parsing")]
 pub mod parsing {
     use super::*;
-    use proc_macro2::TokenTree;
-    use synom::{Synom, IResult};
+    use synom::{Synom, PResult, Cursor, parse_error};
 
     impl Synom for Lit {
-        fn parse(input: &[TokenTree]) -> IResult<&[TokenTree], Self> {
+        fn parse(input: Cursor) -> PResult<Self> {
             let mut tokens = input.iter();
             let token = match tokens.next() {
                 Some(token) => token,
-                None => return IResult::Error,
+                None => return parse_error(),
             };
             let kind = match token.kind {
                 TokenKind::Literal(ref l) => LitKind::Other(l.clone()),
                 TokenKind::Word(ref s) if s.as_str() == "true" => LitKind::Bool(true),
                 TokenKind::Word(ref s) if s.as_str() == "false" => LitKind::Bool(false),
-                _ => return IResult::Error,
+                _ => return parse_error(),
             };
-            IResult::Done(tokens.as_slice(), Lit {
+            Ok((tokens.as_slice(), Lit {
                 span: Span(token.span),
                 value: kind,
-            })
+            }))
         }
     }
 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -77,89 +77,80 @@ ast_enum! {
 #[cfg(feature = "parsing")]
 pub mod parsing {
     use super::*;
-    use synom::{TokenTree, IResult, Synom};
+    use synom::Synom;
     use synom::tokens::*;
 
     impl BinOp {
-        pub fn parse_binop(input: &[TokenTree]) -> IResult<&[TokenTree], Self> {
-            alt! {
-                input,
-                syn!(AndAnd) => { BinOp::And }
-                |
-                syn!(OrOr) => { BinOp::Or }
-                |
-                syn!(Shl) => { BinOp::Shl }
-                |
-                syn!(Shr) => { BinOp::Shr }
-                |
-                syn!(EqEq) => { BinOp::Eq }
-                |
-                syn!(Le) => { BinOp::Le }
-                |
-                syn!(Ne) => { BinOp::Ne }
-                |
-                syn!(Ge) => { BinOp::Ge }
-                |
-                syn!(Add) => { BinOp::Add }
-                |
-                syn!(Sub) => { BinOp::Sub }
-                |
-                syn!(Star) => { BinOp::Mul }
-                |
-                syn!(Div) => { BinOp::Div }
-                |
-                syn!(Rem) => { BinOp::Rem }
-                |
-                syn!(Caret) => { BinOp::BitXor }
-                |
-                syn!(And) => { BinOp::BitAnd }
-                |
-                syn!(Or) => { BinOp::BitOr }
-                |
-                syn!(Lt) => { BinOp::Lt }
-                |
-                syn!(Gt) => { BinOp::Gt }
-            }
-        }
+        named!(pub parse_binop -> Self, alt!(
+            syn!(AndAnd) => { BinOp::And }
+            |
+            syn!(OrOr) => { BinOp::Or }
+            |
+            syn!(Shl) => { BinOp::Shl }
+            |
+            syn!(Shr) => { BinOp::Shr }
+            |
+            syn!(EqEq) => { BinOp::Eq }
+            |
+            syn!(Le) => { BinOp::Le }
+            |
+            syn!(Ne) => { BinOp::Ne }
+            |
+            syn!(Ge) => { BinOp::Ge }
+            |
+            syn!(Add) => { BinOp::Add }
+            |
+            syn!(Sub) => { BinOp::Sub }
+            |
+            syn!(Star) => { BinOp::Mul }
+            |
+            syn!(Div) => { BinOp::Div }
+            |
+            syn!(Rem) => { BinOp::Rem }
+            |
+            syn!(Caret) => { BinOp::BitXor }
+            |
+            syn!(And) => { BinOp::BitAnd }
+            |
+            syn!(Or) => { BinOp::BitOr }
+            |
+            syn!(Lt) => { BinOp::Lt }
+            |
+            syn!(Gt) => { BinOp::Gt }
+        ));
 
         #[cfg(feature = "full")]
-        pub fn parse_assign_op(input: &[TokenTree]) -> IResult<&[TokenTree], Self> {
-            alt! {
-                input,
-                syn!(AddEq) => { BinOp::AddEq }
-                |
-                syn!(SubEq) => { BinOp::SubEq }
-                |
-                syn!(MulEq) => { BinOp::MulEq }
-                |
-                syn!(DivEq) => { BinOp::DivEq }
-                |
-                syn!(RemEq) => { BinOp::RemEq }
-                |
-                syn!(CaretEq) => { BinOp::BitXorEq }
-                |
-                syn!(AndEq) => { BinOp::BitAndEq }
-                |
-                syn!(OrEq) => { BinOp::BitOrEq }
-                |
-                syn!(ShlEq) => { BinOp::ShlEq }
-                |
-                syn!(ShrEq) => { BinOp::ShrEq }
-            }
-        }
+        named!(pub parse_assign_op -> Self, alt!(
+            syn!(AddEq) => { BinOp::AddEq }
+            |
+            syn!(SubEq) => { BinOp::SubEq }
+            |
+            syn!(MulEq) => { BinOp::MulEq }
+            |
+            syn!(DivEq) => { BinOp::DivEq }
+            |
+            syn!(RemEq) => { BinOp::RemEq }
+            |
+            syn!(CaretEq) => { BinOp::BitXorEq }
+            |
+            syn!(AndEq) => { BinOp::BitAndEq }
+            |
+            syn!(OrEq) => { BinOp::BitOrEq }
+            |
+            syn!(ShlEq) => { BinOp::ShlEq }
+            |
+            syn!(ShrEq) => { BinOp::ShrEq }
+        ));
     }
 
     impl Synom for UnOp {
-        fn parse(input: &[TokenTree]) -> IResult<&[TokenTree], Self> {
-            alt! {
-                input,
-                syn!(Star) => { UnOp::Deref }
-                |
-                syn!(Bang) => { UnOp::Not }
-                |
-                syn!(Sub) => { UnOp::Neg }
-            }
-        }
+        named!(parse -> Self, alt!(
+            syn!(Star) => { UnOp::Deref }
+            |
+            syn!(Bang) => { UnOp::Not }
+            |
+            syn!(Sub) => { UnOp::Neg }
+        ));
     }
 }
 

--- a/synom/src/helper.rs
+++ b/synom/src/helper.rs
@@ -17,8 +17,10 @@
 macro_rules! option {
     ($i:expr, $submac:ident!( $($args:tt)* )) => {
         match $submac!($i, $($args)*) {
-            $crate::IResult::Done(i, o) => $crate::IResult::Done(i, Some(o)),
-            $crate::IResult::Error => $crate::IResult::Done($i, None),
+            ::std::result::Result::Ok((i, o)) =>
+                ::std::result::Result::Ok((i, Some(o))),
+            ::std::result::Result::Err(_) =>
+                ::std::result::Result::Ok(($i, None)),
         }
     };
 
@@ -61,8 +63,10 @@ macro_rules! option {
 macro_rules! opt_vec {
     ($i:expr, $submac:ident!( $($args:tt)* )) => {
         match $submac!($i, $($args)*) {
-            $crate::IResult::Done(i, o) => $crate::IResult::Done(i, o),
-            $crate::IResult::Error => $crate::IResult::Done($i, Vec::new()),
+            ::std::result::Result::Ok((i, o)) =>
+                ::std::result::Result::Ok((i, o)),
+            ::std::result::Result::Err(_) =>
+                ::std::result::Result::Ok(($i, Vec::new()))
         }
     };
 }
@@ -91,7 +95,7 @@ macro_rules! opt_vec {
 #[macro_export]
 macro_rules! epsilon {
     ($i:expr,) => {
-        $crate::IResult::Done($i, ())
+        ::std::result::Result::Ok(($i, ()))
     };
 }
 
@@ -132,12 +136,13 @@ macro_rules! epsilon {
 macro_rules! tap {
     ($i:expr, $name:ident : $submac:ident!( $($args:tt)* ) => $e:expr) => {
         match $submac!($i, $($args)*) {
-            $crate::IResult::Done(i, o) => {
+            ::std::result::Result::Ok((i, o)) => {
                 let $name = o;
                 $e;
-                $crate::IResult::Done(i, ())
+                ::std::result::Result::Ok((i, ()))
             }
-            $crate::IResult::Error => $crate::IResult::Error,
+            ::std::result::Result::Err(err) =>
+                ::std::result::Result::Err(err),
         }
     };
 

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -6,7 +6,6 @@ extern crate proc_macro2;
 
 use proc_macro2::{Literal, TokenStream};
 use syn::*;
-use synom::IResult;
 
 fn lit<T: Into<Literal>>(t: T) -> Lit {
     Lit {
@@ -98,11 +97,11 @@ fn run_test<T: Into<MetaItem>>(input: &str, expected: T) {
     let tokens = input.parse::<TokenStream>().unwrap();
     let tokens = tokens.into_iter().collect::<Vec<_>>();
     let attr = match Attribute::parse_outer(&tokens) {
-        IResult::Done(rest, e) => {
+        Ok((rest, e)) => {
             assert!(rest.is_empty());
             e
         }
-        IResult::Error => panic!("failed to parse"),
+        Err(_) => panic!("failed to parse"),
     };
     assert_eq!(expected.into(), attr.meta_item().unwrap());
 }


### PR DESCRIPTION
Fixes #150, #151 

The bulk of this patch is actually #150, as I needed to rewrite every `parse` signature to use the new types, and it was easy enough to just convert them into invocations of `named!` every time.

I also introduced a `Cursor` type alias in `synom` which I use instead of `&[TokenTree]` as the parser input type. I intend in #148 to change the `Cursor` type to be something other than `&[TokenTree]` so this will make my life easier in the future.

I use the type alias of `PResult<'a, O>` to refer to parser results (of the form written above).