### PR TITLE
Fix `_` as an identifier by accident

### DIFF
--- a/src/fold.rs
+++ b/src/fold.rs
@@ -280,7 +280,14 @@ pub fn noop_fold_ty<F: ?Sized + Folder>(folder: &mut F, ty: Ty) -> Ty {
                     }),
                     inputs: ty.inputs.lift(|v| {
                         BareFnArg {
-                            name: v.name.map(|n| (folder.fold_ident(n.0), n.1)),
+                            name: v.name.map(|n| {
+                                (match n.0 {
+                                    BareFnArgName::Named(n) => {
+                                        BareFnArgName::Named(folder.fold_ident(n))
+                                    }
+                                    other => other,
+                                }, n.1)
+                            }),
                             ty: folder.fold_ty(v.ty),
                         }
                     }),

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -201,7 +201,9 @@ pub fn walk_ty<V: Visitor>(visitor: &mut V, ty: &Ty) {
             }
             for argument in ty.inputs.items() {
                 if let Some((ref name, _)) = argument.name {
-                    visitor.visit_ident(name);
+                    if let BareFnArgName::Named(ref name) = *name {
+                        visitor.visit_ident(name);
+                    }
                 }
                 visitor.visit_ty(&argument.ty)
             }


### PR DESCRIPTION
The proc-macro2 crate currently has a bug where a bare `_` token is classified
as an identifier, but this doesn't happen with the upstream `proc_macro` crate!
In preparation for fixing proc-macro2 this commit removes `syn`'s reliance on
this behavior.