### PR TITLE
Rename Mac -> Macro

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -291,7 +291,7 @@ ast_enum_of_structs! {
         }),
 
         /// A macro invocation; pre-expansion
-        pub Mac(Mac),
+        pub Macro(Macro),
 
         /// A struct literal expression.
         ///
@@ -407,7 +407,7 @@ ast_enum! {
         Semi(Box<Expr>, tokens::Semi),
 
         /// Macro invocation.
-        Mac(Box<(Mac, MacStmtStyle, Vec<Attribute>)>),
+        Macro(Box<(Macro, MacStmtStyle, Vec<Attribute>)>),
     }
 }
 
@@ -537,7 +537,7 @@ ast_enum_of_structs! {
             pub bracket_token: tokens::Bracket,
         }),
         /// A macro pattern; pre-expansion
-        pub Mac(Mac),
+        pub Macro(Macro),
     }
 }
 
@@ -1160,7 +1160,7 @@ pub mod parsing {
         |
         syn!(ExprParen) => { ExprKind::Paren } // must be before expr_tup
         |
-        syn!(Mac) => { ExprKind::Mac } // must be before expr_path
+        syn!(Macro) => { ExprKind::Macro } // must be before expr_path
         |
         call!(expr_break, allow_struct) // must be before expr_path
         |
@@ -1213,7 +1213,7 @@ pub mod parsing {
         |
         syn!(ExprParen) => { ExprKind::Paren } // must be before expr_tup
         |
-        syn!(Mac) => { ExprKind::Mac } // must be before expr_path
+        syn!(Macro) => { ExprKind::Macro } // must be before expr_path
         |
         syn!(ExprPath) => { ExprKind::Path }
     ));
@@ -1846,8 +1846,8 @@ pub mod parsing {
     // expression statements
         data: braces!(syn!(TokenStream)) >>
         semi: option!(syn!(Semi)) >>
-        (Stmt::Mac(Box::new((
-            Mac {
+        (Stmt::Macro(Box::new((
+            Macro {
                 path: what,
                 bang_token: bang,
                 ident: None,
@@ -1930,7 +1930,7 @@ pub mod parsing {
             |
             syn!(PatStruct) => { Pat::Struct } // must be before pat_ident
             |
-            syn!(Mac) => { Pat::Mac } // must be before pat_ident
+            syn!(Macro) => { Pat::Macro } // must be before pat_ident
             |
             syn!(PatLit) => { Pat::Lit } // must be before pat_ident
             |
@@ -2959,7 +2959,7 @@ mod printing {
                     expr.to_tokens(tokens);
                     semi.to_tokens(tokens);
                 }
-                Stmt::Mac(ref mac) => {
+                Stmt::Macro(ref mac) => {
                     let (ref mac, ref style, ref attrs) = **mac;
                     tokens.append_all(attrs.outer());
                     mac.to_tokens(tokens);

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -236,7 +236,7 @@ fn fold_item_foreign_mod(&mut self, i: ItemForeignMod) -> ItemForeignMod { fold_
 # [ cfg ( feature = "full" ) ]
 fn fold_item_impl(&mut self, i: ItemImpl) -> ItemImpl { fold_item_impl(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn fold_item_mac(&mut self, i: ItemMac) -> ItemMac { fold_item_mac(self, i) }
+fn fold_item_macro(&mut self, i: ItemMacro) -> ItemMacro { fold_item_macro(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_item_mod(&mut self, i: ItemMod) -> ItemMod { fold_item_mod(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -255,10 +255,10 @@ fn fold_item_use(&mut self, i: ItemUse) -> ItemUse { fold_item_use(self, i) }
 fn fold_lifetime_def(&mut self, i: LifetimeDef) -> LifetimeDef { fold_lifetime_def(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_local(&mut self, i: Local) -> Local { fold_local(self, i) }
-
-fn fold_mac(&mut self, i: Mac) -> Mac { fold_mac(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_mac_stmt_style(&mut self, i: MacStmtStyle) -> MacStmtStyle { fold_mac_stmt_style(self, i) }
+
+fn fold_macro(&mut self, i: Macro) -> Macro { fold_macro(self, i) }
 
 fn fold_meta_item(&mut self, i: MetaItem) -> MetaItem { fold_meta_item(self, i) }
 
@@ -328,7 +328,7 @@ fn fold_trait_item(&mut self, i: TraitItem) -> TraitItem { fold_trait_item(self,
 # [ cfg ( feature = "full" ) ]
 fn fold_trait_item_const(&mut self, i: TraitItemConst) -> TraitItemConst { fold_trait_item_const(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn fold_trait_item_mac(&mut self, i: TraitItemMac) -> TraitItemMac { fold_trait_item_mac(self, i) }
+fn fold_trait_item_macro(&mut self, i: TraitItemMacro) -> TraitItemMacro { fold_trait_item_macro(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_trait_item_method(&mut self, i: TraitItemMethod) -> TraitItemMethod { fold_trait_item_method(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -1116,9 +1116,9 @@ pub fn fold_expr_kind<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprKind) -> Exp
                 full!(_visitor.fold_expr_ret(_binding_0)),
             )
         }
-        Mac(_binding_0, ) => {
-            Mac (
-                _visitor.fold_mac(_binding_0),
+        Macro(_binding_0, ) => {
+            Macro (
+                _visitor.fold_macro(_binding_0),
             )
         }
         Struct(_binding_0, ) => {
@@ -1488,7 +1488,7 @@ pub fn fold_impl_item_kind<V: Folder + ?Sized>(_visitor: &mut V, _i: ImplItemKin
         }
         Macro(_binding_0, ) => {
             Macro (
-                _visitor.fold_mac(_binding_0),
+                _visitor.fold_macro(_binding_0),
             )
         }
     }
@@ -1616,9 +1616,9 @@ pub fn fold_item<V: Folder + ?Sized>(_visitor: &mut V, _i: Item) -> Item {
                 _visitor.fold_item_impl(_binding_0),
             )
         }
-        Mac(_binding_0, ) => {
-            Mac (
-                _visitor.fold_item_mac(_binding_0),
+        Macro(_binding_0, ) => {
+            Macro (
+                _visitor.fold_item_macro(_binding_0),
             )
         }
     }
@@ -1710,10 +1710,10 @@ pub fn fold_item_impl<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemImpl) -> Ite
     }
 }
 # [ cfg ( feature = "full" ) ]
-pub fn fold_item_mac<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemMac) -> ItemMac {
-    ItemMac {
+pub fn fold_item_macro<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemMacro) -> ItemMacro {
+    ItemMacro {
         attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
-        mac: _visitor.fold_mac(_i . mac),
+        mac: _visitor.fold_macro(_i . mac),
     }
 }
 # [ cfg ( feature = "full" ) ]
@@ -1825,15 +1825,6 @@ pub fn fold_local<V: Folder + ?Sized>(_visitor: &mut V, _i: Local) -> Local {
         attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
     }
 }
-
-pub fn fold_mac<V: Folder + ?Sized>(_visitor: &mut V, _i: Mac) -> Mac {
-    Mac {
-        path: _visitor.fold_path(_i . path),
-        bang_token: _i . bang_token,
-        ident: _i . ident,
-        tokens: _i . tokens,
-    }
-}
 # [ cfg ( feature = "full" ) ]
 pub fn fold_mac_stmt_style<V: Folder + ?Sized>(_visitor: &mut V, _i: MacStmtStyle) -> MacStmtStyle {
     use ::MacStmtStyle::*;
@@ -1845,6 +1836,15 @@ pub fn fold_mac_stmt_style<V: Folder + ?Sized>(_visitor: &mut V, _i: MacStmtStyl
         }
         Braces => { Braces }
         NoBraces => { NoBraces }
+    }
+}
+
+pub fn fold_macro<V: Folder + ?Sized>(_visitor: &mut V, _i: Macro) -> Macro {
+    Macro {
+        path: _visitor.fold_path(_i . path),
+        bang_token: _i . bang_token,
+        ident: _i . ident,
+        tokens: _i . tokens,
     }
 }
 
@@ -1996,9 +1996,9 @@ pub fn fold_pat<V: Folder + ?Sized>(_visitor: &mut V, _i: Pat) -> Pat {
                 _visitor.fold_pat_slice(_binding_0),
             )
         }
-        Mac(_binding_0, ) => {
-            Mac (
-                _visitor.fold_mac(_binding_0),
+        Macro(_binding_0, ) => {
+            Macro (
+                _visitor.fold_macro(_binding_0),
             )
         }
     }
@@ -2213,8 +2213,8 @@ pub fn fold_stmt<V: Folder + ?Sized>(_visitor: &mut V, _i: Stmt) -> Stmt {
                 _binding_1,
             )
         }
-        Mac(_binding_0, ) => {
-            Mac (
+        Macro(_binding_0, ) => {
+            Macro (
                 _binding_0,
             )
         }
@@ -2253,7 +2253,7 @@ pub fn fold_trait_item<V: Folder + ?Sized>(_visitor: &mut V, _i: TraitItem) -> T
         }
         Macro(_binding_0, ) => {
             Macro (
-                _visitor.fold_trait_item_mac(_binding_0),
+                _visitor.fold_trait_item_macro(_binding_0),
             )
         }
     }
@@ -2271,10 +2271,10 @@ pub fn fold_trait_item_const<V: Folder + ?Sized>(_visitor: &mut V, _i: TraitItem
     }
 }
 # [ cfg ( feature = "full" ) ]
-pub fn fold_trait_item_mac<V: Folder + ?Sized>(_visitor: &mut V, _i: TraitItemMac) -> TraitItemMac {
-    TraitItemMac {
+pub fn fold_trait_item_macro<V: Folder + ?Sized>(_visitor: &mut V, _i: TraitItemMacro) -> TraitItemMacro {
+    TraitItemMacro {
         attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
-        mac: _visitor.fold_mac(_i . mac),
+        mac: _visitor.fold_macro(_i . mac),
     }
 }
 # [ cfg ( feature = "full" ) ]
@@ -2367,9 +2367,9 @@ pub fn fold_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: Ty) -> Ty {
                 _visitor.fold_ty_infer(_binding_0),
             )
         }
-        Mac(_binding_0, ) => {
-            Mac (
-                _visitor.fold_mac(_binding_0),
+        Macro(_binding_0, ) => {
+            Macro (
+                _visitor.fold_macro(_binding_0),
             )
         }
     }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -209,7 +209,7 @@ fn visit_item_foreign_mod(&mut self, i: &ItemForeignMod) { visit_item_foreign_mo
 # [ cfg ( feature = "full" ) ]
 fn visit_item_impl(&mut self, i: &ItemImpl) { visit_item_impl(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn visit_item_mac(&mut self, i: &ItemMac) { visit_item_mac(self, i) }
+fn visit_item_macro(&mut self, i: &ItemMacro) { visit_item_macro(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_item_mod(&mut self, i: &ItemMod) { visit_item_mod(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -228,10 +228,10 @@ fn visit_item_use(&mut self, i: &ItemUse) { visit_item_use(self, i) }
 fn visit_lifetime_def(&mut self, i: &LifetimeDef) { visit_lifetime_def(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_local(&mut self, i: &Local) { visit_local(self, i) }
-
-fn visit_mac(&mut self, i: &Mac) { visit_mac(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_mac_stmt_style(&mut self, i: &MacStmtStyle) { visit_mac_stmt_style(self, i) }
+
+fn visit_macro(&mut self, i: &Macro) { visit_macro(self, i) }
 
 fn visit_meta_item(&mut self, i: &MetaItem) { visit_meta_item(self, i) }
 
@@ -301,7 +301,7 @@ fn visit_trait_item(&mut self, i: &TraitItem) { visit_trait_item(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_trait_item_const(&mut self, i: &TraitItemConst) { visit_trait_item_const(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn visit_trait_item_mac(&mut self, i: &TraitItemMac) { visit_trait_item_mac(self, i) }
+fn visit_trait_item_macro(&mut self, i: &TraitItemMacro) { visit_trait_item_macro(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_trait_item_method(&mut self, i: &TraitItemMethod) { visit_trait_item_method(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -879,8 +879,8 @@ pub fn visit_expr_kind<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprKind) {
         Ret(ref _binding_0, ) => {
             full!(_visitor.visit_expr_ret(&* _binding_0));
         }
-        Mac(ref _binding_0, ) => {
-            _visitor.visit_mac(&* _binding_0);
+        Macro(ref _binding_0, ) => {
+            _visitor.visit_macro(&* _binding_0);
         }
         Struct(ref _binding_0, ) => {
             full!(_visitor.visit_expr_struct(&* _binding_0));
@@ -1158,7 +1158,7 @@ pub fn visit_impl_item_kind<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ImplItem
             _visitor.visit_impl_item_type(&* _binding_0);
         }
         Macro(ref _binding_0, ) => {
-            _visitor.visit_mac(&* _binding_0);
+            _visitor.visit_macro(&* _binding_0);
         }
     }
 }
@@ -1247,8 +1247,8 @@ pub fn visit_item<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Item) {
         Impl(ref _binding_0, ) => {
             _visitor.visit_item_impl(&* _binding_0);
         }
-        Mac(ref _binding_0, ) => {
-            _visitor.visit_item_mac(&* _binding_0);
+        Macro(ref _binding_0, ) => {
+            _visitor.visit_item_macro(&* _binding_0);
         }
     }
 }
@@ -1325,9 +1325,9 @@ pub fn visit_item_impl<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemImpl) {
     for it in (_i . items).iter() { _visitor.visit_impl_item(&it) };
 }
 # [ cfg ( feature = "full" ) ]
-pub fn visit_item_mac<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemMac) {
+pub fn visit_item_macro<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemMacro) {
     for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
-    _visitor.visit_mac(&_i . mac);
+    _visitor.visit_macro(&_i . mac);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_mod<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemMod) {
@@ -1420,13 +1420,6 @@ pub fn visit_local<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Local) {
     if let Some(ref it) = _i . init { _visitor.visit_expr(&* it) };
     for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
 }
-
-pub fn visit_mac<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Mac) {
-    _visitor.visit_path(&_i . path);
-    // Skipped field _i . bang_token;
-    // Skipped field _i . ident;
-    // Skipped field _i . tokens;
-}
 # [ cfg ( feature = "full" ) ]
 pub fn visit_mac_stmt_style<V: Visitor + ?Sized>(_visitor: &mut V, _i: &MacStmtStyle) {
     use ::MacStmtStyle::*;
@@ -1437,6 +1430,13 @@ pub fn visit_mac_stmt_style<V: Visitor + ?Sized>(_visitor: &mut V, _i: &MacStmtS
         Braces => { }
         NoBraces => { }
     }
+}
+
+pub fn visit_macro<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Macro) {
+    _visitor.visit_path(&_i . path);
+    // Skipped field _i . bang_token;
+    // Skipped field _i . ident;
+    // Skipped field _i . tokens;
 }
 
 pub fn visit_meta_item<V: Visitor + ?Sized>(_visitor: &mut V, _i: &MetaItem) {
@@ -1543,8 +1543,8 @@ pub fn visit_pat<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Pat) {
         Slice(ref _binding_0, ) => {
             _visitor.visit_pat_slice(&* _binding_0);
         }
-        Mac(ref _binding_0, ) => {
-            _visitor.visit_mac(&* _binding_0);
+        Macro(ref _binding_0, ) => {
+            _visitor.visit_macro(&* _binding_0);
         }
     }
 }
@@ -1704,7 +1704,7 @@ pub fn visit_stmt<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Stmt) {
             _visitor.visit_expr(&* _binding_0);
             // Skipped field * _binding_1;
         }
-        Mac(ref _binding_0, ) => {
+        Macro(ref _binding_0, ) => {
             // Skipped field * _binding_0;
         }
     }
@@ -1733,7 +1733,7 @@ pub fn visit_trait_item<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TraitItem) {
             _visitor.visit_trait_item_type(&* _binding_0);
         }
         Macro(ref _binding_0, ) => {
-            _visitor.visit_trait_item_mac(&* _binding_0);
+            _visitor.visit_trait_item_macro(&* _binding_0);
         }
     }
 }
@@ -1748,9 +1748,9 @@ pub fn visit_trait_item_const<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TraitI
     // Skipped field _i . semi_token;
 }
 # [ cfg ( feature = "full" ) ]
-pub fn visit_trait_item_mac<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TraitItemMac) {
+pub fn visit_trait_item_macro<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TraitItemMacro) {
     for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
-    _visitor.visit_mac(&_i . mac);
+    _visitor.visit_macro(&_i . mac);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_trait_item_method<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TraitItemMethod) {
@@ -1812,8 +1812,8 @@ pub fn visit_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Ty) {
         Infer(ref _binding_0, ) => {
             _visitor.visit_ty_infer(&* _binding_0);
         }
-        Mac(ref _binding_0, ) => {
-            _visitor.visit_mac(&* _binding_0);
+        Macro(ref _binding_0, ) => {
+            _visitor.visit_macro(&* _binding_0);
         }
     }
 }

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -209,7 +209,7 @@ fn visit_item_foreign_mod_mut(&mut self, i: &mut ItemForeignMod) { visit_item_fo
 # [ cfg ( feature = "full" ) ]
 fn visit_item_impl_mut(&mut self, i: &mut ItemImpl) { visit_item_impl_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn visit_item_mac_mut(&mut self, i: &mut ItemMac) { visit_item_mac_mut(self, i) }
+fn visit_item_macro_mut(&mut self, i: &mut ItemMacro) { visit_item_macro_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_item_mod_mut(&mut self, i: &mut ItemMod) { visit_item_mod_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -228,10 +228,10 @@ fn visit_item_use_mut(&mut self, i: &mut ItemUse) { visit_item_use_mut(self, i) 
 fn visit_lifetime_def_mut(&mut self, i: &mut LifetimeDef) { visit_lifetime_def_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_local_mut(&mut self, i: &mut Local) { visit_local_mut(self, i) }
-
-fn visit_mac_mut(&mut self, i: &mut Mac) { visit_mac_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_mac_stmt_style_mut(&mut self, i: &mut MacStmtStyle) { visit_mac_stmt_style_mut(self, i) }
+
+fn visit_macro_mut(&mut self, i: &mut Macro) { visit_macro_mut(self, i) }
 
 fn visit_meta_item_mut(&mut self, i: &mut MetaItem) { visit_meta_item_mut(self, i) }
 
@@ -301,7 +301,7 @@ fn visit_trait_item_mut(&mut self, i: &mut TraitItem) { visit_trait_item_mut(sel
 # [ cfg ( feature = "full" ) ]
 fn visit_trait_item_const_mut(&mut self, i: &mut TraitItemConst) { visit_trait_item_const_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn visit_trait_item_mac_mut(&mut self, i: &mut TraitItemMac) { visit_trait_item_mac_mut(self, i) }
+fn visit_trait_item_macro_mut(&mut self, i: &mut TraitItemMacro) { visit_trait_item_macro_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_trait_item_method_mut(&mut self, i: &mut TraitItemMethod) { visit_trait_item_method_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -879,8 +879,8 @@ pub fn visit_expr_kind_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Ex
         Ret(ref mut _binding_0, ) => {
             full!(_visitor.visit_expr_ret_mut(&mut * _binding_0));
         }
-        Mac(ref mut _binding_0, ) => {
-            _visitor.visit_mac_mut(&mut * _binding_0);
+        Macro(ref mut _binding_0, ) => {
+            _visitor.visit_macro_mut(&mut * _binding_0);
         }
         Struct(ref mut _binding_0, ) => {
             full!(_visitor.visit_expr_struct_mut(&mut * _binding_0));
@@ -1158,7 +1158,7 @@ pub fn visit_impl_item_kind_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &m
             _visitor.visit_impl_item_type_mut(&mut * _binding_0);
         }
         Macro(ref mut _binding_0, ) => {
-            _visitor.visit_mac_mut(&mut * _binding_0);
+            _visitor.visit_macro_mut(&mut * _binding_0);
         }
     }
 }
@@ -1247,8 +1247,8 @@ pub fn visit_item_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Item) {
         Impl(ref mut _binding_0, ) => {
             _visitor.visit_item_impl_mut(&mut * _binding_0);
         }
-        Mac(ref mut _binding_0, ) => {
-            _visitor.visit_item_mac_mut(&mut * _binding_0);
+        Macro(ref mut _binding_0, ) => {
+            _visitor.visit_item_macro_mut(&mut * _binding_0);
         }
     }
 }
@@ -1325,9 +1325,9 @@ pub fn visit_item_impl_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut It
     for mut it in (_i . items).iter_mut() { _visitor.visit_impl_item_mut(&mut it) };
 }
 # [ cfg ( feature = "full" ) ]
-pub fn visit_item_mac_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemMac) {
+pub fn visit_item_macro_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemMacro) {
     for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
-    _visitor.visit_mac_mut(&mut _i . mac);
+    _visitor.visit_macro_mut(&mut _i . mac);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_item_mod_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemMod) {
@@ -1420,13 +1420,6 @@ pub fn visit_local_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Local)
     if let Some(ref mut it) = _i . init { _visitor.visit_expr_mut(&mut * it) };
     for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
 }
-
-pub fn visit_mac_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Mac) {
-    _visitor.visit_path_mut(&mut _i . path);
-    // Skipped field _i . bang_token;
-    // Skipped field _i . ident;
-    // Skipped field _i . tokens;
-}
 # [ cfg ( feature = "full" ) ]
 pub fn visit_mac_stmt_style_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut MacStmtStyle) {
     use ::MacStmtStyle::*;
@@ -1437,6 +1430,13 @@ pub fn visit_mac_stmt_style_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &m
         Braces => { }
         NoBraces => { }
     }
+}
+
+pub fn visit_macro_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Macro) {
+    _visitor.visit_path_mut(&mut _i . path);
+    // Skipped field _i . bang_token;
+    // Skipped field _i . ident;
+    // Skipped field _i . tokens;
 }
 
 pub fn visit_meta_item_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut MetaItem) {
@@ -1543,8 +1543,8 @@ pub fn visit_pat_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Pat) {
         Slice(ref mut _binding_0, ) => {
             _visitor.visit_pat_slice_mut(&mut * _binding_0);
         }
-        Mac(ref mut _binding_0, ) => {
-            _visitor.visit_mac_mut(&mut * _binding_0);
+        Macro(ref mut _binding_0, ) => {
+            _visitor.visit_macro_mut(&mut * _binding_0);
         }
     }
 }
@@ -1704,7 +1704,7 @@ pub fn visit_stmt_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Stmt) {
             _visitor.visit_expr_mut(&mut * _binding_0);
             // Skipped field * _binding_1;
         }
-        Mac(ref mut _binding_0, ) => {
+        Macro(ref mut _binding_0, ) => {
             // Skipped field * _binding_0;
         }
     }
@@ -1733,7 +1733,7 @@ pub fn visit_trait_item_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut T
             _visitor.visit_trait_item_type_mut(&mut * _binding_0);
         }
         Macro(ref mut _binding_0, ) => {
-            _visitor.visit_trait_item_mac_mut(&mut * _binding_0);
+            _visitor.visit_trait_item_macro_mut(&mut * _binding_0);
         }
     }
 }
@@ -1748,9 +1748,9 @@ pub fn visit_trait_item_const_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: 
     // Skipped field _i . semi_token;
 }
 # [ cfg ( feature = "full" ) ]
-pub fn visit_trait_item_mac_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TraitItemMac) {
+pub fn visit_trait_item_macro_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TraitItemMacro) {
     for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
-    _visitor.visit_mac_mut(&mut _i . mac);
+    _visitor.visit_macro_mut(&mut _i . mac);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_trait_item_method_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TraitItemMethod) {
@@ -1812,8 +1812,8 @@ pub fn visit_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Ty) {
         Infer(ref mut _binding_0, ) => {
             _visitor.visit_ty_infer_mut(&mut * _binding_0);
         }
-        Mac(ref mut _binding_0, ) => {
-            _visitor.visit_mac_mut(&mut * _binding_0);
+        Macro(ref mut _binding_0, ) => {
+            _visitor.visit_macro_mut(&mut * _binding_0);
         }
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -182,9 +182,9 @@ ast_enum_of_structs! {
         /// A macro invocation (which includes macro definition).
         ///
         /// E.g. `macro_rules! foo { .. }` or `foo!(..)`
-        pub Mac(ItemMac {
+        pub Macro(ItemMacro {
             pub attrs: Vec<Attribute>,
-            pub mac: Mac,
+            pub mac: Macro,
         }),
     }
 
@@ -334,9 +334,9 @@ ast_enum_of_structs! {
             pub default: Option<(tokens::Eq, Ty)>,
             pub semi_token: tokens::Semi,
         }),
-        pub Macro(TraitItemMac {
+        pub Macro(TraitItemMacro {
             pub attrs: Vec<Attribute>,
-            pub mac: Mac,
+            pub mac: Macro,
         }),
     }
 
@@ -388,7 +388,7 @@ ast_enum_of_structs! {
             pub ty: Ty,
             pub semi_token: tokens::Semi,
         }),
-        pub Macro(Mac),
+        pub Macro(Macro),
     }
 
     do_not_generate_to_tokens
@@ -482,19 +482,19 @@ pub mod parsing {
         |
         syn!(ItemImpl) => { Item::Impl }
         |
-        syn!(ItemMac) => { Item::Mac }
+        syn!(ItemMacro) => { Item::Macro }
     ));
 
-    impl_synom!(ItemMac "macro item" do_parse!(
+    impl_synom!(ItemMacro "macro item" do_parse!(
         attrs: many0!(call!(Attribute::parse_outer)) >>
         what: syn!(Path) >>
         bang: syn!(Bang) >>
         ident: option!(syn!(Ident)) >>
         body: call!(::TokenTree::parse_delimited) >>
         cond!(!body.is_braced(), syn!(Semi)) >>
-        (ItemMac {
+        (ItemMacro {
             attrs: attrs,
-            mac: Mac {
+            mac: Macro {
                 path: what,
                 bang_token: bang,
                 ident: ident,
@@ -1010,7 +1010,7 @@ pub mod parsing {
         |
         syn!(TraitItemType) => { TraitItem::Type }
         |
-        syn!(TraitItemMac) => { TraitItem::Macro }
+        syn!(TraitItemMacro) => { TraitItem::Macro }
     ));
 
     impl_synom!(TraitItemConst "const trait item" do_parse!(
@@ -1109,11 +1109,11 @@ pub mod parsing {
         })
     ));
 
-    impl_synom!(TraitItemMac "trait item macro" do_parse!(
+    impl_synom!(TraitItemMacro "trait item macro" do_parse!(
         attrs: many0!(call!(Attribute::parse_outer)) >>
-        mac: syn!(Mac) >>
+        mac: syn!(Macro) >>
         cond!(!mac.is_braced(), syn!(Semi)) >>
-        (TraitItemMac {
+        (TraitItemMacro {
             attrs: attrs,
             mac: mac,
         })
@@ -1270,7 +1270,7 @@ pub mod parsing {
 
     named!(impl_item_mac -> ImplItem, do_parse!(
         attrs: many0!(call!(Attribute::parse_outer)) >>
-        mac: syn!(Mac) >>
+        mac: syn!(Macro) >>
         cond!(!mac.is_braced(), syn!(Semi)) >>
         (ImplItem {
             attrs: attrs,
@@ -1485,7 +1485,7 @@ mod printing {
                         tokens.append_all(&item.items);
                     });
                 }
-                Item::Mac(ref item) => {
+                Item::Macro(ref item) => {
                     tokens.append_all(item.attrs.outer());
                     item.mac.path.to_tokens(tokens);
                     item.mac.bang_token.to_tokens(tokens);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,10 @@ mod item;
 pub use item::{Constness, Defaultness, FnArg, FnDecl, ForeignItemKind, ForeignItem, ItemForeignMod,
                ImplItem, ImplItemKind, ImplPolarity, Item, MethodSig, PathListItem,
                TraitItem, ViewPath, ItemExternCrate, ItemUse,
-               ItemStatic, ItemConst, ItemFn, ItemMac, ItemMod, ItemTy, ItemEnum,
+               ItemStatic, ItemConst, ItemFn, ItemMacro, ItemMod, ItemTy, ItemEnum,
                ItemStruct, ItemUnion, ItemTrait, ItemDefaultImpl, ItemImpl,
                PathSimple, PathGlob, PathList, ForeignItemFn, ForeignItemStatic,
-               TraitItemConst, TraitItemMac, TraitItemMethod, TraitItemType,
+               TraitItemConst, TraitItemMacro, TraitItemMethod, TraitItemType,
                ImplItemConst, ImplItemMethod, ImplItemType, ArgSelfRef,
                ArgSelf, ArgCaptured};
 
@@ -74,7 +74,7 @@ mod lit;
 pub use lit::{Lit, LitKind};
 
 mod mac;
-pub use mac::{Mac, TokenTree};
+pub use mac::{Macro, TokenTree};
 
 mod derive;
 pub use derive::{Body, DeriveInput, BodyEnum, BodyStruct};

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -9,7 +9,7 @@ ast_struct! {
     /// Represents a macro invocation. The Path indicates which macro
     /// is being invoked, and the vector of token-trees contains the source
     /// of the macro invocation.
-    pub struct Mac {
+    pub struct Macro {
         pub path: Path,
         pub bang_token: tokens::Bang,
         /// The `example` in `macro_rules! example { ... }`.
@@ -21,7 +21,7 @@ ast_struct! {
 #[cfg_attr(feature = "clone-impls", derive(Clone))]
 pub struct TokenTree(pub proc_macro2::TokenTree);
 
-impl Mac {
+impl Macro {
     pub fn is_braced(&self) -> bool {
         match self.tokens.last() {
             Some(t) => t.is_braced(),
@@ -138,12 +138,12 @@ pub mod parsing {
     use synom::tokens::*;
     use synom::{Synom, PResult, Cursor, parse_error};
 
-    impl Synom for Mac {
+    impl Synom for Macro {
         named!(parse -> Self, do_parse!(
             what: syn!(Path) >>
             bang: syn!(Bang) >>
             body: call!(::TokenTree::parse_delimited) >>
-            (Mac {
+            (Macro {
                 path: what,
                 bang_token: bang,
                 ident: None,
@@ -173,7 +173,7 @@ mod printing {
     use super::*;
     use quote::{Tokens, ToTokens};
 
-    impl ToTokens for Mac {
+    impl ToTokens for Macro {
         fn to_tokens(&self, tokens: &mut Tokens) {
             self.path.to_tokens(tokens);
             self.bang_token.to_tokens(tokens);

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -77,7 +77,7 @@ ast_enum_of_structs! {
             pub underscore_token: tokens::Underscore
         }),
         /// A macro in the type position.
-        pub Mac(Mac),
+        pub Macro(Macro),
     }
 }
 
@@ -362,7 +362,7 @@ pub mod parsing {
         syn!(TyParen) => { Ty::Paren }
         |
         // must be before path
-        syn!(Mac) => { Ty::Mac }
+        syn!(Macro) => { Ty::Macro }
         |
         // must be before ty_poly_trait_ref
         call!(ty_path, allow_plus)

--- a/syn_codegen/src/main.rs
+++ b/syn_codegen/src/main.rs
@@ -114,7 +114,7 @@ fn load_file<P: AsRef<Path>>(
                 let path = parent.join(&format!("{}.rs", item.ident.as_ref()));
                 load_file(path, features, lookup)?;
             }
-            Item::Mac(ref item) => {
+            Item::Macro(ref item) => {
                 // Lookip any #[cfg()] attributes directly on the macro
                 // invocation, and add them to the feature set.
                 let features = get_features(&item.attrs, features.clone());


### PR DESCRIPTION
This is part of a move to standardize on abbreviating only those types in the AST that are abbreviated in Rust source code, like `impl` or `fn`. The grammar of Rust source code never abbreviates `macro` to `mac`, so this commit reflects that.

Field names are being kept as `mac` because `macro` is a reserved word.