### PR TITLE
Change README.md Cargo.toml version to 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ not related to syn. Please file a ticket in this repo.
 
 ```toml
 [dependencies]
-syn = "0.12"
+syn = "0.11"
 quote = "0.3"
 
 [lib]


### PR DESCRIPTION
0.12 isn't on crates.io yet so having 0.12 as an example in the README.md is a bit confusing for the new users.