### PR TITLE
Add a dump-ast example program for dumping the AST for a single file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ categories = ["development-tools::procedural-macro-helpers"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 publish = false # this branch contains breaking changes
 
+[[example]]
+name = "dump-ast"
+path = "examples/dump-ast.rs"
+required-features = ["extra-traits", "parsing", "printing", "full"]
+
 [features]
 default = ["parsing", "printing", "clone-impls"]
 full = []

--- a/examples/dump-ast.rs
+++ b/examples/dump-ast.rs
@@ -1,0 +1,28 @@
+#![cfg(all(feature = "full", feature = "extra-traits"))]
+extern crate syn;
+
+use std::env;
+use std::fs::File;
+use std::io::{self, Read};
+
+fn main() {
+    let mut args = env::args();
+    let _ = args.next(); // executable name
+    let filename = args.next().unwrap_or_else(|| {
+        panic!("USAGE: dump-ast FILENAME");
+    });
+    if args.next().is_some() {
+        panic!("dump-ast only takes one argument");
+    }
+
+    let mut src = String::new();
+    if filename != "-" {
+        let mut file = File::open(&filename).expect("Unable to open source file");
+        file.read_to_string(&mut src).expect("Unable to read input file");
+    } else {
+        io::stdin().read_to_string(&mut src).expect("Unable to read stdin");
+    }
+
+    let ast = syn::parse_file(&src).expect("Unable to parse file");
+    println!("{:#?}", ast);
+}

--- a/examples/dump-ast.rs
+++ b/examples/dump-ast.rs
@@ -1,4 +1,3 @@
-#![cfg(all(feature = "full", feature = "extra-traits"))]
 extern crate syn;
 
 use std::env;

--- a/synom/src/delimited.rs
+++ b/synom/src/delimited.rs
@@ -1,8 +1,10 @@
 use std::iter::FromIterator;
 use std::slice;
 use std::vec;
+#[cfg(feature = "extra-traits")]
+use std::fmt::{self, Debug};
 
-#[cfg_attr(feature = "extra-traits", derive(Eq, PartialEq, Hash, Debug))]
+#[cfg_attr(feature = "extra-traits", derive(Eq, PartialEq, Hash))]
 #[cfg_attr(feature = "clone-impls", derive(Clone))]
 pub struct Delimited<T, D> {
     inner: Vec<(T, Option<D>)>
@@ -141,6 +143,13 @@ impl<T, D> Delimited<T, D> {
     #[doc(hidden)]
     pub fn empty_or_trailing(&self) -> bool {
         self.is_empty() || self.trailing_delim()
+    }
+}
+
+#[cfg(feature = "extra-traits")]
+impl<T: Debug, D: Debug> Debug for Delimited<T, D> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
     }
 }
 

--- a/synom/src/span.rs
+++ b/synom/src/span.rs
@@ -1,9 +1,16 @@
 use std::hash::{Hash, Hasher};
+use std::fmt::{self, Debug};
 
 use proc_macro2;
 
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default)]
 pub struct Span(pub proc_macro2::Span);
+
+impl Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl PartialEq for Span {
     fn eq(&self, _other: &Span) -> bool {

--- a/synom/src/tokens.rs
+++ b/synom/src/tokens.rs
@@ -28,9 +28,20 @@ macro_rules! tokens {
 macro_rules! op {
     (pub struct $name:ident($($contents:tt)*) => $s:expr) => {
         #[cfg_attr(feature = "clone-impls", derive(Copy, Clone))]
-        #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
+        #[cfg_attr(feature = "extra-traits", derive(Eq, PartialEq, Hash))]
         #[derive(Default)]
         pub struct $name(pub $($contents)*);
+
+        #[cfg(feature = "extra-traits")]
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                let mut t = f.debug_tuple(stringify!($name));
+                for span in &self.0 {
+                    t.field(span);
+                }
+                t.finish()
+            }
+        }
 
         #[cfg(feature = "printing")]
         impl ::quote::ToTokens for $name {


### PR DESCRIPTION
I wrote this originally to make it easier for me to quickly test stuff like #196, and I figured it might be useful to have in tree. It's just a really simple example program that reads a file, parses it, and debug prints out the result.

I also cleaned up the debug output a bit as it was a little noisy.