### PR TITLE
Flatten ItemKind into an Item enum

### DIFF
--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -236,7 +236,7 @@ fn fold_item_foreign_mod(&mut self, i: ItemForeignMod) -> ItemForeignMod { fold_
 # [ cfg ( feature = "full" ) ]
 fn fold_item_impl(&mut self, i: ItemImpl) -> ItemImpl { fold_item_impl(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn fold_item_kind(&mut self, i: ItemKind) -> ItemKind { fold_item_kind(self, i) }
+fn fold_item_mac(&mut self, i: ItemMac) -> ItemMac { fold_item_mac(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_item_mod(&mut self, i: ItemMod) -> ItemMod { fold_item_mod(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -1544,93 +1544,7 @@ pub fn fold_in_place_kind<V: Folder + ?Sized>(_visitor: &mut V, _i: InPlaceKind)
 }
 # [ cfg ( feature = "full" ) ]
 pub fn fold_item<V: Folder + ?Sized>(_visitor: &mut V, _i: Item) -> Item {
-    Item {
-        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
-        node: _visitor.fold_item_kind(_i . node),
-    }
-}
-# [ cfg ( feature = "full" ) ]
-pub fn fold_item_const<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemConst) -> ItemConst {
-    ItemConst {
-        vis: _visitor.fold_visibility(_i . vis),
-        const_token: _i . const_token,
-        ident: _i . ident,
-        colon_token: _i . colon_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
-        eq_token: _i . eq_token,
-        expr: Box::new(_visitor.fold_expr(* _i . expr)),
-        semi_token: _i . semi_token,
-    }
-}
-# [ cfg ( feature = "full" ) ]
-pub fn fold_item_default_impl<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemDefaultImpl) -> ItemDefaultImpl {
-    ItemDefaultImpl {
-        unsafety: _visitor.fold_unsafety(_i . unsafety),
-        impl_token: _i . impl_token,
-        path: _visitor.fold_path(_i . path),
-        for_token: _i . for_token,
-        dot2_token: _i . dot2_token,
-        brace_token: _i . brace_token,
-    }
-}
-# [ cfg ( feature = "full" ) ]
-pub fn fold_item_enum<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemEnum) -> ItemEnum {
-    ItemEnum {
-        vis: _visitor.fold_visibility(_i . vis),
-        enum_token: _i . enum_token,
-        ident: _i . ident,
-        generics: _visitor.fold_generics(_i . generics),
-        brace_token: _i . brace_token,
-        variants: FoldHelper::lift(_i . variants, |it| { _visitor.fold_variant(it) }),
-    }
-}
-# [ cfg ( feature = "full" ) ]
-pub fn fold_item_extern_crate<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemExternCrate) -> ItemExternCrate {
-    ItemExternCrate {
-        vis: _visitor.fold_visibility(_i . vis),
-        extern_token: _i . extern_token,
-        crate_token: _i . crate_token,
-        ident: _i . ident,
-        rename: _i . rename,
-        semi_token: _i . semi_token,
-    }
-}
-# [ cfg ( feature = "full" ) ]
-pub fn fold_item_fn<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemFn) -> ItemFn {
-    ItemFn {
-        vis: _visitor.fold_visibility(_i . vis),
-        constness: _visitor.fold_constness(_i . constness),
-        unsafety: _visitor.fold_unsafety(_i . unsafety),
-        abi: (_i . abi).map(|it| { _visitor.fold_abi(it) }),
-        decl: Box::new(_visitor.fold_fn_decl(* _i . decl)),
-        ident: _i . ident,
-        block: Box::new(_visitor.fold_block(* _i . block)),
-    }
-}
-# [ cfg ( feature = "full" ) ]
-pub fn fold_item_foreign_mod<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemForeignMod) -> ItemForeignMod {
-    ItemForeignMod {
-        abi: _visitor.fold_abi(_i . abi),
-        brace_token: _i . brace_token,
-        items: FoldHelper::lift(_i . items, |it| { _visitor.fold_foreign_item(it) }),
-    }
-}
-# [ cfg ( feature = "full" ) ]
-pub fn fold_item_impl<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemImpl) -> ItemImpl {
-    ItemImpl {
-        defaultness: _visitor.fold_defaultness(_i . defaultness),
-        unsafety: _visitor.fold_unsafety(_i . unsafety),
-        impl_token: _i . impl_token,
-        generics: _visitor.fold_generics(_i . generics),
-        trait_: _i . trait_,
-        self_ty: Box::new(_visitor.fold_ty(* _i . self_ty)),
-        brace_token: _i . brace_token,
-        items: FoldHelper::lift(_i . items, |it| { _visitor.fold_impl_item(it) }),
-    }
-}
-# [ cfg ( feature = "full" ) ]
-pub fn fold_item_kind<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemKind) -> ItemKind {
-    use ::ItemKind::*;
+    use ::Item::*;
     match _i {
         ExternCrate(_binding_0, ) => {
             ExternCrate (
@@ -1704,14 +1618,108 @@ pub fn fold_item_kind<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemKind) -> Ite
         }
         Mac(_binding_0, ) => {
             Mac (
-                _visitor.fold_mac(_binding_0),
+                _visitor.fold_item_mac(_binding_0),
             )
         }
     }
 }
 # [ cfg ( feature = "full" ) ]
+pub fn fold_item_const<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemConst) -> ItemConst {
+    ItemConst {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
+        vis: _visitor.fold_visibility(_i . vis),
+        const_token: _i . const_token,
+        ident: _i . ident,
+        colon_token: _i . colon_token,
+        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        eq_token: _i . eq_token,
+        expr: Box::new(_visitor.fold_expr(* _i . expr)),
+        semi_token: _i . semi_token,
+    }
+}
+# [ cfg ( feature = "full" ) ]
+pub fn fold_item_default_impl<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemDefaultImpl) -> ItemDefaultImpl {
+    ItemDefaultImpl {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
+        unsafety: _visitor.fold_unsafety(_i . unsafety),
+        impl_token: _i . impl_token,
+        path: _visitor.fold_path(_i . path),
+        for_token: _i . for_token,
+        dot2_token: _i . dot2_token,
+        brace_token: _i . brace_token,
+    }
+}
+# [ cfg ( feature = "full" ) ]
+pub fn fold_item_enum<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemEnum) -> ItemEnum {
+    ItemEnum {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
+        vis: _visitor.fold_visibility(_i . vis),
+        enum_token: _i . enum_token,
+        ident: _i . ident,
+        generics: _visitor.fold_generics(_i . generics),
+        brace_token: _i . brace_token,
+        variants: FoldHelper::lift(_i . variants, |it| { _visitor.fold_variant(it) }),
+    }
+}
+# [ cfg ( feature = "full" ) ]
+pub fn fold_item_extern_crate<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemExternCrate) -> ItemExternCrate {
+    ItemExternCrate {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
+        vis: _visitor.fold_visibility(_i . vis),
+        extern_token: _i . extern_token,
+        crate_token: _i . crate_token,
+        ident: _i . ident,
+        rename: _i . rename,
+        semi_token: _i . semi_token,
+    }
+}
+# [ cfg ( feature = "full" ) ]
+pub fn fold_item_fn<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemFn) -> ItemFn {
+    ItemFn {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
+        vis: _visitor.fold_visibility(_i . vis),
+        constness: _visitor.fold_constness(_i . constness),
+        unsafety: _visitor.fold_unsafety(_i . unsafety),
+        abi: (_i . abi).map(|it| { _visitor.fold_abi(it) }),
+        decl: Box::new(_visitor.fold_fn_decl(* _i . decl)),
+        ident: _i . ident,
+        block: Box::new(_visitor.fold_block(* _i . block)),
+    }
+}
+# [ cfg ( feature = "full" ) ]
+pub fn fold_item_foreign_mod<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemForeignMod) -> ItemForeignMod {
+    ItemForeignMod {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
+        abi: _visitor.fold_abi(_i . abi),
+        brace_token: _i . brace_token,
+        items: FoldHelper::lift(_i . items, |it| { _visitor.fold_foreign_item(it) }),
+    }
+}
+# [ cfg ( feature = "full" ) ]
+pub fn fold_item_impl<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemImpl) -> ItemImpl {
+    ItemImpl {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
+        defaultness: _visitor.fold_defaultness(_i . defaultness),
+        unsafety: _visitor.fold_unsafety(_i . unsafety),
+        impl_token: _i . impl_token,
+        generics: _visitor.fold_generics(_i . generics),
+        trait_: _i . trait_,
+        self_ty: Box::new(_visitor.fold_ty(* _i . self_ty)),
+        brace_token: _i . brace_token,
+        items: FoldHelper::lift(_i . items, |it| { _visitor.fold_impl_item(it) }),
+    }
+}
+# [ cfg ( feature = "full" ) ]
+pub fn fold_item_mac<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemMac) -> ItemMac {
+    ItemMac {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
+        mac: _visitor.fold_mac(_i . mac),
+    }
+}
+# [ cfg ( feature = "full" ) ]
 pub fn fold_item_mod<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemMod) -> ItemMod {
     ItemMod {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         vis: _visitor.fold_visibility(_i . vis),
         mod_token: _i . mod_token,
         ident: _i . ident,
@@ -1722,6 +1730,7 @@ pub fn fold_item_mod<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemMod) -> ItemM
 # [ cfg ( feature = "full" ) ]
 pub fn fold_item_static<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemStatic) -> ItemStatic {
     ItemStatic {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         vis: _visitor.fold_visibility(_i . vis),
         static_token: _i . static_token,
         mutbl: _visitor.fold_mutability(_i . mutbl),
@@ -1736,6 +1745,7 @@ pub fn fold_item_static<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemStatic) ->
 # [ cfg ( feature = "full" ) ]
 pub fn fold_item_struct<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemStruct) -> ItemStruct {
     ItemStruct {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         vis: _visitor.fold_visibility(_i . vis),
         struct_token: _i . struct_token,
         ident: _i . ident,
@@ -1747,6 +1757,7 @@ pub fn fold_item_struct<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemStruct) ->
 # [ cfg ( feature = "full" ) ]
 pub fn fold_item_trait<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemTrait) -> ItemTrait {
     ItemTrait {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         vis: _visitor.fold_visibility(_i . vis),
         unsafety: _visitor.fold_unsafety(_i . unsafety),
         trait_token: _i . trait_token,
@@ -1761,6 +1772,7 @@ pub fn fold_item_trait<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemTrait) -> I
 # [ cfg ( feature = "full" ) ]
 pub fn fold_item_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemTy) -> ItemTy {
     ItemTy {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         vis: _visitor.fold_visibility(_i . vis),
         type_token: _i . type_token,
         ident: _i . ident,
@@ -1773,6 +1785,7 @@ pub fn fold_item_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemTy) -> ItemTy 
 # [ cfg ( feature = "full" ) ]
 pub fn fold_item_union<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemUnion) -> ItemUnion {
     ItemUnion {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         vis: _visitor.fold_visibility(_i . vis),
         union_token: _i . union_token,
         ident: _i . ident,
@@ -1783,6 +1796,7 @@ pub fn fold_item_union<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemUnion) -> I
 # [ cfg ( feature = "full" ) ]
 pub fn fold_item_use<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemUse) -> ItemUse {
     ItemUse {
+        attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         vis: _visitor.fold_visibility(_i . vis),
         use_token: _i . use_token,
         path: Box::new(_visitor.fold_view_path(* _i . path)),

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -209,7 +209,7 @@ fn visit_item_foreign_mod(&mut self, i: &ItemForeignMod) { visit_item_foreign_mo
 # [ cfg ( feature = "full" ) ]
 fn visit_item_impl(&mut self, i: &ItemImpl) { visit_item_impl(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn visit_item_kind(&mut self, i: &ItemKind) { visit_item_kind(self, i) }
+fn visit_item_mac(&mut self, i: &ItemMac) { visit_item_mac(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_item_mod(&mut self, i: &ItemMod) { visit_item_mod(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -1203,77 +1203,7 @@ pub fn visit_in_place_kind<V: Visitor + ?Sized>(_visitor: &mut V, _i: &InPlaceKi
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Item) {
-    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
-    _visitor.visit_item_kind(&_i . node);
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_const<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemConst) {
-    _visitor.visit_visibility(&_i . vis);
-    // Skipped field _i . const_token;
-    // Skipped field _i . ident;
-    // Skipped field _i . colon_token;
-    _visitor.visit_ty(&_i . ty);
-    // Skipped field _i . eq_token;
-    _visitor.visit_expr(&_i . expr);
-    // Skipped field _i . semi_token;
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_default_impl<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemDefaultImpl) {
-    _visitor.visit_unsafety(&_i . unsafety);
-    // Skipped field _i . impl_token;
-    _visitor.visit_path(&_i . path);
-    // Skipped field _i . for_token;
-    // Skipped field _i . dot2_token;
-    // Skipped field _i . brace_token;
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_enum<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemEnum) {
-    _visitor.visit_visibility(&_i . vis);
-    // Skipped field _i . enum_token;
-    // Skipped field _i . ident;
-    _visitor.visit_generics(&_i . generics);
-    // Skipped field _i . brace_token;
-    for el in (_i . variants).iter() { let it = el.item(); _visitor.visit_variant(&it) };
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_extern_crate<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemExternCrate) {
-    _visitor.visit_visibility(&_i . vis);
-    // Skipped field _i . extern_token;
-    // Skipped field _i . crate_token;
-    // Skipped field _i . ident;
-    // Skipped field _i . rename;
-    // Skipped field _i . semi_token;
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_fn<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemFn) {
-    _visitor.visit_visibility(&_i . vis);
-    _visitor.visit_constness(&_i . constness);
-    _visitor.visit_unsafety(&_i . unsafety);
-    if let Some(ref it) = _i . abi { _visitor.visit_abi(&* it) };
-    _visitor.visit_fn_decl(&_i . decl);
-    // Skipped field _i . ident;
-    _visitor.visit_block(&_i . block);
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_foreign_mod<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemForeignMod) {
-    _visitor.visit_abi(&_i . abi);
-    // Skipped field _i . brace_token;
-    for it in (_i . items).iter() { _visitor.visit_foreign_item(&it) };
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_impl<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemImpl) {
-    _visitor.visit_defaultness(&_i . defaultness);
-    _visitor.visit_unsafety(&_i . unsafety);
-    // Skipped field _i . impl_token;
-    _visitor.visit_generics(&_i . generics);
-    // Skipped field _i . trait_;
-    _visitor.visit_ty(&_i . self_ty);
-    // Skipped field _i . brace_token;
-    for it in (_i . items).iter() { _visitor.visit_impl_item(&it) };
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_kind<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemKind) {
-    use ::ItemKind::*;
+    use ::Item::*;
     match *_i {
         ExternCrate(ref _binding_0, ) => {
             _visitor.visit_item_extern_crate(&* _binding_0);
@@ -1318,12 +1248,90 @@ pub fn visit_item_kind<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemKind) {
             _visitor.visit_item_impl(&* _binding_0);
         }
         Mac(ref _binding_0, ) => {
-            _visitor.visit_mac(&* _binding_0);
+            _visitor.visit_item_mac(&* _binding_0);
         }
     }
 }
 # [ cfg ( feature = "full" ) ]
+pub fn visit_item_const<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemConst) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
+    _visitor.visit_visibility(&_i . vis);
+    // Skipped field _i . const_token;
+    // Skipped field _i . ident;
+    // Skipped field _i . colon_token;
+    _visitor.visit_ty(&_i . ty);
+    // Skipped field _i . eq_token;
+    _visitor.visit_expr(&_i . expr);
+    // Skipped field _i . semi_token;
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_default_impl<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemDefaultImpl) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
+    _visitor.visit_unsafety(&_i . unsafety);
+    // Skipped field _i . impl_token;
+    _visitor.visit_path(&_i . path);
+    // Skipped field _i . for_token;
+    // Skipped field _i . dot2_token;
+    // Skipped field _i . brace_token;
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_enum<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemEnum) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
+    _visitor.visit_visibility(&_i . vis);
+    // Skipped field _i . enum_token;
+    // Skipped field _i . ident;
+    _visitor.visit_generics(&_i . generics);
+    // Skipped field _i . brace_token;
+    for el in (_i . variants).iter() { let it = el.item(); _visitor.visit_variant(&it) };
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_extern_crate<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemExternCrate) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
+    _visitor.visit_visibility(&_i . vis);
+    // Skipped field _i . extern_token;
+    // Skipped field _i . crate_token;
+    // Skipped field _i . ident;
+    // Skipped field _i . rename;
+    // Skipped field _i . semi_token;
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_fn<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemFn) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
+    _visitor.visit_visibility(&_i . vis);
+    _visitor.visit_constness(&_i . constness);
+    _visitor.visit_unsafety(&_i . unsafety);
+    if let Some(ref it) = _i . abi { _visitor.visit_abi(&* it) };
+    _visitor.visit_fn_decl(&_i . decl);
+    // Skipped field _i . ident;
+    _visitor.visit_block(&_i . block);
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_foreign_mod<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemForeignMod) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
+    _visitor.visit_abi(&_i . abi);
+    // Skipped field _i . brace_token;
+    for it in (_i . items).iter() { _visitor.visit_foreign_item(&it) };
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_impl<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemImpl) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
+    _visitor.visit_defaultness(&_i . defaultness);
+    _visitor.visit_unsafety(&_i . unsafety);
+    // Skipped field _i . impl_token;
+    _visitor.visit_generics(&_i . generics);
+    // Skipped field _i . trait_;
+    _visitor.visit_ty(&_i . self_ty);
+    // Skipped field _i . brace_token;
+    for it in (_i . items).iter() { _visitor.visit_impl_item(&it) };
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_mac<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemMac) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
+    _visitor.visit_mac(&_i . mac);
+}
+# [ cfg ( feature = "full" ) ]
 pub fn visit_item_mod<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemMod) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     _visitor.visit_visibility(&_i . vis);
     // Skipped field _i . mod_token;
     // Skipped field _i . ident;
@@ -1332,6 +1340,7 @@ pub fn visit_item_mod<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemMod) {
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_static<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemStatic) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     _visitor.visit_visibility(&_i . vis);
     // Skipped field _i . static_token;
     _visitor.visit_mutability(&_i . mutbl);
@@ -1344,6 +1353,7 @@ pub fn visit_item_static<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemStatic)
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_struct<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemStruct) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     _visitor.visit_visibility(&_i . vis);
     // Skipped field _i . struct_token;
     // Skipped field _i . ident;
@@ -1353,6 +1363,7 @@ pub fn visit_item_struct<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemStruct)
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_trait<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemTrait) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     _visitor.visit_visibility(&_i . vis);
     _visitor.visit_unsafety(&_i . unsafety);
     // Skipped field _i . trait_token;
@@ -1365,6 +1376,7 @@ pub fn visit_item_trait<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemTrait) {
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemTy) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     _visitor.visit_visibility(&_i . vis);
     // Skipped field _i . type_token;
     // Skipped field _i . ident;
@@ -1375,6 +1387,7 @@ pub fn visit_item_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemTy) {
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_union<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemUnion) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     _visitor.visit_visibility(&_i . vis);
     // Skipped field _i . union_token;
     // Skipped field _i . ident;
@@ -1383,6 +1396,7 @@ pub fn visit_item_union<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemUnion) {
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_use<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemUse) {
+    for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     _visitor.visit_visibility(&_i . vis);
     // Skipped field _i . use_token;
     _visitor.visit_view_path(&_i . path);

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -209,7 +209,7 @@ fn visit_item_foreign_mod_mut(&mut self, i: &mut ItemForeignMod) { visit_item_fo
 # [ cfg ( feature = "full" ) ]
 fn visit_item_impl_mut(&mut self, i: &mut ItemImpl) { visit_item_impl_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn visit_item_kind_mut(&mut self, i: &mut ItemKind) { visit_item_kind_mut(self, i) }
+fn visit_item_mac_mut(&mut self, i: &mut ItemMac) { visit_item_mac_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_item_mod_mut(&mut self, i: &mut ItemMod) { visit_item_mod_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -1203,77 +1203,7 @@ pub fn visit_in_place_kind_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mu
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Item) {
-    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
-    _visitor.visit_item_kind_mut(&mut _i . node);
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_const_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemConst) {
-    _visitor.visit_visibility_mut(&mut _i . vis);
-    // Skipped field _i . const_token;
-    // Skipped field _i . ident;
-    // Skipped field _i . colon_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
-    // Skipped field _i . eq_token;
-    _visitor.visit_expr_mut(&mut _i . expr);
-    // Skipped field _i . semi_token;
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_default_impl_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemDefaultImpl) {
-    _visitor.visit_unsafety_mut(&mut _i . unsafety);
-    // Skipped field _i . impl_token;
-    _visitor.visit_path_mut(&mut _i . path);
-    // Skipped field _i . for_token;
-    // Skipped field _i . dot2_token;
-    // Skipped field _i . brace_token;
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_enum_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemEnum) {
-    _visitor.visit_visibility_mut(&mut _i . vis);
-    // Skipped field _i . enum_token;
-    // Skipped field _i . ident;
-    _visitor.visit_generics_mut(&mut _i . generics);
-    // Skipped field _i . brace_token;
-    for mut el in (_i . variants).iter_mut() { let mut it = el.item_mut(); _visitor.visit_variant_mut(&mut it) };
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_extern_crate_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemExternCrate) {
-    _visitor.visit_visibility_mut(&mut _i . vis);
-    // Skipped field _i . extern_token;
-    // Skipped field _i . crate_token;
-    // Skipped field _i . ident;
-    // Skipped field _i . rename;
-    // Skipped field _i . semi_token;
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_fn_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemFn) {
-    _visitor.visit_visibility_mut(&mut _i . vis);
-    _visitor.visit_constness_mut(&mut _i . constness);
-    _visitor.visit_unsafety_mut(&mut _i . unsafety);
-    if let Some(ref mut it) = _i . abi { _visitor.visit_abi_mut(&mut * it) };
-    _visitor.visit_fn_decl_mut(&mut _i . decl);
-    // Skipped field _i . ident;
-    _visitor.visit_block_mut(&mut _i . block);
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_foreign_mod_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemForeignMod) {
-    _visitor.visit_abi_mut(&mut _i . abi);
-    // Skipped field _i . brace_token;
-    for mut it in (_i . items).iter_mut() { _visitor.visit_foreign_item_mut(&mut it) };
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_impl_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemImpl) {
-    _visitor.visit_defaultness_mut(&mut _i . defaultness);
-    _visitor.visit_unsafety_mut(&mut _i . unsafety);
-    // Skipped field _i . impl_token;
-    _visitor.visit_generics_mut(&mut _i . generics);
-    // Skipped field _i . trait_;
-    _visitor.visit_ty_mut(&mut _i . self_ty);
-    // Skipped field _i . brace_token;
-    for mut it in (_i . items).iter_mut() { _visitor.visit_impl_item_mut(&mut it) };
-}
-# [ cfg ( feature = "full" ) ]
-pub fn visit_item_kind_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemKind) {
-    use ::ItemKind::*;
+    use ::Item::*;
     match *_i {
         ExternCrate(ref mut _binding_0, ) => {
             _visitor.visit_item_extern_crate_mut(&mut * _binding_0);
@@ -1318,12 +1248,90 @@ pub fn visit_item_kind_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut It
             _visitor.visit_item_impl_mut(&mut * _binding_0);
         }
         Mac(ref mut _binding_0, ) => {
-            _visitor.visit_mac_mut(&mut * _binding_0);
+            _visitor.visit_item_mac_mut(&mut * _binding_0);
         }
     }
 }
 # [ cfg ( feature = "full" ) ]
+pub fn visit_item_const_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemConst) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
+    _visitor.visit_visibility_mut(&mut _i . vis);
+    // Skipped field _i . const_token;
+    // Skipped field _i . ident;
+    // Skipped field _i . colon_token;
+    _visitor.visit_ty_mut(&mut _i . ty);
+    // Skipped field _i . eq_token;
+    _visitor.visit_expr_mut(&mut _i . expr);
+    // Skipped field _i . semi_token;
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_default_impl_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemDefaultImpl) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
+    _visitor.visit_unsafety_mut(&mut _i . unsafety);
+    // Skipped field _i . impl_token;
+    _visitor.visit_path_mut(&mut _i . path);
+    // Skipped field _i . for_token;
+    // Skipped field _i . dot2_token;
+    // Skipped field _i . brace_token;
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_enum_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemEnum) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
+    _visitor.visit_visibility_mut(&mut _i . vis);
+    // Skipped field _i . enum_token;
+    // Skipped field _i . ident;
+    _visitor.visit_generics_mut(&mut _i . generics);
+    // Skipped field _i . brace_token;
+    for mut el in (_i . variants).iter_mut() { let mut it = el.item_mut(); _visitor.visit_variant_mut(&mut it) };
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_extern_crate_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemExternCrate) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
+    _visitor.visit_visibility_mut(&mut _i . vis);
+    // Skipped field _i . extern_token;
+    // Skipped field _i . crate_token;
+    // Skipped field _i . ident;
+    // Skipped field _i . rename;
+    // Skipped field _i . semi_token;
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_fn_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemFn) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
+    _visitor.visit_visibility_mut(&mut _i . vis);
+    _visitor.visit_constness_mut(&mut _i . constness);
+    _visitor.visit_unsafety_mut(&mut _i . unsafety);
+    if let Some(ref mut it) = _i . abi { _visitor.visit_abi_mut(&mut * it) };
+    _visitor.visit_fn_decl_mut(&mut _i . decl);
+    // Skipped field _i . ident;
+    _visitor.visit_block_mut(&mut _i . block);
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_foreign_mod_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemForeignMod) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
+    _visitor.visit_abi_mut(&mut _i . abi);
+    // Skipped field _i . brace_token;
+    for mut it in (_i . items).iter_mut() { _visitor.visit_foreign_item_mut(&mut it) };
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_impl_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemImpl) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
+    _visitor.visit_defaultness_mut(&mut _i . defaultness);
+    _visitor.visit_unsafety_mut(&mut _i . unsafety);
+    // Skipped field _i . impl_token;
+    _visitor.visit_generics_mut(&mut _i . generics);
+    // Skipped field _i . trait_;
+    _visitor.visit_ty_mut(&mut _i . self_ty);
+    // Skipped field _i . brace_token;
+    for mut it in (_i . items).iter_mut() { _visitor.visit_impl_item_mut(&mut it) };
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_item_mac_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemMac) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
+    _visitor.visit_mac_mut(&mut _i . mac);
+}
+# [ cfg ( feature = "full" ) ]
 pub fn visit_item_mod_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemMod) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     _visitor.visit_visibility_mut(&mut _i . vis);
     // Skipped field _i . mod_token;
     // Skipped field _i . ident;
@@ -1332,6 +1340,7 @@ pub fn visit_item_mod_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Ite
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_static_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemStatic) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     _visitor.visit_visibility_mut(&mut _i . vis);
     // Skipped field _i . static_token;
     _visitor.visit_mutability_mut(&mut _i . mutbl);
@@ -1344,6 +1353,7 @@ pub fn visit_item_static_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut 
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_struct_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemStruct) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     _visitor.visit_visibility_mut(&mut _i . vis);
     // Skipped field _i . struct_token;
     // Skipped field _i . ident;
@@ -1353,6 +1363,7 @@ pub fn visit_item_struct_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut 
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_trait_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemTrait) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     _visitor.visit_visibility_mut(&mut _i . vis);
     _visitor.visit_unsafety_mut(&mut _i . unsafety);
     // Skipped field _i . trait_token;
@@ -1365,6 +1376,7 @@ pub fn visit_item_trait_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut I
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemTy) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     _visitor.visit_visibility_mut(&mut _i . vis);
     // Skipped field _i . type_token;
     // Skipped field _i . ident;
@@ -1375,6 +1387,7 @@ pub fn visit_item_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Item
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_union_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemUnion) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     _visitor.visit_visibility_mut(&mut _i . vis);
     // Skipped field _i . union_token;
     // Skipped field _i . ident;
@@ -1383,6 +1396,7 @@ pub fn visit_item_union_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut I
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_use_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemUse) {
+    for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     _visitor.visit_visibility_mut(&mut _i . vis);
     // Skipped field _i . use_token;
     _visitor.visit_view_path_mut(&mut _i . path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,9 @@ pub use ident::Ident;
 mod item;
 #[cfg(feature = "full")]
 pub use item::{Constness, Defaultness, FnArg, FnDecl, ForeignItemKind, ForeignItem, ItemForeignMod,
-               ImplItem, ImplItemKind, ImplPolarity, Item, ItemKind, MethodSig, PathListItem,
+               ImplItem, ImplItemKind, ImplPolarity, Item, MethodSig, PathListItem,
                TraitItem, TraitItemKind, ViewPath, ItemExternCrate, ItemUse,
-               ItemStatic, ItemConst, ItemFn, ItemMod, ItemTy, ItemEnum,
+               ItemStatic, ItemConst, ItemFn, ItemMac, ItemMod, ItemTy, ItemEnum,
                ItemStruct, ItemUnion, ItemTrait, ItemDefaultImpl, ItemImpl,
                PathSimple, PathGlob, PathList, ForeignItemFn, ForeignItemStatic,
                TraitItemConst, TraitItemMethod, TraitItemType,

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -88,11 +88,11 @@ fn test_catch_expr() {
 
     let actual: File = syn::parse_str(raw).unwrap();
 
-    assert_let!(ItemKind::Struct(ItemStruct { ref ident, .. }) = actual.items[0].node; {
+    assert_let!(Item::Struct(ItemStruct { ref ident, .. }) = actual.items[0]; {
         assert_eq!(ident, "catch");
     });
 
-    assert_let!(Item { node: ItemKind::Fn(ItemFn { ref block, .. }), .. } = actual.items[1]; {
+    assert_let!(Item::Fn(ItemFn { ref block, .. }) = actual.items[1]; {
         assert_let!(Stmt::Local(ref local) = block.stmts[0]; {
             assert_let!(Local { init: Some(ref init_expr), .. } = **local; {
                 assert_let!(Expr { node: ExprKind::Catch(..), .. } = **init_expr);


### PR DESCRIPTION
Side note: this pattern is sort of nice:

```rust
let item: &Item = /* ... */;

match *item {
    Item::Mod(ref item) => {
        do_something_with(&item.ident, &item.content);
    }
    Item::Fn(ref item) => {
        do_something_with(&item.abi, &item.block);
    }
    /* ... */
}
```

Basically pattern matching on an `item` and rebinding the same name `item` just takes your variable and imbues it with those additional fields that exist on the type of item that it happens to be.