### PR TITLE
Enable round-trip tests for 128-bit integers

### DIFF
--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -60,16 +60,12 @@ fn filter(entry: &DirEntry) -> bool {
         "tests/rust/src/libcollections/tests/vec.rs" |
         // TODO placement syntax
         "tests/rust/src/libcollections/tests/vec_deque.rs" |
-        // TODO 128-bit integer literals
-        "tests/rust/src/libcompiler_builtins/lib.rs" |
         // TODO better support for attributes
         "tests/rust/src/librustc_data_structures/blake2b.rs" |
         // TODO placement syntax
         "tests/rust/src/librustc_mir/build/matches/test.rs" |
         // TODO placement syntax
         "tests/rust/src/libstd/collections/hash/map.rs" |
-        // TODO 128-bit integer literals
-        "tests/rust/src/libstd/net/ip.rs" |
         // TODO better support for attributes
         "tests/rust/src/test/incremental/hashes/enum_defs.rs" |
         // TODO better support for attributes
@@ -78,22 +74,14 @@ fn filter(entry: &DirEntry) -> bool {
         "tests/rust/src/test/run-pass/auxiliary/macro-include-items-expr.rs" |
         // TODO better support for attributes
         "tests/rust/src/test/run-pass/cfg_stmt_expr.rs" |
-        // TODO 128-bit integer literals
-        "tests/rust/src/test/run-pass/i128.rs" |
-        // TODO 128-bit integer literals
-        "tests/rust/src/test/run-pass/i128-ffi.rs" |
         // TODO weird glob import
         "tests/rust/src/test/run-pass/import-glob-crate.rs" |
         // TODO better support for attributes
         "tests/rust/src/test/run-pass/inner-attrs-on-impl.rs" |
-        // TODO 128-bit integer literals
-        "tests/rust/src/test/run-pass/issue-38987.rs" |
         // TODO better support for attributes
         "tests/rust/src/test/run-pass/item-attributes.rs" |
         // TODO precedence issue with binop vs poly trait ref
-        "tests/rust/src/test/run-pass/try-macro.rs" |
-        // TODO 128-bit integer literals
-        "tests/rust/src/test/run-pass/u128.rs" => false,
+        "tests/rust/src/test/run-pass/try-macro.rs" => false,
         _ => true,
     }
 }


### PR DESCRIPTION
We support parsing these now due to
https://github.com/alexcrichton/proc-macro2/issues/6 and
https://github.com/alexcrichton/proc-macro2/pull/8.

This fixes #114