### PR TITLE
Add a test to ensure that we round-trip literals faithfully

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ mod parsing {
         Ident,
         WhereClause,
         Ty,
+        Lit,
     }
 
     #[cfg(feature = "full")]

--- a/tests/test_token_trees.rs
+++ b/tests/test_token_trees.rs
@@ -1,9 +1,11 @@
 #![cfg(feature = "extra-traits")]
 
+#[macro_use]
+extern crate quote;
 extern crate syn;
 extern crate proc_macro2;
 
-use syn::TokenTree;
+use syn::{Lit, TokenTree};
 use proc_macro2::{TokenKind, OpKind, Delimiter, TokenStream};
 use proc_macro2::Delimiter::*;
 
@@ -83,4 +85,11 @@ fn test_struct() {
     if result != expected {
         panic!("{:#?}\n!=\n{:#?}", result, expected);
     }
+}
+
+#[test]
+fn test_literal_mangling() {
+    let raw = "0_4";
+    let parsed = raw.parse::<Lit>().unwrap();
+    assert_eq!(raw, quote!(#parsed).to_string());
 }


### PR DESCRIPTION
#125 was fixed by the TokenStream changes, and this adds a test to make sure that doesn't change.