### PR TITLE
Handle precedence when parsing expressions

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -29,7 +29,7 @@ ast_enum_of_structs! {
             pub box_token: tokens::Box_,
         }),
 
-        /// E.g. 'place <- val'.
+        /// E.g. 'place <- val' or `in place { val }`.
         pub InPlace(ExprInPlace {
             pub place: Box<Expr>,
             pub value: Box<Expr>,
@@ -593,20 +593,31 @@ pub mod parsing {
     use synom::{PResult, Cursor, Synom, parse_error};
     use synom::tokens::*;
 
-    // Struct literals are ambiguous in certain positions
-    // https://github.com/rust-lang/rfcs/pull/92
-    macro_rules! named_ambiguous_expr {
-        ($name:ident -> $o:ty, $allow_struct:ident, $submac:ident!( $($args:tt)* )) => {
-            fn $name(i: $crate::synom::Cursor, $allow_struct: bool)
-                     -> $crate::synom::PResult<$o> {
-                $submac!(i, $($args)*)
-            }
-        };
-    }
-
+    /// When we're parsing expressions which occur before blocks, like in
+    /// an if statement's condition, we cannot parse a struct literal.
+    ///
+    /// Struct literals are ambiguous in certain positions
+    /// https://github.com/rust-lang/rfcs/pull/92
     macro_rules! ambiguous_expr {
         ($i:expr, $allow_struct:ident) => {
             ambiguous_expr($i, $allow_struct, true)
+        };
+    }
+
+    /// When we are parsing an optional suffix expression, we cannot allow
+    /// blocks if structs are not allowed.
+    ///
+    /// Example:
+    /// ```ignore
+    /// if break { } { }
+    /// // is ambiguous between:
+    /// if (break { }) { }
+    /// // - or -
+    /// if (break) { } { }
+    /// ```
+    macro_rules! opt_ambiguous_expr {
+        ($i:expr, $allow_struct:ident) => {
+            option!($i, call!(ambiguous_expr, $allow_struct, $allow_struct))
         };
     }
 
@@ -621,174 +632,448 @@ pub mod parsing {
 
     named!(expr_no_struct -> Expr, ambiguous_expr!(false));
 
-    #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
-    fn ambiguous_expr(i: Cursor,
-                      allow_struct: bool,
-                      allow_block: bool)
-                      -> PResult<Expr> {
-        do_parse! {
+    /// Parse an arbitrary expression.
+    pub fn ambiguous_expr(i: Cursor,
+                          allow_struct: bool,
+                          allow_block: bool)
+                          -> PResult<Expr> {
+        map!(
             i,
-            mut e: alt!(
-                syn!(Lit) => { ExprKind::Lit } // must be before expr_struct
-                |
-                // must be before expr_path
-                cond_reduce!(allow_struct, map!(syn!(ExprStruct), ExprKind::Struct))
-                |
-                syn!(ExprParen) => { ExprKind::Paren } // must be before expr_tup
-                |
-                syn!(Mac) => { ExprKind::Mac } // must be before expr_path
-                |
-                call!(expr_break, allow_struct) // must be before expr_path
-                |
-                syn!(ExprContinue) => { ExprKind::Continue } // must be before expr_path
-                |
-                call!(expr_ret, allow_struct) // must be before expr_path
-                |
-                call!(expr_box, allow_struct)
-                |
-                syn!(ExprInPlace) => { ExprKind::InPlace }
-                |
-                syn!(ExprArray) => { ExprKind::Array }
-                |
-                syn!(ExprTup) => { ExprKind::Tup }
-                |
-                call!(expr_unary, allow_struct)
-                |
-                syn!(ExprIf) => { ExprKind::If }
-                |
-                syn!(ExprIfLet) => { ExprKind::IfLet }
-                |
-                syn!(ExprWhile) => { ExprKind::While }
-                |
-                syn!(ExprWhileLet) => { ExprKind::WhileLet }
-                |
-                syn!(ExprForLoop) => { ExprKind::ForLoop }
-                |
-                syn!(ExprLoop) => { ExprKind::Loop }
-                |
-                syn!(ExprMatch) => { ExprKind::Match }
-                |
-                syn!(ExprCatch) => { ExprKind::Catch }
-                |
-                call!(expr_closure, allow_struct)
-                |
-                cond_reduce!(allow_block, map!(syn!(ExprBlock), ExprKind::Block))
-                |
-                call!(expr_range, allow_struct)
-                |
-                syn!(ExprPath) => { ExprKind::Path }
-                |
-                call!(expr_addr_of, allow_struct)
-                |
-                syn!(ExprRepeat) => { ExprKind::Repeat }
-            ) >>
-            many0!(alt!(
-                tap!(args: and_call => {
-                    let (args, paren) = args;
-                    e = ExprCall {
-                        func: Box::new(e.into()),
-                        args: args,
-                        paren_token: paren,
-                    }.into();
-                })
-                |
-                tap!(more: and_method_call => {
-                    let mut call = more;
-                    call.expr = Box::new(e.into());
-                    e = call.into();
-                })
-                |
-                tap!(more: call!(and_binary, allow_struct) => {
-                    let (op, other) = more;
-                    e = ExprBinary {
-                        op: op,
-                        left: Box::new(e.into()),
-                        right: Box::new(other),
-                    }.into();
-                })
-                |
-                tap!(ty: and_cast => {
-                    let (ty, token) = ty;
-                    e = ExprCast {
-                        expr: Box::new(e.into()),
-                        ty: Box::new(ty),
-                        as_token: token,
-                    }.into();
-                })
-                |
-                tap!(ty: and_ascription => {
-                    let (ty, token) = ty;
-                    e = ExprType {
-                        expr: Box::new(e.into()),
-                        ty: Box::new(ty),
-                        colon_token: token,
-                    }.into();
-                })
-                |
-                tap!(v: call!(and_assign, allow_struct) => {
-                    let (v, token) = v;
-                    e = ExprAssign {
-                        left: Box::new(e.into()),
-                        eq_token: token,
-                        right: Box::new(v),
-                    }.into();
-                })
-                |
-                tap!(more: call!(and_assign_op, allow_struct) => {
-                    let (op, v) = more;
-                    e = ExprAssignOp {
-                        op: op,
-                        left: Box::new(e.into()),
-                        right: Box::new(v),
-                    }.into();
-                })
-                |
-                tap!(field: and_field => {
-                    let (field, token) = field;
-                    e = ExprField {
-                        expr: Box::new(e.into()),
-                        field: field,
-                        dot_token: token,
-                    }.into();
-                })
-                |
-                tap!(field: and_tup_field => {
-                    let (field, token) = field;
-                    e = ExprTupField {
-                        expr: Box::new(e.into()),
-                        field: field,
-                        dot_token: token,
-                    }.into();
-                })
-                |
-                tap!(i: and_index => {
-                    let (i, token) = i;
-                    e = ExprIndex {
-                        expr: Box::new(e.into()),
-                        bracket_token: token,
-                        index: Box::new(i),
-                    }.into();
-                })
-                |
-                tap!(more: call!(and_range, allow_struct) => {
-                    let (limits, hi) = more;
-                    e = ExprRange {
-                        from: Some(Box::new(e.into())),
-                        to: hi.map(Box::new),
-                        limits: limits,
-                    }.into();
-                })
-                |
-                tap!(question: syn!(Question) => {
-                    e = ExprTry {
-                        expr: Box::new(e.into()),
-                        question_token: question,
-                    }.into();
-                })
-            )) >>
-            (e.into())
+            call!(assign_expr, allow_struct, allow_block),
+            ExprKind::into
+        )
+    }
+
+    /// Parse a left-associative binary operator.
+    macro_rules! binop {
+        (
+            $name: ident,
+            $next: ident,
+            $submac: ident!( $($args:tt)* )
+        ) => {
+            named!($name(allow_struct: bool, allow_block: bool) -> ExprKind, do_parse!(
+                mut e: call!($next, allow_struct, allow_block) >>
+                many0!(do_parse!(
+                    op: $submac!($($args)*) >>
+                    rhs: call!($next, allow_struct, true) >>
+                    ({
+                        e = ExprBinary {
+                            left: Box::new(e.into()),
+                            op: op,
+                            right: Box::new(rhs.into()),
+                        }.into();
+                    })
+                )) >>
+                (e)
+            ));
         }
     }
+
+    /// ```ignore
+    /// <placement> = <placement> ..
+    /// <placement> += <placement> ..
+    /// <placement> -= <placement> ..
+    /// <placement> *= <placement> ..
+    /// <placement> /= <placement> ..
+    /// <placement> %= <placement> ..
+    /// <placement> ^= <placement> ..
+    /// <placement> &= <placement> ..
+    /// <placement> |= <placement> ..
+    /// <placement> <<= <placement> ..
+    /// <placement> >>= <placement> ..
+    /// ```
+    ///
+    /// NOTE: This operator is right-associative.
+    named!(assign_expr(allow_struct: bool, allow_block: bool) -> ExprKind, do_parse!(
+        mut e: call!(placement_expr, allow_struct, allow_block) >>
+        alt!(
+            do_parse!(
+                eq: syn!(Eq) >>
+                // Recurse into self to parse right-associative operator.
+                rhs: call!(assign_expr, allow_struct, true) >>
+                ({
+                    e = ExprAssign {
+                        left: Box::new(e.into()),
+                        eq_token: eq,
+                        right: Box::new(rhs.into()),
+                    }.into();
+                })
+            )
+            |
+            do_parse!(
+                op: call!(BinOp::parse_assign_op) >>
+                // Recurse into self to parse right-associative operator.
+                rhs: call!(assign_expr, allow_struct, true) >>
+                ({
+                    e = ExprAssignOp {
+                        left: Box::new(e.into()),
+                        op: op,
+                        right: Box::new(rhs.into()),
+                    }.into();
+                })
+            )
+            |
+            epsilon!()
+        ) >>
+        (e)
+    ));
+
+    /// ```ignore
+    /// <range> <- <range> ..
+    /// ```
+    ///
+    /// NOTE: The `in place { expr }` version of this syntax is parsed in
+    /// `atom_expr`, not here.
+    ///
+    /// NOTE: This operator is right-associative.
+    named!(placement_expr(allow_struct: bool, allow_block: bool) -> ExprKind, do_parse!(
+        mut e: call!(range_expr, allow_struct, allow_block) >>
+        alt!(
+            do_parse!(
+                syn!(LArrow) >>
+                // Recurse into self to parse right-associative operator.
+                rhs: call!(placement_expr, allow_struct, true) >>
+                ({
+                    // XXX: Stop transforming the <- syntax into the InPlace
+                    // syntax.
+                    e = ExprInPlace {
+                        // op: BinOp::Place(larrow),
+                        place: Box::new(e.into()),
+                        value: Box::new(rhs.into()),
+                        in_token: tokens::In::default(),
+                    }.into();
+                })
+            )
+            |
+            epsilon!()
+        ) >>
+        (e)
+    ));
+
+    /// ```ignore
+    /// <or> ... <or> ..
+    /// <or> .. <or> ..
+    /// <or> ..
+    /// ```
+    ///
+    /// NOTE: This is currently parsed oddly - I'm not sure of what the exact
+    /// rules are for parsing these expressions are, but this is not correct.
+    /// For example, `a .. b .. c` is not a legal expression. It should not
+    /// be parsed as either `(a .. b) .. c` or `a .. (b .. c)` apparently.
+    ///
+    /// NOTE: The form of ranges which don't include a preceding expression are
+    /// parsed by `atom_expr`, rather than by this function.
+    named!(range_expr(allow_struct: bool, allow_block: bool) -> ExprKind, do_parse!(
+        mut e: call!(or_expr, allow_struct, allow_block) >>
+        many0!(do_parse!(
+            limits: syn!(RangeLimits) >>
+            // We don't want to allow blocks here if we don't allow structs. See
+            // the reasoning for `opt_ambiguous_expr!` above.
+            hi: option!(call!(or_expr, allow_struct, allow_struct)) >>
+            ({
+                e = ExprRange {
+                    from: Some(Box::new(e.into())),
+                    limits: limits,
+                    to: hi.map(|e| Box::new(e.into())),
+                }.into();
+            })
+        )) >>
+        (e)
+    ));
+
+    /// ```ignore
+    /// <and> || <and> ...
+    /// ```
+    binop!(or_expr, and_expr, map!(syn!(OrOr), BinOp::Or));
+
+    /// ```ignore
+    /// <compare> && <compare> ...
+    /// ```
+    binop!(and_expr, compare_expr, map!(syn!(AndAnd), BinOp::And));
+
+    /// ```ignore
+    /// <bitor> == <bitor> ...
+    /// <bitor> != <bitor> ...
+    /// <bitor> >= <bitor> ...
+    /// <bitor> <= <bitor> ...
+    /// <bitor> > <bitor> ...
+    /// <bitor> < <bitor> ...
+    /// ```
+    ///
+    /// NOTE: This operator appears to be parsed as left-associative, but errors
+    /// if it is used in a non-associative manner.
+    binop!(compare_expr, bitor_expr, alt!(
+        syn!(EqEq) => { BinOp::Eq }
+        |
+        syn!(Ne) => { BinOp::Ne }
+        |
+        // must be above Lt
+        syn!(Le) => { BinOp::Le }
+        |
+        // must be above Gt
+        syn!(Ge) => { BinOp::Ge }
+        |
+        syn!(Lt) => { BinOp::Lt }
+        |
+        syn!(Gt) => { BinOp::Gt }
+    ));
+
+    /// ```ignore
+    /// <bitxor> | <bitxor> ...
+    /// ```
+    binop!(bitor_expr, bitxor_expr, do_parse!(
+        not!(syn!(OrOr)) >>
+        not!(syn!(OrEq)) >>
+        t: syn!(Or) >>
+        (BinOp::BitOr(t))
+    ));
+
+    /// ```ignore
+    /// <bitand> ^ <bitand> ...
+    /// ```
+    binop!(bitxor_expr, bitand_expr, do_parse!(
+        // NOTE: Make sure we aren't looking at ^=.
+        not!(syn!(CaretEq)) >>
+        t: syn!(Caret) >>
+        (BinOp::BitXor(t))
+    ));
+
+    /// ```ignore
+    /// <shift> & <shift> ...
+    /// ```
+    binop!(bitand_expr, shift_expr, do_parse!(
+        // NOTE: Make sure we aren't looking at && or &=.
+        not!(syn!(AndAnd)) >>
+        not!(syn!(AndEq)) >>
+        t: syn!(And) >>
+        (BinOp::BitAnd(t))
+    ));
+
+    /// ```ignore
+    /// <arith> << <arith> ...
+    /// <arith> >> <arith> ...
+    /// ```
+    binop!(shift_expr, arith_expr, alt!(
+        syn!(Shl) => { BinOp::Shl }
+        |
+        syn!(Shr) => { BinOp::Shr }
+    ));
+
+    /// ```ignore
+    /// <term> + <term> ...
+    /// <term> - <term> ...
+    /// ```
+    binop!(arith_expr, term_expr, alt!(
+        syn!(Add) => { BinOp::Add }
+        |
+        syn!(Sub) => { BinOp::Sub }
+    ));
+
+    /// ```ignore
+    /// <cast> * <cast> ...
+    /// <cast> / <cast> ...
+    /// <cast> % <cast> ...
+    /// ```
+    binop!(term_expr, cast_expr, alt!(
+        syn!(Star) => { BinOp::Mul }
+        |
+        syn!(Div) => { BinOp::Div }
+        |
+        syn!(Rem) => { BinOp::Rem }
+    ));
+
+    /// ```ignore
+    /// <unary> as <ty>
+    /// <unary> : <ty>
+    /// ```
+    named!(cast_expr(allow_struct: bool, allow_block: bool) -> ExprKind, do_parse!(
+        mut e: call!(unary_expr, allow_struct, allow_block) >>
+        many0!(alt!(
+            do_parse!(
+                as_: syn!(As) >>
+                // We can't accept `A + B` in cast expressions, as it's
+                // ambiguous with the + expression.
+                ty: call!(Ty::without_plus) >>
+                ({
+                    e = ExprCast {
+                        expr: Box::new(e.into()),
+                        as_token: as_,
+                        ty: Box::new(ty),
+                    }.into();
+                })
+            )
+            |
+            do_parse!(
+                colon: syn!(Colon) >>
+                // We can't accept `A + B` in cast expressions, as it's
+                // ambiguous with the + expression.
+                ty: call!(Ty::without_plus) >>
+                ({
+                    e = ExprType {
+                        expr: Box::new(e.into()),
+                        colon_token: colon,
+                        ty: Box::new(ty),
+                    }.into();
+                })
+            )
+        )) >>
+        (e)
+    ));
+
+    /// ```
+    /// <UnOp> <trailer>
+    /// & <trailer>
+    /// &mut <trailer>
+    /// box <trailer>
+    /// ```
+    named!(unary_expr(allow_struct: bool, allow_block: bool) -> ExprKind, alt!(
+        do_parse!(
+            op: syn!(UnOp) >>
+            expr: call!(unary_expr, allow_struct, true) >>
+            (ExprUnary {
+                op: op,
+                expr: Box::new(expr.into()),
+            }.into())
+        )
+        |
+        do_parse!(
+            and: syn!(And) >>
+            mutability: syn!(Mutability) >>
+            expr: call!(unary_expr, allow_struct, true) >>
+            (ExprAddrOf {
+                and_token: and,
+                mutbl: mutability,
+                expr: Box::new(expr.into()),
+            }.into())
+        )
+        |
+        do_parse!(
+            box_: syn!(Box_) >>
+            expr: call!(unary_expr, allow_struct, true) >>
+            (ExprBox {
+                box_token: box_,
+                expr: Box::new(expr.into()),
+            }.into())
+        )
+        |
+        call!(trailer_expr, allow_struct, allow_block)
+    ));
+
+    /// ```ignore
+    /// <atom> (..<args>) ...
+    /// <atom> . <ident> (..<args>) ...
+    /// <atom> . <ident> ...
+    /// <atom> . <lit> ...
+    /// <atom> [ <expr> ] ...
+    /// <atom> ? ...
+    /// ```
+    named!(trailer_expr(allow_struct: bool, allow_block: bool) -> ExprKind, do_parse!(
+        mut e: call!(atom_expr, allow_struct, allow_block) >>
+        many0!(alt!(
+            tap!(args: and_call => {
+                let (args, paren) = args;
+                e = ExprCall {
+                    func: Box::new(e.into()),
+                    args: args,
+                    paren_token: paren,
+                }.into();
+            })
+            |
+            tap!(more: and_method_call => {
+                let mut call = more;
+                call.expr = Box::new(e.into());
+                e = call.into();
+            })
+            |
+            tap!(field: and_field => {
+                let (field, token) = field;
+                e = ExprField {
+                    expr: Box::new(e.into()),
+                    field: field,
+                    dot_token: token,
+                }.into();
+            })
+            |
+            tap!(field: and_tup_field => {
+                let (field, token) = field;
+                e = ExprTupField {
+                    expr: Box::new(e.into()),
+                    field: field,
+                    dot_token: token,
+                }.into();
+            })
+            |
+            tap!(i: and_index => {
+                let (i, token) = i;
+                e = ExprIndex {
+                    expr: Box::new(e.into()),
+                    bracket_token: token,
+                    index: Box::new(i),
+                }.into();
+            })
+            |
+            tap!(question: syn!(Question) => {
+                e = ExprTry {
+                    expr: Box::new(e.into()),
+                    question_token: question,
+                }.into();
+            })
+        )) >>
+        (e)
+    ));
+
+    /// Parse all atomic expressions which don't have to worry about precidence
+    /// interactions, as they are fully contained.
+    named!(atom_expr(allow_struct: bool, allow_block: bool) -> ExprKind, alt!(
+        syn!(Lit) => { ExprKind::Lit } // must be before expr_struct
+        |
+        // must be before expr_path
+        cond_reduce!(allow_struct, map!(syn!(ExprStruct), ExprKind::Struct))
+        |
+        syn!(ExprParen) => { ExprKind::Paren } // must be before expr_tup
+        |
+        syn!(Mac) => { ExprKind::Mac } // must be before expr_path
+        |
+        call!(expr_break, allow_struct) // must be before expr_path
+        |
+        syn!(ExprContinue) => { ExprKind::Continue } // must be before expr_path
+        |
+        call!(expr_ret, allow_struct) // must be before expr_path
+        |
+        // NOTE: The `in place { expr }` form. `place <- expr` is parsed above.
+        syn!(ExprInPlace) => { ExprKind::InPlace }
+        |
+        syn!(ExprArray) => { ExprKind::Array }
+        |
+        syn!(ExprTup) => { ExprKind::Tup }
+        |
+        syn!(ExprIf) => { ExprKind::If }
+        |
+        syn!(ExprIfLet) => { ExprKind::IfLet }
+        |
+        syn!(ExprWhile) => { ExprKind::While }
+        |
+        syn!(ExprWhileLet) => { ExprKind::WhileLet }
+        |
+        syn!(ExprForLoop) => { ExprKind::ForLoop }
+        |
+        syn!(ExprLoop) => { ExprKind::Loop }
+        |
+        syn!(ExprMatch) => { ExprKind::Match }
+        |
+        syn!(ExprCatch) => { ExprKind::Catch }
+        |
+        call!(expr_closure, allow_struct)
+        |
+        cond_reduce!(allow_block, map!(syn!(ExprBlock), ExprKind::Block))
+        |
+        // NOTE: This is the prefix-form of range
+        call!(expr_range, allow_struct)
+        |
+        syn!(ExprPath) => { ExprKind::Path }
+        |
+        syn!(ExprRepeat) => { ExprKind::Repeat }
+    ));
 
     impl Synom for ExprParen {
         named!(parse -> Self, do_parse!(
@@ -799,15 +1084,6 @@ pub mod parsing {
             }.into())
         ));
     }
-
-    named_ambiguous_expr!(expr_box -> ExprKind, allow_struct, do_parse!(
-        box_: syn!(Box_) >>
-        inner: ambiguous_expr!(allow_struct) >>
-        (ExprBox {
-            expr: Box::new(inner),
-            box_token: box_,
-        }.into())
-    ));
 
     impl Synom for ExprInPlace {
         named!(parse -> Self, do_parse!(
@@ -889,26 +1165,6 @@ pub mod parsing {
             })
         ));
     }
-
-    named_ambiguous_expr!(and_binary -> (BinOp, Expr), allow_struct, tuple!(
-        call!(BinOp::parse_binop),
-        ambiguous_expr!(allow_struct)
-    ));
-
-    named_ambiguous_expr!(expr_unary -> ExprKind, allow_struct, do_parse!(
-        operator: syn!(UnOp) >>
-        operand: ambiguous_expr!(allow_struct) >>
-        (ExprUnary { op: operator, expr: Box::new(operand) }.into())
-    ));
-
-    named!(and_cast -> (Ty, As), do_parse!(
-        as_: syn!(As) >>
-        ty: syn!(Ty) >>
-        (ty, as_)
-    ));
-
-    named!(and_ascription -> (Ty, Colon),
-           map!(tuple!(syn!(Colon), syn!(Ty)), |(a, b)| (b, a)));
 
     impl Synom for ExprIfLet {
         named!(parse -> Self, do_parse!(
@@ -1095,7 +1351,7 @@ pub mod parsing {
         ));
     }
 
-    named_ambiguous_expr!(expr_closure -> ExprKind, allow_struct, do_parse!(
+    named!(expr_closure(allow_struct: bool) -> ExprKind, do_parse!(
         capture: syn!(CaptureBy) >>
         or1: syn!(Or) >>
         inputs: call!(Delimited::parse_terminated_with, fn_arg) >>
@@ -1197,10 +1453,12 @@ pub mod parsing {
         ));
     }
 
-    named_ambiguous_expr!(expr_break -> ExprKind, allow_struct, do_parse!(
+    named!(expr_break(allow_struct: bool) -> ExprKind, do_parse!(
         break_: syn!(Break) >>
         lbl: option!(syn!(Lifetime)) >>
-        val: option!(call!(ambiguous_expr, allow_struct, false)) >>
+        // We can't allow blocks after a `break` expression when we wouldn't
+        // allow structs, as this expression is ambiguous.
+        val: opt_ambiguous_expr!(allow_struct) >>
         (ExprBreak {
             label: lbl,
             expr: val.map(Box::new),
@@ -1208,8 +1466,13 @@ pub mod parsing {
         }.into())
     ));
 
-    named_ambiguous_expr!(expr_ret -> ExprKind, allow_struct, do_parse!(
+    named!(expr_ret(allow_struct: bool) -> ExprKind, do_parse!(
         return_: syn!(Return) >>
+        // NOTE: return is greedy and eats blocks after it even when in a
+        // position where structs are not allowed, such as in if statement
+        // conditions. For example:
+        //
+        // if return { println!("A") } { } // Prints "A"
         ret_value: option!(ambiguous_expr!(allow_struct)) >>
         (ExprRet {
             expr: ret_value.map(Box::new),
@@ -1303,9 +1566,9 @@ pub mod parsing {
         ));
     }
 
-    named_ambiguous_expr!(expr_range -> ExprKind, allow_struct, do_parse!(
+    named!(expr_range(allow_struct: bool) -> ExprKind, do_parse!(
         limits: syn!(RangeLimits) >>
-        hi: option!(ambiguous_expr!(allow_struct)) >>
+        hi: opt_ambiguous_expr!(allow_struct) >>
         (ExprRange { from: None, to: hi.map(Box::new), limits: limits }.into())
     ));
 
@@ -1328,29 +1591,6 @@ pub mod parsing {
         ));
     }
 
-    named_ambiguous_expr!(expr_addr_of -> ExprKind, allow_struct, do_parse!(
-        and: syn!(And) >>
-        mutability: syn!(Mutability) >>
-        expr: ambiguous_expr!(allow_struct) >>
-        (ExprAddrOf {
-            mutbl: mutability,
-            expr: Box::new(expr),
-            and_token: and,
-        }.into())
-    ));
-
-    named_ambiguous_expr!(and_assign -> (Expr, Eq), allow_struct,
-        map!(
-            tuple!(syn!(Eq), ambiguous_expr!(allow_struct)),
-            |(a, b)| (b, a)
-        )
-    );
-
-    named_ambiguous_expr!(and_assign_op -> (BinOp, Expr), allow_struct, tuple!(
-        call!(BinOp::parse_assign_op),
-        ambiguous_expr!(allow_struct)
-    ));
-
     named!(and_field -> (Ident, Dot),
            map!(tuple!(syn!(Dot), syn!(Ident)), |(a, b)| (b, a)));
 
@@ -1358,11 +1598,6 @@ pub mod parsing {
            map!(tuple!(syn!(Dot), syn!(Lit)), |(a, b)| (b, a)));
 
     named!(and_index -> (Expr, tokens::Bracket), brackets!(syn!(Expr)));
-
-    named_ambiguous_expr!(and_range -> (RangeLimits, Option<Expr>), allow_struct, tuple!(
-        syn!(RangeLimits),
-        option!(call!(ambiguous_expr, allow_struct, false))
-    ));
 
     impl Synom for Block {
         named!(parse -> Self, do_parse!(

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -234,6 +234,12 @@ pub fn noop_fold_ty<F: ?Sized + Folder>(folder: &mut F, ty: Ty) -> Ty {
                 ..t
             })
         }
+        Group(t) => {
+            Group(TyGrpup {
+                ty: t.ty.lift(|v| folder.fold_ty(v)),
+                ..t
+            })
+        }
         Paren(t) => {
             Paren(TyParen {
                 ty: t.ty.lift(|v| folder.fold_ty(v)),
@@ -1033,6 +1039,12 @@ pub fn noop_fold_expr<F: ?Sized + Folder>(folder: &mut F, Expr { node, attrs }: 
             }
             Paren(e) => {
                 Paren(ExprParen {
+                    expr: e.expr.lift(|e| folder.fold_expr(e)),
+                    ..e
+                })
+            }
+            Group(e) => {
+                Group(ExprGroup {
                     expr: e.expr.lift(|e| folder.fold_expr(e)),
                     ..e
                 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use expr::{Arm, BindingMode, Block, CaptureBy, Expr, ExprKind, FieldPat, Fie
                ExprRange, ExprPath, ExprAddrOf, ExprBreak, ExprContinue,
                ExprRet, ExprStruct, ExprRepeat, ExprParen, ExprTry, ExprCatch,
                PatIdent, PatWild, PatStruct, PatTuple, PatTupleStruct, PatPath,
-               PatBox, PatRef, PatLit, PatRange, PatSlice, InPlaceKind};
+               PatBox, PatRef, PatLit, PatRange, PatSlice, InPlaceKind, ExprGroup};
 
 mod generics;
 pub use generics::{Generics, LifetimeDef, TraitBoundModifier, TyParam, TyParamBound,
@@ -91,7 +91,7 @@ pub use ty::{Abi, AngleBracketedParameterData, BareFnArg, BareFnTy, FunctionRetT
              Mutability, ParenthesizedParameterData, Path, PathParameters, PathSegment,
              PolyTraitRef, QSelf, Ty, TypeBinding, Unsafety, TySlice, TyArray,
              TyPtr, TyRptr, TyBareFn, TyNever, TyTup, TyPath, TyTraitObject,
-             TyImplTrait, TyParen, TyInfer};
+             TyImplTrait, TyParen, TyInfer, TyGroup};
 #[cfg(feature = "printing")]
 pub use ty::PathTokens;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use expr::{Arm, BindingMode, Block, CaptureBy, Expr, ExprKind, FieldPat, Fie
                ExprRange, ExprPath, ExprAddrOf, ExprBreak, ExprContinue,
                ExprRet, ExprStruct, ExprRepeat, ExprParen, ExprTry, ExprCatch,
                PatIdent, PatWild, PatStruct, PatTuple, PatTupleStruct, PatPath,
-               PatBox, PatRef, PatLit, PatRange, PatSlice};
+               PatBox, PatRef, PatLit, PatRange, PatSlice, InPlaceKind};
 
 mod generics;
 pub use generics::{Generics, LifetimeDef, TraitBoundModifier, TyParam, TyParamBound,

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -337,7 +337,7 @@ pub mod parsing {
         /// contain a `+` character.
         ///
         /// This parser does not allow a `+`, while the default parser does.
-        named!(without_plus -> Self, call!(ambig_ty, false));
+        named!(pub without_plus -> Self, call!(ambig_ty, false));
     }
 
     named!(ambig_ty(allow_plus: bool) -> Ty, alt!(

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -188,6 +188,7 @@ pub fn walk_ty<V: Visitor>(visitor: &mut V, ty: &Ty) {
 
     match *ty {
         Ty::Slice(TySlice { ref ty, .. }) |
+        Ty::Group(TyGroup { ref ty, .. }) |
         Ty::Paren(TyParen { ref ty, .. }) => visitor.visit_ty(ty),
         Ty::Ptr(TyPtr { ref ty, .. }) => visitor.visit_ty(&ty.ty),
         Ty::Rptr(TyRptr { ref lifetime, ref ty, .. }) => {
@@ -599,6 +600,7 @@ pub fn walk_expr<V: Visitor>(visitor: &mut V, expr: &Expr) {
         Box(ExprBox { ref expr, .. }) |
         AddrOf(ExprAddrOf { ref expr, .. }) |
         Paren(ExprParen { ref expr, .. }) |
+        Group(ExprGroup { ref expr, .. }) |
         Try(ExprTry { ref expr, .. }) => {
             visitor.visit_expr(expr);
         }

--- a/synom/src/helper.rs
+++ b/synom/src/helper.rs
@@ -235,3 +235,15 @@ macro_rules! braces {
         braces!($i, call!($f));
     };
 }
+
+/// Same as the `parens` macro, but for none-delimited sequences (groups).
+#[macro_export]
+macro_rules! grouped {
+    ($i:expr, $submac:ident!( $($args:tt)* )) => {
+        $crate::tokens::Group::parse($i, |i| $submac!(i, $($args)*))
+    };
+
+    ($i:expr, $f:expr) => {
+        grouped!($i, call!($f));
+    };
+}

--- a/synom/src/lib.rs
+++ b/synom/src/lib.rs
@@ -156,6 +156,20 @@ macro_rules! named {
             $submac!(i, $($args)*)
         }
     };
+
+    // These two variants are for defining named parsers which have custom
+    // arguments, and are called with `call!()`
+    ($name:ident($($params:tt)*) -> $o:ty, $submac:ident!( $($args:tt)* )) => {
+        fn $name(i: $crate::Cursor, $($params)*) -> $crate::PResult<$o> {
+            $submac!(i, $($args)*)
+        }
+    };
+
+    (pub $name:ident($($params:tt)*) -> $o:ty, $submac:ident!( $($args:tt)* )) => {
+        pub fn $name(i: $crate::Cursor, $($params)*) -> $crate::PResult<$o> {
+            $submac!(i, $($args)*)
+        }
+    };
 }
 
 /// Invoke the given parser function with the passed in arguments.

--- a/synom/src/lib.rs
+++ b/synom/src/lib.rs
@@ -66,24 +66,23 @@ pub trait Synom: Sized {
 
     fn parse_all(input: TokenStream) -> Result<Self, ParseError> {
         let buf = SynomBuffer::new(input);
-        let result = Self::parse(buf.begin());
-        let err = match result {
+        let descr = Self::description().unwrap_or("unnamed parser");
+        let err = match Self::parse(buf.begin()) {
             Ok((rest, t)) => {
                 if rest.eof() {
                     return Ok(t)
                 } else if rest == buf.begin() {
                     // parsed nothing
-                    "failed to parse"
+                    format!("parsed no input while parsing {}", descr)
                 } else {
-                    "unparsed tokens after"
+                    // Partially parsed the output. Print the input which remained.
+                    format!("unparsed tokens after parsing {}:\n{}",
+                            descr, rest.token_stream())
                 }
             }
-            Err(ref err) => err.description(),
+            Err(ref err) => format!("{} while parsing {}", err.description(), descr),
         };
-        match Self::description() {
-            Some(s) => Err(ParseError(Some(format!("{} {}", err, s)))),
-            None => Err(ParseError(Some(err.to_string()))),
-        }
+        Err(ParseError(Some(err)))
     }
 
     fn parse_str_all(input: &str) -> Result<Self, ParseError> {

--- a/synom/src/tokens.rs
+++ b/synom/src/tokens.rs
@@ -131,6 +131,7 @@ tokens! {
         (pub struct Pound([Span; 1])        => "#"),
         (pub struct Question([Span; 1])     => "?"),
         (pub struct RArrow([Span; 2])       => "->"),
+        (pub struct LArrow([Span; 2])       => "<-"),
         (pub struct Rem([Span; 1])          => "%"),
         (pub struct RemEq([Span; 2])        => "%="),
         (pub struct Rocket([Span; 2])       => "=>"),

--- a/synom/src/tokens.rs
+++ b/synom/src/tokens.rs
@@ -149,6 +149,7 @@ tokens! {
         (pub struct Brace                   => "{"),
         (pub struct Bracket                 => "["),
         (pub struct Paren                   => "("),
+        (pub struct Group                   => " "),
     }
     syms: {
         (pub struct As                      => "as"),
@@ -273,6 +274,7 @@ mod parsing {
             "(" => Delimiter::Parenthesis,
             "{" => Delimiter::Brace,
             "[" => Delimiter::Bracket,
+            " " => Delimiter::None,
             _ => panic!("unknown delimiter: {}", delim),
         };
 

--- a/tests/test_grouping.rs
+++ b/tests/test_grouping.rs
@@ -1,0 +1,93 @@
+#![cfg(all(feature = "extra-traits", feature = "full"))]
+
+extern crate syn;
+use syn::{Expr, ExprKind, ExprGroup, ExprBinary, Lit, LitKind, BinOp};
+
+extern crate synom;
+use synom::{tokens, Synom};
+
+extern crate proc_macro2;
+use proc_macro2::*;
+
+fn tt(k: TokenKind) -> TokenTree {
+    TokenTree {
+        span: Span::default(),
+        kind: k,
+    }
+}
+
+fn expr<T: Into<ExprKind>>(t: T) -> Expr {
+    t.into().into()
+}
+
+fn lit<T: Into<Literal>>(t: T) -> Expr {
+    expr(Lit {
+        value: LitKind::Other(t.into()),
+        span: syn::Span::default(),
+    })
+}
+
+#[test]
+fn test_grouping() {
+    let raw: TokenStream = vec![
+        tt(TokenKind::Literal(Literal::from(1))),
+        tt(TokenKind::Op('+', OpKind::Alone)),
+        tt(TokenKind::Sequence(Delimiter::None, vec![
+            tt(TokenKind::Literal(Literal::from(2))),
+            tt(TokenKind::Op('+', OpKind::Alone)),
+            tt(TokenKind::Literal(Literal::from(3))),
+        ].into_iter().collect())),
+        tt(TokenKind::Op('*', OpKind::Alone)),
+        tt(TokenKind::Literal(Literal::from(4))),
+    ].into_iter().collect();
+
+    assert_eq!(raw.to_string(), "1i32 +  2i32 + 3i32  * 4i32");
+
+    assert_eq!(Expr::parse_all(raw).unwrap(), expr(ExprBinary {
+        left: Box::new(lit(1)),
+        op: BinOp::Add(tokens::Add::default()),
+        right: Box::new(expr(ExprBinary {
+            left: Box::new(expr(ExprGroup {
+                group_token: tokens::Group::default(),
+                expr: Box::new(expr(ExprBinary {
+                    left: Box::new(lit(2)),
+                    op: BinOp::Add(tokens::Add::default()),
+                    right: Box::new(lit(3)),
+                })),
+            })),
+            op: BinOp::Mul(tokens::Star::default()),
+            right: Box::new(lit(4)),
+        })),
+    }));
+}
+
+#[test]
+fn test_invalid_grouping() {
+    let raw: TokenStream = vec![
+        tt(TokenKind::Literal(Literal::from(1))),
+        tt(TokenKind::Op('+', OpKind::Alone)),
+        tt(TokenKind::Sequence(Delimiter::None, vec![
+            tt(TokenKind::Literal(Literal::from(2))),
+            tt(TokenKind::Op('+', OpKind::Alone)),
+        ].into_iter().collect())),
+        tt(TokenKind::Literal(Literal::from(3))),
+        tt(TokenKind::Op('*', OpKind::Alone)),
+        tt(TokenKind::Literal(Literal::from(4))),
+    ].into_iter().collect();
+
+    assert_eq!(raw.to_string(), "1i32 +  2i32 +  3i32 * 4i32");
+
+    assert_eq!(Expr::parse_all(raw).unwrap(), expr(ExprBinary {
+        left: Box::new(expr(ExprBinary {
+            left: Box::new(lit(1)),
+            op: BinOp::Add(tokens::Add::default()),
+            right: Box::new(lit(2)),
+        })),
+        op: BinOp::Add(tokens::Add::default()),
+        right: Box::new(expr(ExprBinary {
+            left: Box::new(lit(3)),
+            op: BinOp::Mul(tokens::Star::default()),
+            right: Box::new(lit(4)),
+        })),
+    }));
+}

--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -54,18 +54,8 @@ fn filter(entry: &DirEntry) -> bool {
     }
 
     match path_string.as_ref() {
-        // TODO placement syntax
-        "tests/rust/src/libcollections/tests/binary_heap.rs" |
-        // TODO placement syntax
-        "tests/rust/src/libcollections/tests/vec.rs" |
-        // TODO placement syntax
-        "tests/rust/src/libcollections/tests/vec_deque.rs" |
         // TODO better support for attributes
         "tests/rust/src/librustc_data_structures/blake2b.rs" |
-        // TODO placement syntax
-        "tests/rust/src/librustc_mir/build/matches/test.rs" |
-        // TODO placement syntax
-        "tests/rust/src/libstd/collections/hash/map.rs" |
         // TODO better support for attributes
         "tests/rust/src/test/incremental/hashes/enum_defs.rs" |
         // TODO better support for attributes

--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -69,9 +69,7 @@ fn filter(entry: &DirEntry) -> bool {
         // TODO better support for attributes
         "tests/rust/src/test/run-pass/inner-attrs-on-impl.rs" |
         // TODO better support for attributes
-        "tests/rust/src/test/run-pass/item-attributes.rs" |
-        // TODO precedence issue with binop vs poly trait ref
-        "tests/rust/src/test/run-pass/try-macro.rs" => false,
+        "tests/rust/src/test/run-pass/item-attributes.rs" => false,
         _ => true,
     }
 }


### PR DESCRIPTION
This should fix #163.

This changes a bunch of stuff, adding a few new debugging tools which I found useful for fixing the test failures while writing these patches, some changes to `Ty`'s parsing, a ton of `Expr` parsing changes etc.

I have not written good tests for the precedence parsing yet. I have an idea of how to do it well, comparing us against `syntex` on rustc's source, like `test_round_trip` does, but I'm going to use `fold` to implement it, so I'll have to fix #166 before I can do that. This doesn't regress any tests though (it actually fixes a few of them!), and we aren't shipping this version of `syn` yet, so I would like to land this patch, and add the tests in a follow-up :).