### PR TITLE
Rename FunctionRetTy -> ReturnType

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1536,14 +1536,14 @@ pub mod parsing {
                 arrow: syn!(RArrow) >>
                 ty: syn!(Ty) >>
                 body: syn!(Block) >>
-                (FunctionRetTy::Ty(ty, arrow),
+                (ReturnType::Ty(ty, arrow),
                  ExprKind::Block(ExprBlock {
                     unsafety: Unsafety::Normal,
                     block: body,
                 }).into())
             )
             |
-            map!(ambiguous_expr!(allow_struct), |e| (FunctionRetTy::Default, e))
+            map!(ambiguous_expr!(allow_struct), |e| (ReturnType::Default, e))
         ) >>
         (ExprClosure {
             capture: capture,

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -200,8 +200,6 @@ fn fold_foreign_item_fn(&mut self, i: ForeignItemFn) -> ForeignItemFn { fold_for
 # [ cfg ( feature = "full" ) ]
 fn fold_foreign_item_static(&mut self, i: ForeignItemStatic) -> ForeignItemStatic { fold_foreign_item_static(self, i) }
 
-fn fold_function_ret_ty(&mut self, i: FunctionRetTy) -> FunctionRetTy { fold_function_ret_ty(self, i) }
-
 fn fold_generics(&mut self, i: Generics) -> Generics { fold_generics(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_impl_item(&mut self, i: ImplItem) -> ImplItem { fold_impl_item(self, i) }
@@ -317,6 +315,8 @@ fn fold_poly_trait_ref(&mut self, i: PolyTraitRef) -> PolyTraitRef { fold_poly_t
 fn fold_qself(&mut self, i: QSelf) -> QSelf { fold_qself(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_range_limits(&mut self, i: RangeLimits) -> RangeLimits { fold_range_limits(self, i) }
+
+fn fold_return_type(&mut self, i: ReturnType) -> ReturnType { fold_return_type(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_stmt(&mut self, i: Stmt) -> Stmt { fold_stmt(self, i) }
 
@@ -520,7 +520,7 @@ pub fn fold_bare_fn_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: BareFnTy) -> Ba
         paren_token: _i . paren_token,
         inputs: FoldHelper::lift(_i . inputs, |it| { _visitor.fold_bare_fn_arg(it) }),
         variadic: _i . variadic,
-        output: _visitor.fold_function_ret_ty(_i . output),
+        output: _visitor.fold_return_type(_i . output),
     }
 }
 
@@ -1374,7 +1374,7 @@ pub fn fold_fn_decl<V: Folder + ?Sized>(_visitor: &mut V, _i: FnDecl) -> FnDecl 
         fn_token: _i . fn_token,
         paren_token: _i . paren_token,
         inputs: FoldHelper::lift(_i . inputs, |it| { _visitor.fold_fn_arg(it) }),
-        output: _visitor.fold_function_ret_ty(_i . output),
+        output: _visitor.fold_return_type(_i . output),
         generics: _visitor.fold_generics(_i . generics),
         variadic: _i . variadic,
         dot_tokens: _i . dot_tokens,
@@ -1417,19 +1417,6 @@ pub fn fold_foreign_item_static<V: Folder + ?Sized>(_visitor: &mut V, _i: Foreig
         colon_token: _i . colon_token,
         ty: Box::new(_visitor.fold_ty(* _i . ty)),
         semi_token: _i . semi_token,
-    }
-}
-
-pub fn fold_function_ret_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: FunctionRetTy) -> FunctionRetTy {
-    use ::FunctionRetTy::*;
-    match _i {
-        Default => { Default }
-        Ty(_binding_0, _binding_1, ) => {
-            Ty (
-                _visitor.fold_ty(_binding_0),
-                _binding_1,
-            )
-        }
     }
 }
 
@@ -1933,7 +1920,7 @@ pub fn fold_parenthesized_parameter_data<V: Folder + ?Sized>(_visitor: &mut V, _
     ParenthesizedParameterData {
         paren_token: _i . paren_token,
         inputs: FoldHelper::lift(_i . inputs, |it| { _visitor.fold_ty(it) }),
-        output: _visitor.fold_function_ret_ty(_i . output),
+        output: _visitor.fold_return_type(_i . output),
     }
 }
 # [ cfg ( feature = "full" ) ]
@@ -2183,6 +2170,19 @@ pub fn fold_range_limits<V: Folder + ?Sized>(_visitor: &mut V, _i: RangeLimits) 
         Closed(_binding_0, ) => {
             Closed (
                 _binding_0,
+            )
+        }
+    }
+}
+
+pub fn fold_return_type<V: Folder + ?Sized>(_visitor: &mut V, _i: ReturnType) -> ReturnType {
+    use ::ReturnType::*;
+    match _i {
+        Default => { Default }
+        Ty(_binding_0, _binding_1, ) => {
+            Ty (
+                _visitor.fold_ty(_binding_0),
+                _binding_1,
             )
         }
     }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -173,8 +173,6 @@ fn visit_foreign_item_fn(&mut self, i: &ForeignItemFn) { visit_foreign_item_fn(s
 # [ cfg ( feature = "full" ) ]
 fn visit_foreign_item_static(&mut self, i: &ForeignItemStatic) { visit_foreign_item_static(self, i) }
 
-fn visit_function_ret_ty(&mut self, i: &FunctionRetTy) { visit_function_ret_ty(self, i) }
-
 fn visit_generics(&mut self, i: &Generics) { visit_generics(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_impl_item(&mut self, i: &ImplItem) { visit_impl_item(self, i) }
@@ -290,6 +288,8 @@ fn visit_poly_trait_ref(&mut self, i: &PolyTraitRef) { visit_poly_trait_ref(self
 fn visit_qself(&mut self, i: &QSelf) { visit_qself(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_range_limits(&mut self, i: &RangeLimits) { visit_range_limits(self, i) }
+
+fn visit_return_type(&mut self, i: &ReturnType) { visit_return_type(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_stmt(&mut self, i: &Stmt) { visit_stmt(self, i) }
 
@@ -468,7 +468,7 @@ pub fn visit_bare_fn_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &BareFnTy) {
     // Skipped field _i . paren_token;
     for el in (_i . inputs).iter() { let it = el.item(); _visitor.visit_bare_fn_arg(&it) };
     // Skipped field _i . variadic;
-    _visitor.visit_function_ret_ty(&_i . output);
+    _visitor.visit_return_type(&_i . output);
 }
 
 pub fn visit_bin_op<V: Visitor + ?Sized>(_visitor: &mut V, _i: &BinOp) {
@@ -1070,7 +1070,7 @@ pub fn visit_fn_decl<V: Visitor + ?Sized>(_visitor: &mut V, _i: &FnDecl) {
     // Skipped field _i . fn_token;
     // Skipped field _i . paren_token;
     for el in (_i . inputs).iter() { let it = el.item(); _visitor.visit_fn_arg(&it) };
-    _visitor.visit_function_ret_ty(&_i . output);
+    _visitor.visit_return_type(&_i . output);
     _visitor.visit_generics(&_i . generics);
     // Skipped field _i . variadic;
     // Skipped field _i . dot_tokens;
@@ -1105,17 +1105,6 @@ pub fn visit_foreign_item_static<V: Visitor + ?Sized>(_visitor: &mut V, _i: &For
     // Skipped field _i . colon_token;
     _visitor.visit_ty(&_i . ty);
     // Skipped field _i . semi_token;
-}
-
-pub fn visit_function_ret_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &FunctionRetTy) {
-    use ::FunctionRetTy::*;
-    match *_i {
-        Default => { }
-        Ty(ref _binding_0, ref _binding_1, ) => {
-            _visitor.visit_ty(&* _binding_0);
-            // Skipped field * _binding_1;
-        }
-    }
 }
 
 pub fn visit_generics<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Generics) {
@@ -1505,7 +1494,7 @@ pub fn visit_nested_meta_item<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Nested
 pub fn visit_parenthesized_parameter_data<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ParenthesizedParameterData) {
     // Skipped field _i . paren_token;
     for el in (_i . inputs).iter() { let it = el.item(); _visitor.visit_ty(&it) };
-    _visitor.visit_function_ret_ty(&_i . output);
+    _visitor.visit_return_type(&_i . output);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_pat<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Pat) {
@@ -1685,6 +1674,17 @@ pub fn visit_range_limits<V: Visitor + ?Sized>(_visitor: &mut V, _i: &RangeLimit
         }
         Closed(ref _binding_0, ) => {
             // Skipped field * _binding_0;
+        }
+    }
+}
+
+pub fn visit_return_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ReturnType) {
+    use ::ReturnType::*;
+    match *_i {
+        Default => { }
+        Ty(ref _binding_0, ref _binding_1, ) => {
+            _visitor.visit_ty(&* _binding_0);
+            // Skipped field * _binding_1;
         }
     }
 }

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -173,8 +173,6 @@ fn visit_foreign_item_fn_mut(&mut self, i: &mut ForeignItemFn) { visit_foreign_i
 # [ cfg ( feature = "full" ) ]
 fn visit_foreign_item_static_mut(&mut self, i: &mut ForeignItemStatic) { visit_foreign_item_static_mut(self, i) }
 
-fn visit_function_ret_ty_mut(&mut self, i: &mut FunctionRetTy) { visit_function_ret_ty_mut(self, i) }
-
 fn visit_generics_mut(&mut self, i: &mut Generics) { visit_generics_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_impl_item_mut(&mut self, i: &mut ImplItem) { visit_impl_item_mut(self, i) }
@@ -290,6 +288,8 @@ fn visit_poly_trait_ref_mut(&mut self, i: &mut PolyTraitRef) { visit_poly_trait_
 fn visit_qself_mut(&mut self, i: &mut QSelf) { visit_qself_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_range_limits_mut(&mut self, i: &mut RangeLimits) { visit_range_limits_mut(self, i) }
+
+fn visit_return_type_mut(&mut self, i: &mut ReturnType) { visit_return_type_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_stmt_mut(&mut self, i: &mut Stmt) { visit_stmt_mut(self, i) }
 
@@ -468,7 +468,7 @@ pub fn visit_bare_fn_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut B
     // Skipped field _i . paren_token;
     for mut el in (_i . inputs).iter_mut() { let mut it = el.item_mut(); _visitor.visit_bare_fn_arg_mut(&mut it) };
     // Skipped field _i . variadic;
-    _visitor.visit_function_ret_ty_mut(&mut _i . output);
+    _visitor.visit_return_type_mut(&mut _i . output);
 }
 
 pub fn visit_bin_op_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut BinOp) {
@@ -1070,7 +1070,7 @@ pub fn visit_fn_decl_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut FnDe
     // Skipped field _i . fn_token;
     // Skipped field _i . paren_token;
     for mut el in (_i . inputs).iter_mut() { let mut it = el.item_mut(); _visitor.visit_fn_arg_mut(&mut it) };
-    _visitor.visit_function_ret_ty_mut(&mut _i . output);
+    _visitor.visit_return_type_mut(&mut _i . output);
     _visitor.visit_generics_mut(&mut _i . generics);
     // Skipped field _i . variadic;
     // Skipped field _i . dot_tokens;
@@ -1105,17 +1105,6 @@ pub fn visit_foreign_item_static_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _
     // Skipped field _i . colon_token;
     _visitor.visit_ty_mut(&mut _i . ty);
     // Skipped field _i . semi_token;
-}
-
-pub fn visit_function_ret_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut FunctionRetTy) {
-    use ::FunctionRetTy::*;
-    match *_i {
-        Default => { }
-        Ty(ref mut _binding_0, ref mut _binding_1, ) => {
-            _visitor.visit_ty_mut(&mut * _binding_0);
-            // Skipped field * _binding_1;
-        }
-    }
 }
 
 pub fn visit_generics_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Generics) {
@@ -1505,7 +1494,7 @@ pub fn visit_nested_meta_item_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: 
 pub fn visit_parenthesized_parameter_data_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ParenthesizedParameterData) {
     // Skipped field _i . paren_token;
     for mut el in (_i . inputs).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_mut(&mut it) };
-    _visitor.visit_function_ret_ty_mut(&mut _i . output);
+    _visitor.visit_return_type_mut(&mut _i . output);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_pat_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Pat) {
@@ -1685,6 +1674,17 @@ pub fn visit_range_limits_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut
         }
         Closed(ref mut _binding_0, ) => {
             // Skipped field * _binding_0;
+        }
+    }
+}
+
+pub fn visit_return_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ReturnType) {
+    use ::ReturnType::*;
+    match *_i {
+        Default => { }
+        Ty(ref mut _binding_0, ref mut _binding_1, ) => {
+            _visitor.visit_ty_mut(&mut * _binding_0);
+            // Skipped field * _binding_1;
         }
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -405,7 +405,7 @@ ast_struct! {
         pub fn_token: tokens::Fn_,
         pub paren_token: tokens::Paren,
         pub inputs: Delimited<FnArg, tokens::Comma>,
-        pub output: FunctionRetTy,
+        pub output: ReturnType,
         pub generics: Generics,
         pub variadic: bool,
         pub dot_tokens: Option<tokens::Dot3>,
@@ -686,7 +686,7 @@ pub mod parsing {
         ident: syn!(Ident) >>
         generics: syn!(Generics) >>
         inputs: parens!(Delimited::parse_terminated) >>
-        ret: syn!(FunctionRetTy) >>
+        ret: syn!(ReturnType) >>
         where_clause: syn!(WhereClause) >>
         inner_attrs_stmts: braces!(tuple!(
             many0!(call!(Attribute::parse_inner)),
@@ -830,7 +830,7 @@ pub mod parsing {
                             option!(syn!(Dot3))) >>
             (args, variadic)
         )) >>
-        ret: syn!(FunctionRetTy) >>
+        ret: syn!(ReturnType) >>
         where_clause: syn!(WhereClause) >>
         semi: syn!(Semi) >>
         ({
@@ -1026,7 +1026,7 @@ pub mod parsing {
         ident: syn!(Ident) >>
         generics: syn!(Generics) >>
         inputs: parens!(call!(Delimited::parse_terminated)) >>
-        ret: syn!(FunctionRetTy) >>
+        ret: syn!(ReturnType) >>
         where_clause: syn!(WhereClause) >>
         body: option!(braces!(
             tuple!(many0!(call!(Attribute::parse_inner)),
@@ -1185,7 +1185,7 @@ pub mod parsing {
         ident: syn!(Ident) >>
         generics: syn!(Generics) >>
         inputs: parens!(call!(Delimited::parse_terminated)) >>
-        ret: syn!(FunctionRetTy) >>
+        ret: syn!(ReturnType) >>
         where_clause: syn!(WhereClause) >>
         inner_attrs_stmts: braces!(tuple!(
             many0!(call!(Attribute::parse_inner)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub use op::{BinOp, UnOp};
 
 mod ty;
 pub use ty::{Abi, AbiKind, AngleBracketedParameterData, BareFnArg, BareFnArgName, BareFnTy,
-             FunctionRetTy, MutTy, Mutability, ParenthesizedParameterData, Path,
+             ReturnType, MutTy, Mutability, ParenthesizedParameterData, Path,
              PathParameters, PathSegment, PolyTraitRef, QSelf, Ty, TypeBinding, Unsafety,
              TySlice, TyArray, TyPtr, TyRptr, TyBareFn, TyNever, TyTup, TyPath,
              TyTraitObject, TyImplTrait, TyParen, TyInfer, TyGroup};

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -227,7 +227,7 @@ ast_struct! {
         /// `(A, B)`
         pub inputs: Delimited<Ty, tokens::Comma>,
         /// `C`
-        pub output: FunctionRetTy,
+        pub output: ReturnType,
     }
 }
 
@@ -273,7 +273,7 @@ ast_struct! {
         pub paren_token: tokens::Paren,
         pub inputs: Delimited<BareFnArg, tokens::Comma>,
         pub variadic: Option<tokens::Dot3>,
-        pub output: FunctionRetTy,
+        pub output: ReturnType,
     }
 }
 
@@ -320,7 +320,7 @@ ast_enum! {
 }
 
 ast_enum! {
-    pub enum FunctionRetTy {
+    pub enum ReturnType {
         /// Return type is not specified.
         ///
         /// Functions default to `()` and
@@ -468,7 +468,7 @@ pub mod parsing {
                                                 syn!(Dot3))) >>
                 (inputs, variadic)
             )) >>
-            output: syn!(FunctionRetTy) >>
+            output: syn!(ReturnType) >>
             (TyBareFn {
                 ty: Box::new(BareFnTy {
                     unsafety: unsafety,
@@ -600,7 +600,7 @@ pub mod parsing {
     impl Synom for ParenthesizedParameterData {
         named!(parse -> Self, do_parse!(
             data: parens!(call!(Delimited::parse_terminated)) >>
-            output: syn!(FunctionRetTy) >>
+            output: syn!(ReturnType) >>
             (ParenthesizedParameterData {
                 paren_token: data.1,
                 inputs: data.0,
@@ -609,15 +609,15 @@ pub mod parsing {
         ));
     }
 
-    impl Synom for FunctionRetTy {
+    impl Synom for ReturnType {
         named!(parse -> Self, alt!(
             do_parse!(
                 arrow: syn!(RArrow) >>
                 ty: syn!(Ty) >>
-                (FunctionRetTy::Ty(ty, arrow))
+                (ReturnType::Ty(ty, arrow))
             )
             |
-            epsilon!() => { |_| FunctionRetTy::Default }
+            epsilon!() => { |_| ReturnType::Default }
         ));
     }
 
@@ -1061,11 +1061,11 @@ mod printing {
         }
     }
 
-    impl ToTokens for FunctionRetTy {
+    impl ToTokens for ReturnType {
         fn to_tokens(&self, tokens: &mut Tokens) {
             match *self {
-                FunctionRetTy::Default => {}
-                FunctionRetTy::Ty(ref ty, ref arrow) => {
+                ReturnType::Default => {}
+                ReturnType::Ty(ref ty, ref arrow) => {
                     arrow.to_tokens(tokens);
                     ty.to_tokens(tokens);
                 }


### PR DESCRIPTION
The FunctionRetTy naming was copied from libsyntax. The new name uses 2 fewer non-standard abbreviations (where standard means used in Rust source code, like `impl` or `mod`).