### PR TITLE
Rename Ty -> Type

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -70,7 +70,7 @@ ast_struct! {
         pub attrs: Vec<Attribute>,
 
         /// Type of the field.
-        pub ty: Ty,
+        pub ty: Type,
 
         pub colon_token: Option<Token![:]>,
     }
@@ -116,7 +116,7 @@ pub mod parsing {
             vis: syn!(Visibility) >>
             id: syn!(Ident) >>
             colon: punct!(:) >>
-            ty: syn!(Ty) >>
+            ty: syn!(Type) >>
             (Field {
                 ident: Some(id),
                 vis: vis,
@@ -129,7 +129,7 @@ pub mod parsing {
         named!(pub parse_tuple -> Self, do_parse!(
             attrs: many0!(call!(Attribute::parse_outer)) >>
             vis: syn!(Visibility) >>
-            ty: syn!(Ty) >>
+            ty: syn!(Type) >>
             (Field {
                 ident: None,
                 colon_token: None,

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -80,7 +80,7 @@ fn fold_bare_fn_arg(&mut self, i: BareFnArg) -> BareFnArg { fold_bare_fn_arg(sel
 
 fn fold_bare_fn_arg_name(&mut self, i: BareFnArgName) -> BareFnArgName { fold_bare_fn_arg_name(self, i) }
 
-fn fold_bare_fn_ty(&mut self, i: BareFnTy) -> BareFnTy { fold_bare_fn_ty(self, i) }
+fn fold_bare_fn_type(&mut self, i: BareFnType) -> BareFnType { fold_bare_fn_type(self, i) }
 
 fn fold_bin_op(&mut self, i: BinOp) -> BinOp { fold_bin_op(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -242,7 +242,7 @@ fn fold_item_struct(&mut self, i: ItemStruct) -> ItemStruct { fold_item_struct(s
 # [ cfg ( feature = "full" ) ]
 fn fold_item_trait(&mut self, i: ItemTrait) -> ItemTrait { fold_item_trait(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn fold_item_ty(&mut self, i: ItemTy) -> ItemTy { fold_item_ty(self, i) }
+fn fold_item_type(&mut self, i: ItemType) -> ItemType { fold_item_type(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_item_union(&mut self, i: ItemUnion) -> ItemUnion { fold_item_union(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -264,7 +264,7 @@ fn fold_meta_name_value(&mut self, i: MetaNameValue) -> MetaNameValue { fold_met
 # [ cfg ( feature = "full" ) ]
 fn fold_method_sig(&mut self, i: MethodSig) -> MethodSig { fold_method_sig(self, i) }
 
-fn fold_mut_ty(&mut self, i: MutTy) -> MutTy { fold_mut_ty(self, i) }
+fn fold_mut_type(&mut self, i: MutType) -> MutType { fold_mut_type(self, i) }
 
 fn fold_mutability(&mut self, i: Mutability) -> Mutability { fold_mutability(self, i) }
 
@@ -332,39 +332,39 @@ fn fold_trait_item_method(&mut self, i: TraitItemMethod) -> TraitItemMethod { fo
 # [ cfg ( feature = "full" ) ]
 fn fold_trait_item_type(&mut self, i: TraitItemType) -> TraitItemType { fold_trait_item_type(self, i) }
 
-fn fold_ty(&mut self, i: Ty) -> Ty { fold_ty(self, i) }
+fn fold_type(&mut self, i: Type) -> Type { fold_type(self, i) }
 
-fn fold_ty_array(&mut self, i: TyArray) -> TyArray { fold_ty_array(self, i) }
+fn fold_type_array(&mut self, i: TypeArray) -> TypeArray { fold_type_array(self, i) }
 
-fn fold_ty_bare_fn(&mut self, i: TyBareFn) -> TyBareFn { fold_ty_bare_fn(self, i) }
-
-fn fold_ty_group(&mut self, i: TyGroup) -> TyGroup { fold_ty_group(self, i) }
-
-fn fold_ty_impl_trait(&mut self, i: TyImplTrait) -> TyImplTrait { fold_ty_impl_trait(self, i) }
-
-fn fold_ty_infer(&mut self, i: TyInfer) -> TyInfer { fold_ty_infer(self, i) }
-
-fn fold_ty_never(&mut self, i: TyNever) -> TyNever { fold_ty_never(self, i) }
-
-fn fold_ty_param(&mut self, i: TyParam) -> TyParam { fold_ty_param(self, i) }
-
-fn fold_ty_param_bound(&mut self, i: TyParamBound) -> TyParamBound { fold_ty_param_bound(self, i) }
-
-fn fold_ty_paren(&mut self, i: TyParen) -> TyParen { fold_ty_paren(self, i) }
-
-fn fold_ty_path(&mut self, i: TyPath) -> TyPath { fold_ty_path(self, i) }
-
-fn fold_ty_ptr(&mut self, i: TyPtr) -> TyPtr { fold_ty_ptr(self, i) }
-
-fn fold_ty_rptr(&mut self, i: TyRptr) -> TyRptr { fold_ty_rptr(self, i) }
-
-fn fold_ty_slice(&mut self, i: TySlice) -> TySlice { fold_ty_slice(self, i) }
-
-fn fold_ty_trait_object(&mut self, i: TyTraitObject) -> TyTraitObject { fold_ty_trait_object(self, i) }
-
-fn fold_ty_tup(&mut self, i: TyTup) -> TyTup { fold_ty_tup(self, i) }
+fn fold_type_bare_fn(&mut self, i: TypeBareFn) -> TypeBareFn { fold_type_bare_fn(self, i) }
 
 fn fold_type_binding(&mut self, i: TypeBinding) -> TypeBinding { fold_type_binding(self, i) }
+
+fn fold_type_group(&mut self, i: TypeGroup) -> TypeGroup { fold_type_group(self, i) }
+
+fn fold_type_impl_trait(&mut self, i: TypeImplTrait) -> TypeImplTrait { fold_type_impl_trait(self, i) }
+
+fn fold_type_infer(&mut self, i: TypeInfer) -> TypeInfer { fold_type_infer(self, i) }
+
+fn fold_type_never(&mut self, i: TypeNever) -> TypeNever { fold_type_never(self, i) }
+
+fn fold_type_param(&mut self, i: TypeParam) -> TypeParam { fold_type_param(self, i) }
+
+fn fold_type_param_bound(&mut self, i: TypeParamBound) -> TypeParamBound { fold_type_param_bound(self, i) }
+
+fn fold_type_paren(&mut self, i: TypeParen) -> TypeParen { fold_type_paren(self, i) }
+
+fn fold_type_path(&mut self, i: TypePath) -> TypePath { fold_type_path(self, i) }
+
+fn fold_type_ptr(&mut self, i: TypePtr) -> TypePtr { fold_type_ptr(self, i) }
+
+fn fold_type_rptr(&mut self, i: TypeRptr) -> TypeRptr { fold_type_rptr(self, i) }
+
+fn fold_type_slice(&mut self, i: TypeSlice) -> TypeSlice { fold_type_slice(self, i) }
+
+fn fold_type_trait_object(&mut self, i: TypeTraitObject) -> TypeTraitObject { fold_type_trait_object(self, i) }
+
+fn fold_type_tup(&mut self, i: TypeTup) -> TypeTup { fold_type_tup(self, i) }
 
 fn fold_un_op(&mut self, i: UnOp) -> UnOp { fold_un_op(self, i) }
 
@@ -423,7 +423,7 @@ pub fn fold_angle_bracketed_parameter_data<V: Folder + ?Sized>(_visitor: &mut V,
         turbofish: _i . turbofish,
         lt_token: _i . lt_token,
         lifetimes: _i . lifetimes,
-        types: FoldHelper::lift(_i . types, |it| { _visitor.fold_ty(it) }),
+        types: FoldHelper::lift(_i . types, |it| { _visitor.fold_type(it) }),
         bindings: FoldHelper::lift(_i . bindings, |it| { _visitor.fold_type_binding(it) }),
         gt_token: _i . gt_token,
     }
@@ -433,7 +433,7 @@ pub fn fold_arg_captured<V: Folder + ?Sized>(_visitor: &mut V, _i: ArgCaptured) 
     ArgCaptured {
         pat: _visitor.fold_pat(_i . pat),
         colon_token: _i . colon_token,
-        ty: _visitor.fold_ty(_i . ty),
+        ty: _visitor.fold_type(_i . ty),
     }
 }
 # [ cfg ( feature = "full" ) ]
@@ -491,7 +491,7 @@ pub fn fold_attribute<V: Folder + ?Sized>(_visitor: &mut V, _i: Attribute) -> At
 pub fn fold_bare_fn_arg<V: Folder + ?Sized>(_visitor: &mut V, _i: BareFnArg) -> BareFnArg {
     BareFnArg {
         name: _i . name,
-        ty: _visitor.fold_ty(_i . ty),
+        ty: _visitor.fold_type(_i . ty),
     }
 }
 
@@ -511,8 +511,8 @@ pub fn fold_bare_fn_arg_name<V: Folder + ?Sized>(_visitor: &mut V, _i: BareFnArg
     }
 }
 
-pub fn fold_bare_fn_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: BareFnTy) -> BareFnTy {
-    BareFnTy {
+pub fn fold_bare_fn_type<V: Folder + ?Sized>(_visitor: &mut V, _i: BareFnType) -> BareFnType {
+    BareFnType {
         lifetimes: (_i . lifetimes).map(|it| { _visitor.fold_bound_lifetimes(it) }),
         unsafety: _visitor.fold_unsafety(_i . unsafety),
         abi: (_i . abi).map(|it| { _visitor.fold_abi(it) }),
@@ -861,7 +861,7 @@ pub fn fold_expr_cast<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprCast) -> Exp
     ExprCast {
         expr: Box::new(_visitor.fold_expr(* _i . expr)),
         as_token: _i . as_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
     }
 }
 # [ cfg ( feature = "full" ) ]
@@ -1179,7 +1179,7 @@ pub fn fold_expr_method_call<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprMetho
     ExprMethodCall {
         expr: Box::new(_visitor.fold_expr(* _i . expr)),
         method: _i . method,
-        typarams: FoldHelper::lift(_i . typarams, |it| { _visitor.fold_ty(it) }),
+        typarams: FoldHelper::lift(_i . typarams, |it| { _visitor.fold_type(it) }),
         args: FoldHelper::lift(_i . args, |it| { _visitor.fold_expr(it) }),
         paren_token: _i . paren_token,
         dot_token: _i . dot_token,
@@ -1264,7 +1264,7 @@ pub fn fold_expr_type<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprType) -> Exp
     ExprType {
         expr: Box::new(_visitor.fold_expr(* _i . expr)),
         colon_token: _i . colon_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
     }
 }
 
@@ -1310,7 +1310,7 @@ pub fn fold_field<V: Folder + ?Sized>(_visitor: &mut V, _i: Field) -> Field {
         ident: _i . ident,
         vis: _visitor.fold_visibility(_i . vis),
         attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
-        ty: _visitor.fold_ty(_i . ty),
+        ty: _visitor.fold_type(_i . ty),
         colon_token: _i . colon_token,
     }
 }
@@ -1363,7 +1363,7 @@ pub fn fold_fn_arg<V: Folder + ?Sized>(_visitor: &mut V, _i: FnArg) -> FnArg {
         }
         Ignored(_binding_0, ) => {
             Ignored (
-                _visitor.fold_ty(_binding_0),
+                _visitor.fold_type(_binding_0),
             )
         }
     }
@@ -1415,7 +1415,7 @@ pub fn fold_foreign_item_static<V: Folder + ?Sized>(_visitor: &mut V, _i: Foreig
         mutbl: _visitor.fold_mutability(_i . mutbl),
         ident: _i . ident,
         colon_token: _i . colon_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
         semi_token: _i . semi_token,
     }
 }
@@ -1425,7 +1425,7 @@ pub fn fold_generics<V: Folder + ?Sized>(_visitor: &mut V, _i: Generics) -> Gene
         lt_token: _i . lt_token,
         gt_token: _i . gt_token,
         lifetimes: FoldHelper::lift(_i . lifetimes, |it| { _visitor.fold_lifetime_def(it) }),
-        ty_params: FoldHelper::lift(_i . ty_params, |it| { _visitor.fold_ty_param(it) }),
+        ty_params: FoldHelper::lift(_i . ty_params, |it| { _visitor.fold_type_param(it) }),
         where_clause: _visitor.fold_where_clause(_i . where_clause),
     }
 }
@@ -1464,7 +1464,7 @@ pub fn fold_impl_item_const<V: Folder + ?Sized>(_visitor: &mut V, _i: ImplItemCo
         const_token: _i . const_token,
         ident: _i . ident,
         colon_token: _i . colon_token,
-        ty: _visitor.fold_ty(_i . ty),
+        ty: _visitor.fold_type(_i . ty),
         eq_token: _i . eq_token,
         expr: _visitor.fold_expr(_i . expr),
         semi_token: _i . semi_token,
@@ -1496,7 +1496,7 @@ pub fn fold_impl_item_type<V: Folder + ?Sized>(_visitor: &mut V, _i: ImplItemTyp
         type_token: _i . type_token,
         ident: _i . ident,
         eq_token: _i . eq_token,
-        ty: _visitor.fold_ty(_i . ty),
+        ty: _visitor.fold_type(_i . ty),
         semi_token: _i . semi_token,
     }
 }
@@ -1567,9 +1567,9 @@ pub fn fold_item<V: Folder + ?Sized>(_visitor: &mut V, _i: Item) -> Item {
                 _visitor.fold_item_foreign_mod(_binding_0),
             )
         }
-        Ty(_binding_0, ) => {
-            Ty (
-                _visitor.fold_item_ty(_binding_0),
+        Type(_binding_0, ) => {
+            Type (
+                _visitor.fold_item_type(_binding_0),
             )
         }
         Enum(_binding_0, ) => {
@@ -1617,7 +1617,7 @@ pub fn fold_item_const<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemConst) -> I
         const_token: _i . const_token,
         ident: _i . ident,
         colon_token: _i . colon_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
         eq_token: _i . eq_token,
         expr: Box::new(_visitor.fold_expr(* _i . expr)),
         semi_token: _i . semi_token,
@@ -1690,7 +1690,7 @@ pub fn fold_item_impl<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemImpl) -> Ite
         impl_token: _i . impl_token,
         generics: _visitor.fold_generics(_i . generics),
         trait_: _i . trait_,
-        self_ty: Box::new(_visitor.fold_ty(* _i . self_ty)),
+        self_ty: Box::new(_visitor.fold_type(* _i . self_ty)),
         brace_token: _i . brace_token,
         items: FoldHelper::lift(_i . items, |it| { _visitor.fold_impl_item(it) }),
     }
@@ -1723,7 +1723,7 @@ pub fn fold_item_static<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemStatic) ->
         mutbl: _visitor.fold_mutability(_i . mutbl),
         ident: _i . ident,
         colon_token: _i . colon_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
         eq_token: _i . eq_token,
         expr: Box::new(_visitor.fold_expr(* _i . expr)),
         semi_token: _i . semi_token,
@@ -1751,21 +1751,21 @@ pub fn fold_item_trait<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemTrait) -> I
         ident: _i . ident,
         generics: _visitor.fold_generics(_i . generics),
         colon_token: _i . colon_token,
-        supertraits: FoldHelper::lift(_i . supertraits, |it| { _visitor.fold_ty_param_bound(it) }),
+        supertraits: FoldHelper::lift(_i . supertraits, |it| { _visitor.fold_type_param_bound(it) }),
         brace_token: _i . brace_token,
         items: FoldHelper::lift(_i . items, |it| { _visitor.fold_trait_item(it) }),
     }
 }
 # [ cfg ( feature = "full" ) ]
-pub fn fold_item_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemTy) -> ItemTy {
-    ItemTy {
+pub fn fold_item_type<V: Folder + ?Sized>(_visitor: &mut V, _i: ItemType) -> ItemType {
+    ItemType {
         attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         vis: _visitor.fold_visibility(_i . vis),
         type_token: _i . type_token,
         ident: _i . ident,
         generics: _visitor.fold_generics(_i . generics),
         eq_token: _i . eq_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
         semi_token: _i . semi_token,
     }
 }
@@ -1807,7 +1807,7 @@ pub fn fold_local<V: Folder + ?Sized>(_visitor: &mut V, _i: Local) -> Local {
         eq_token: _i . eq_token,
         semi_token: _i . semi_token,
         pat: Box::new(_visitor.fold_pat(* _i . pat)),
-        ty: (_i . ty).map(|it| { Box::new(_visitor.fold_ty(* it)) }),
+        ty: (_i . ty).map(|it| { Box::new(_visitor.fold_type(* it)) }),
         init: (_i . init).map(|it| { Box::new(_visitor.fold_expr(* it)) }),
         attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
     }
@@ -1881,9 +1881,9 @@ pub fn fold_method_sig<V: Folder + ?Sized>(_visitor: &mut V, _i: MethodSig) -> M
     }
 }
 
-pub fn fold_mut_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: MutTy) -> MutTy {
-    MutTy {
-        ty: _visitor.fold_ty(_i . ty),
+pub fn fold_mut_type<V: Folder + ?Sized>(_visitor: &mut V, _i: MutType) -> MutType {
+    MutType {
+        ty: _visitor.fold_type(_i . ty),
         mutability: _visitor.fold_mutability(_i . mutability),
     }
 }
@@ -1919,7 +1919,7 @@ pub fn fold_nested_meta_item<V: Folder + ?Sized>(_visitor: &mut V, _i: NestedMet
 pub fn fold_parenthesized_parameter_data<V: Folder + ?Sized>(_visitor: &mut V, _i: ParenthesizedParameterData) -> ParenthesizedParameterData {
     ParenthesizedParameterData {
         paren_token: _i . paren_token,
-        inputs: FoldHelper::lift(_i . inputs, |it| { _visitor.fold_ty(it) }),
+        inputs: FoldHelper::lift(_i . inputs, |it| { _visitor.fold_type(it) }),
         output: _visitor.fold_return_type(_i . output),
     }
 }
@@ -2152,7 +2152,7 @@ pub fn fold_poly_trait_ref<V: Folder + ?Sized>(_visitor: &mut V, _i: PolyTraitRe
 pub fn fold_qself<V: Folder + ?Sized>(_visitor: &mut V, _i: QSelf) -> QSelf {
     QSelf {
         lt_token: _i . lt_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
         position: _i . position,
         as_token: _i . as_token,
         gt_token: _i . gt_token,
@@ -2179,9 +2179,9 @@ pub fn fold_return_type<V: Folder + ?Sized>(_visitor: &mut V, _i: ReturnType) ->
     use ::ReturnType::*;
     match _i {
         Default => { Default }
-        Ty(_binding_0, _binding_1, ) => {
-            Ty (
-                _visitor.fold_ty(_binding_0),
+        Type(_binding_0, _binding_1, ) => {
+            Type (
+                _visitor.fold_type(_binding_0),
                 _binding_1,
             )
         }
@@ -2264,7 +2264,7 @@ pub fn fold_trait_item_const<V: Folder + ?Sized>(_visitor: &mut V, _i: TraitItem
         const_token: _i . const_token,
         ident: _i . ident,
         colon_token: _i . colon_token,
-        ty: _visitor.fold_ty(_i . ty),
+        ty: _visitor.fold_type(_i . ty),
         default: _i . default,
         semi_token: _i . semi_token,
     }
@@ -2292,78 +2292,78 @@ pub fn fold_trait_item_type<V: Folder + ?Sized>(_visitor: &mut V, _i: TraitItemT
         type_token: _i . type_token,
         ident: _i . ident,
         colon_token: _i . colon_token,
-        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_ty_param_bound(it) }),
+        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_type_param_bound(it) }),
         default: _i . default,
         semi_token: _i . semi_token,
     }
 }
 
-pub fn fold_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: Ty) -> Ty {
-    use ::Ty::*;
+pub fn fold_type<V: Folder + ?Sized>(_visitor: &mut V, _i: Type) -> Type {
+    use ::Type::*;
     match _i {
         Slice(_binding_0, ) => {
             Slice (
-                _visitor.fold_ty_slice(_binding_0),
+                _visitor.fold_type_slice(_binding_0),
             )
         }
         Array(_binding_0, ) => {
             Array (
-                _visitor.fold_ty_array(_binding_0),
+                _visitor.fold_type_array(_binding_0),
             )
         }
         Ptr(_binding_0, ) => {
             Ptr (
-                _visitor.fold_ty_ptr(_binding_0),
+                _visitor.fold_type_ptr(_binding_0),
             )
         }
         Rptr(_binding_0, ) => {
             Rptr (
-                _visitor.fold_ty_rptr(_binding_0),
+                _visitor.fold_type_rptr(_binding_0),
             )
         }
         BareFn(_binding_0, ) => {
             BareFn (
-                _visitor.fold_ty_bare_fn(_binding_0),
+                _visitor.fold_type_bare_fn(_binding_0),
             )
         }
         Never(_binding_0, ) => {
             Never (
-                _visitor.fold_ty_never(_binding_0),
+                _visitor.fold_type_never(_binding_0),
             )
         }
         Tup(_binding_0, ) => {
             Tup (
-                _visitor.fold_ty_tup(_binding_0),
+                _visitor.fold_type_tup(_binding_0),
             )
         }
         Path(_binding_0, ) => {
             Path (
-                _visitor.fold_ty_path(_binding_0),
+                _visitor.fold_type_path(_binding_0),
             )
         }
         TraitObject(_binding_0, ) => {
             TraitObject (
-                _visitor.fold_ty_trait_object(_binding_0),
+                _visitor.fold_type_trait_object(_binding_0),
             )
         }
         ImplTrait(_binding_0, ) => {
             ImplTrait (
-                _visitor.fold_ty_impl_trait(_binding_0),
+                _visitor.fold_type_impl_trait(_binding_0),
             )
         }
         Paren(_binding_0, ) => {
             Paren (
-                _visitor.fold_ty_paren(_binding_0),
+                _visitor.fold_type_paren(_binding_0),
             )
         }
         Group(_binding_0, ) => {
             Group (
-                _visitor.fold_ty_group(_binding_0),
+                _visitor.fold_type_group(_binding_0),
             )
         }
         Infer(_binding_0, ) => {
             Infer (
-                _visitor.fold_ty_infer(_binding_0),
+                _visitor.fold_type_infer(_binding_0),
             )
         }
         Macro(_binding_0, ) => {
@@ -2374,60 +2374,68 @@ pub fn fold_ty<V: Folder + ?Sized>(_visitor: &mut V, _i: Ty) -> Ty {
     }
 }
 
-pub fn fold_ty_array<V: Folder + ?Sized>(_visitor: &mut V, _i: TyArray) -> TyArray {
-    TyArray {
+pub fn fold_type_array<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeArray) -> TypeArray {
+    TypeArray {
         bracket_token: _i . bracket_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
         semi_token: _i . semi_token,
         amt: _visitor.fold_expr(_i . amt),
     }
 }
 
-pub fn fold_ty_bare_fn<V: Folder + ?Sized>(_visitor: &mut V, _i: TyBareFn) -> TyBareFn {
-    TyBareFn {
-        ty: Box::new(_visitor.fold_bare_fn_ty(* _i . ty)),
+pub fn fold_type_bare_fn<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeBareFn) -> TypeBareFn {
+    TypeBareFn {
+        ty: Box::new(_visitor.fold_bare_fn_type(* _i . ty)),
     }
 }
 
-pub fn fold_ty_group<V: Folder + ?Sized>(_visitor: &mut V, _i: TyGroup) -> TyGroup {
-    TyGroup {
+pub fn fold_type_binding<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeBinding) -> TypeBinding {
+    TypeBinding {
+        ident: _i . ident,
+        eq_token: _i . eq_token,
+        ty: _visitor.fold_type(_i . ty),
+    }
+}
+
+pub fn fold_type_group<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeGroup) -> TypeGroup {
+    TypeGroup {
         group_token: _i . group_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
     }
 }
 
-pub fn fold_ty_impl_trait<V: Folder + ?Sized>(_visitor: &mut V, _i: TyImplTrait) -> TyImplTrait {
-    TyImplTrait {
+pub fn fold_type_impl_trait<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeImplTrait) -> TypeImplTrait {
+    TypeImplTrait {
         impl_token: _i . impl_token,
-        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_ty_param_bound(it) }),
+        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_type_param_bound(it) }),
     }
 }
 
-pub fn fold_ty_infer<V: Folder + ?Sized>(_visitor: &mut V, _i: TyInfer) -> TyInfer {
-    TyInfer {
+pub fn fold_type_infer<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeInfer) -> TypeInfer {
+    TypeInfer {
         underscore_token: _i . underscore_token,
     }
 }
 
-pub fn fold_ty_never<V: Folder + ?Sized>(_visitor: &mut V, _i: TyNever) -> TyNever {
-    TyNever {
+pub fn fold_type_never<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeNever) -> TypeNever {
+    TypeNever {
         bang_token: _i . bang_token,
     }
 }
 
-pub fn fold_ty_param<V: Folder + ?Sized>(_visitor: &mut V, _i: TyParam) -> TyParam {
-    TyParam {
+pub fn fold_type_param<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeParam) -> TypeParam {
+    TypeParam {
         attrs: FoldHelper::lift(_i . attrs, |it| { _visitor.fold_attribute(it) }),
         ident: _i . ident,
         colon_token: _i . colon_token,
-        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_ty_param_bound(it) }),
+        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_type_param_bound(it) }),
         eq_token: _i . eq_token,
-        default: (_i . default).map(|it| { _visitor.fold_ty(it) }),
+        default: (_i . default).map(|it| { _visitor.fold_type(it) }),
     }
 }
 
-pub fn fold_ty_param_bound<V: Folder + ?Sized>(_visitor: &mut V, _i: TyParamBound) -> TyParamBound {
-    use ::TyParamBound::*;
+pub fn fold_type_param_bound<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeParamBound) -> TypeParamBound {
+    use ::TypeParamBound::*;
     match _i {
         Trait(_binding_0, _binding_1, ) => {
             Trait (
@@ -2443,62 +2451,54 @@ pub fn fold_ty_param_bound<V: Folder + ?Sized>(_visitor: &mut V, _i: TyParamBoun
     }
 }
 
-pub fn fold_ty_paren<V: Folder + ?Sized>(_visitor: &mut V, _i: TyParen) -> TyParen {
-    TyParen {
+pub fn fold_type_paren<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeParen) -> TypeParen {
+    TypeParen {
         paren_token: _i . paren_token,
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
     }
 }
 
-pub fn fold_ty_path<V: Folder + ?Sized>(_visitor: &mut V, _i: TyPath) -> TyPath {
-    TyPath {
+pub fn fold_type_path<V: Folder + ?Sized>(_visitor: &mut V, _i: TypePath) -> TypePath {
+    TypePath {
         qself: (_i . qself).map(|it| { _visitor.fold_qself(it) }),
         path: _visitor.fold_path(_i . path),
     }
 }
 
-pub fn fold_ty_ptr<V: Folder + ?Sized>(_visitor: &mut V, _i: TyPtr) -> TyPtr {
-    TyPtr {
+pub fn fold_type_ptr<V: Folder + ?Sized>(_visitor: &mut V, _i: TypePtr) -> TypePtr {
+    TypePtr {
         star_token: _i . star_token,
         const_token: _i . const_token,
-        ty: Box::new(_visitor.fold_mut_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_mut_type(* _i . ty)),
     }
 }
 
-pub fn fold_ty_rptr<V: Folder + ?Sized>(_visitor: &mut V, _i: TyRptr) -> TyRptr {
-    TyRptr {
+pub fn fold_type_rptr<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeRptr) -> TypeRptr {
+    TypeRptr {
         and_token: _i . and_token,
         lifetime: _i . lifetime,
-        ty: Box::new(_visitor.fold_mut_ty(* _i . ty)),
+        ty: Box::new(_visitor.fold_mut_type(* _i . ty)),
     }
 }
 
-pub fn fold_ty_slice<V: Folder + ?Sized>(_visitor: &mut V, _i: TySlice) -> TySlice {
-    TySlice {
-        ty: Box::new(_visitor.fold_ty(* _i . ty)),
+pub fn fold_type_slice<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeSlice) -> TypeSlice {
+    TypeSlice {
+        ty: Box::new(_visitor.fold_type(* _i . ty)),
         bracket_token: _i . bracket_token,
     }
 }
 
-pub fn fold_ty_trait_object<V: Folder + ?Sized>(_visitor: &mut V, _i: TyTraitObject) -> TyTraitObject {
-    TyTraitObject {
-        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_ty_param_bound(it) }),
+pub fn fold_type_trait_object<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeTraitObject) -> TypeTraitObject {
+    TypeTraitObject {
+        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_type_param_bound(it) }),
     }
 }
 
-pub fn fold_ty_tup<V: Folder + ?Sized>(_visitor: &mut V, _i: TyTup) -> TyTup {
-    TyTup {
+pub fn fold_type_tup<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeTup) -> TypeTup {
+    TypeTup {
         paren_token: _i . paren_token,
-        tys: FoldHelper::lift(_i . tys, |it| { _visitor.fold_ty(it) }),
+        tys: FoldHelper::lift(_i . tys, |it| { _visitor.fold_type(it) }),
         lone_comma: _i . lone_comma,
-    }
-}
-
-pub fn fold_type_binding<V: Folder + ?Sized>(_visitor: &mut V, _i: TypeBinding) -> TypeBinding {
-    TypeBinding {
-        ident: _i . ident,
-        eq_token: _i . eq_token,
-        ty: _visitor.fold_ty(_i . ty),
     }
 }
 
@@ -2642,9 +2642,9 @@ pub fn fold_visibility<V: Folder + ?Sized>(_visitor: &mut V, _i: Visibility) -> 
 pub fn fold_where_bound_predicate<V: Folder + ?Sized>(_visitor: &mut V, _i: WhereBoundPredicate) -> WhereBoundPredicate {
     WhereBoundPredicate {
         bound_lifetimes: (_i . bound_lifetimes).map(|it| { _visitor.fold_bound_lifetimes(it) }),
-        bounded_ty: _visitor.fold_ty(_i . bounded_ty),
+        bounded_ty: _visitor.fold_type(_i . bounded_ty),
         colon_token: _i . colon_token,
-        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_ty_param_bound(it) }),
+        bounds: FoldHelper::lift(_i . bounds, |it| { _visitor.fold_type_param_bound(it) }),
     }
 }
 
@@ -2657,9 +2657,9 @@ pub fn fold_where_clause<V: Folder + ?Sized>(_visitor: &mut V, _i: WhereClause) 
 
 pub fn fold_where_eq_predicate<V: Folder + ?Sized>(_visitor: &mut V, _i: WhereEqPredicate) -> WhereEqPredicate {
     WhereEqPredicate {
-        lhs_ty: _visitor.fold_ty(_i . lhs_ty),
+        lhs_ty: _visitor.fold_type(_i . lhs_ty),
         eq_token: _i . eq_token,
-        rhs_ty: _visitor.fold_ty(_i . rhs_ty),
+        rhs_ty: _visitor.fold_type(_i . rhs_ty),
     }
 }
 

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -53,7 +53,7 @@ fn visit_bare_fn_arg(&mut self, i: &BareFnArg) { visit_bare_fn_arg(self, i) }
 
 fn visit_bare_fn_arg_name(&mut self, i: &BareFnArgName) { visit_bare_fn_arg_name(self, i) }
 
-fn visit_bare_fn_ty(&mut self, i: &BareFnTy) { visit_bare_fn_ty(self, i) }
+fn visit_bare_fn_type(&mut self, i: &BareFnType) { visit_bare_fn_type(self, i) }
 
 fn visit_bin_op(&mut self, i: &BinOp) { visit_bin_op(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -215,7 +215,7 @@ fn visit_item_struct(&mut self, i: &ItemStruct) { visit_item_struct(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_item_trait(&mut self, i: &ItemTrait) { visit_item_trait(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn visit_item_ty(&mut self, i: &ItemTy) { visit_item_ty(self, i) }
+fn visit_item_type(&mut self, i: &ItemType) { visit_item_type(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_item_union(&mut self, i: &ItemUnion) { visit_item_union(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -237,7 +237,7 @@ fn visit_meta_name_value(&mut self, i: &MetaNameValue) { visit_meta_name_value(s
 # [ cfg ( feature = "full" ) ]
 fn visit_method_sig(&mut self, i: &MethodSig) { visit_method_sig(self, i) }
 
-fn visit_mut_ty(&mut self, i: &MutTy) { visit_mut_ty(self, i) }
+fn visit_mut_type(&mut self, i: &MutType) { visit_mut_type(self, i) }
 
 fn visit_mutability(&mut self, i: &Mutability) { visit_mutability(self, i) }
 
@@ -305,39 +305,39 @@ fn visit_trait_item_method(&mut self, i: &TraitItemMethod) { visit_trait_item_me
 # [ cfg ( feature = "full" ) ]
 fn visit_trait_item_type(&mut self, i: &TraitItemType) { visit_trait_item_type(self, i) }
 
-fn visit_ty(&mut self, i: &Ty) { visit_ty(self, i) }
+fn visit_type(&mut self, i: &Type) { visit_type(self, i) }
 
-fn visit_ty_array(&mut self, i: &TyArray) { visit_ty_array(self, i) }
+fn visit_type_array(&mut self, i: &TypeArray) { visit_type_array(self, i) }
 
-fn visit_ty_bare_fn(&mut self, i: &TyBareFn) { visit_ty_bare_fn(self, i) }
-
-fn visit_ty_group(&mut self, i: &TyGroup) { visit_ty_group(self, i) }
-
-fn visit_ty_impl_trait(&mut self, i: &TyImplTrait) { visit_ty_impl_trait(self, i) }
-
-fn visit_ty_infer(&mut self, i: &TyInfer) { visit_ty_infer(self, i) }
-
-fn visit_ty_never(&mut self, i: &TyNever) { visit_ty_never(self, i) }
-
-fn visit_ty_param(&mut self, i: &TyParam) { visit_ty_param(self, i) }
-
-fn visit_ty_param_bound(&mut self, i: &TyParamBound) { visit_ty_param_bound(self, i) }
-
-fn visit_ty_paren(&mut self, i: &TyParen) { visit_ty_paren(self, i) }
-
-fn visit_ty_path(&mut self, i: &TyPath) { visit_ty_path(self, i) }
-
-fn visit_ty_ptr(&mut self, i: &TyPtr) { visit_ty_ptr(self, i) }
-
-fn visit_ty_rptr(&mut self, i: &TyRptr) { visit_ty_rptr(self, i) }
-
-fn visit_ty_slice(&mut self, i: &TySlice) { visit_ty_slice(self, i) }
-
-fn visit_ty_trait_object(&mut self, i: &TyTraitObject) { visit_ty_trait_object(self, i) }
-
-fn visit_ty_tup(&mut self, i: &TyTup) { visit_ty_tup(self, i) }
+fn visit_type_bare_fn(&mut self, i: &TypeBareFn) { visit_type_bare_fn(self, i) }
 
 fn visit_type_binding(&mut self, i: &TypeBinding) { visit_type_binding(self, i) }
+
+fn visit_type_group(&mut self, i: &TypeGroup) { visit_type_group(self, i) }
+
+fn visit_type_impl_trait(&mut self, i: &TypeImplTrait) { visit_type_impl_trait(self, i) }
+
+fn visit_type_infer(&mut self, i: &TypeInfer) { visit_type_infer(self, i) }
+
+fn visit_type_never(&mut self, i: &TypeNever) { visit_type_never(self, i) }
+
+fn visit_type_param(&mut self, i: &TypeParam) { visit_type_param(self, i) }
+
+fn visit_type_param_bound(&mut self, i: &TypeParamBound) { visit_type_param_bound(self, i) }
+
+fn visit_type_paren(&mut self, i: &TypeParen) { visit_type_paren(self, i) }
+
+fn visit_type_path(&mut self, i: &TypePath) { visit_type_path(self, i) }
+
+fn visit_type_ptr(&mut self, i: &TypePtr) { visit_type_ptr(self, i) }
+
+fn visit_type_rptr(&mut self, i: &TypeRptr) { visit_type_rptr(self, i) }
+
+fn visit_type_slice(&mut self, i: &TypeSlice) { visit_type_slice(self, i) }
+
+fn visit_type_trait_object(&mut self, i: &TypeTraitObject) { visit_type_trait_object(self, i) }
+
+fn visit_type_tup(&mut self, i: &TypeTup) { visit_type_tup(self, i) }
 
 fn visit_un_op(&mut self, i: &UnOp) { visit_un_op(self, i) }
 
@@ -391,7 +391,7 @@ pub fn visit_angle_bracketed_parameter_data<V: Visitor + ?Sized>(_visitor: &mut 
     // Skipped field _i . turbofish;
     // Skipped field _i . lt_token;
     // Skipped field _i . lifetimes;
-    for el in (_i . types).iter() { let it = el.item(); _visitor.visit_ty(&it) };
+    for el in (_i . types).iter() { let it = el.item(); _visitor.visit_type(&it) };
     for el in (_i . bindings).iter() { let it = el.item(); _visitor.visit_type_binding(&it) };
     // Skipped field _i . gt_token;
 }
@@ -399,7 +399,7 @@ pub fn visit_angle_bracketed_parameter_data<V: Visitor + ?Sized>(_visitor: &mut 
 pub fn visit_arg_captured<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ArgCaptured) {
     _visitor.visit_pat(&_i . pat);
     // Skipped field _i . colon_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_arg_self<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ArgSelf) {
@@ -445,7 +445,7 @@ pub fn visit_attribute<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Attribute) {
 
 pub fn visit_bare_fn_arg<V: Visitor + ?Sized>(_visitor: &mut V, _i: &BareFnArg) {
     // Skipped field _i . name;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
 }
 
 pub fn visit_bare_fn_arg_name<V: Visitor + ?Sized>(_visitor: &mut V, _i: &BareFnArgName) {
@@ -460,7 +460,7 @@ pub fn visit_bare_fn_arg_name<V: Visitor + ?Sized>(_visitor: &mut V, _i: &BareFn
     }
 }
 
-pub fn visit_bare_fn_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &BareFnTy) {
+pub fn visit_bare_fn_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &BareFnType) {
     if let Some(ref it) = _i . lifetimes { _visitor.visit_bound_lifetimes(&* it) };
     _visitor.visit_unsafety(&_i . unsafety);
     if let Some(ref it) = _i . abi { _visitor.visit_abi(&* it) };
@@ -707,7 +707,7 @@ pub fn visit_expr_call<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprCall) {
 pub fn visit_expr_cast<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprCast) {
     _visitor.visit_expr(&_i . expr);
     // Skipped field _i . as_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_expr_catch<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprCatch) {
@@ -921,7 +921,7 @@ pub fn visit_expr_match<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprMatch) {
 pub fn visit_expr_method_call<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprMethodCall) {
     _visitor.visit_expr(&_i . expr);
     // Skipped field _i . method;
-    for el in (_i . typarams).iter() { let it = el.item(); _visitor.visit_ty(&it) };
+    for el in (_i . typarams).iter() { let it = el.item(); _visitor.visit_type(&it) };
     for el in (_i . args).iter() { let it = el.item(); _visitor.visit_expr(&it) };
     // Skipped field _i . paren_token;
     // Skipped field _i . dot_token;
@@ -986,7 +986,7 @@ pub fn visit_expr_tup_field<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprTupF
 pub fn visit_expr_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprType) {
     _visitor.visit_expr(&_i . expr);
     // Skipped field _i . colon_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
 }
 
 pub fn visit_expr_unary<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ExprUnary) {
@@ -1022,7 +1022,7 @@ pub fn visit_field<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Field) {
     // Skipped field _i . ident;
     _visitor.visit_visibility(&_i . vis);
     for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . colon_token;
 }
 # [ cfg ( feature = "full" ) ]
@@ -1061,7 +1061,7 @@ pub fn visit_fn_arg<V: Visitor + ?Sized>(_visitor: &mut V, _i: &FnArg) {
             _visitor.visit_arg_captured(&* _binding_0);
         }
         Ignored(ref _binding_0, ) => {
-            _visitor.visit_ty(&* _binding_0);
+            _visitor.visit_type(&* _binding_0);
         }
     }
 }
@@ -1103,7 +1103,7 @@ pub fn visit_foreign_item_static<V: Visitor + ?Sized>(_visitor: &mut V, _i: &For
     _visitor.visit_mutability(&_i . mutbl);
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . semi_token;
 }
 
@@ -1111,7 +1111,7 @@ pub fn visit_generics<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Generics) {
     // Skipped field _i . lt_token;
     // Skipped field _i . gt_token;
     for el in (_i . lifetimes).iter() { let it = el.item(); _visitor.visit_lifetime_def(&it) };
-    for el in (_i . ty_params).iter() { let it = el.item(); _visitor.visit_ty_param(&it) };
+    for el in (_i . ty_params).iter() { let it = el.item(); _visitor.visit_type_param(&it) };
     _visitor.visit_where_clause(&_i . where_clause);
 }
 # [ cfg ( feature = "full" ) ]
@@ -1140,7 +1140,7 @@ pub fn visit_impl_item_const<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ImplIte
     // Skipped field _i . const_token;
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . eq_token;
     _visitor.visit_expr(&_i . expr);
     // Skipped field _i . semi_token;
@@ -1166,7 +1166,7 @@ pub fn visit_impl_item_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ImplItem
     // Skipped field _i . type_token;
     // Skipped field _i . ident;
     // Skipped field _i . eq_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . semi_token;
 }
 # [ cfg ( feature = "full" ) ]
@@ -1216,8 +1216,8 @@ pub fn visit_item<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Item) {
         ForeignMod(ref _binding_0, ) => {
             _visitor.visit_item_foreign_mod(&* _binding_0);
         }
-        Ty(ref _binding_0, ) => {
-            _visitor.visit_item_ty(&* _binding_0);
+        Type(ref _binding_0, ) => {
+            _visitor.visit_item_type(&* _binding_0);
         }
         Enum(ref _binding_0, ) => {
             _visitor.visit_item_enum(&* _binding_0);
@@ -1249,7 +1249,7 @@ pub fn visit_item_const<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemConst) {
     // Skipped field _i . const_token;
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . eq_token;
     _visitor.visit_expr(&_i . expr);
     // Skipped field _i . semi_token;
@@ -1310,7 +1310,7 @@ pub fn visit_item_impl<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemImpl) {
     // Skipped field _i . impl_token;
     _visitor.visit_generics(&_i . generics);
     // Skipped field _i . trait_;
-    _visitor.visit_ty(&_i . self_ty);
+    _visitor.visit_type(&_i . self_ty);
     // Skipped field _i . brace_token;
     for it in (_i . items).iter() { _visitor.visit_impl_item(&it) };
 }
@@ -1337,7 +1337,7 @@ pub fn visit_item_static<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemStatic)
     _visitor.visit_mutability(&_i . mutbl);
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . eq_token;
     _visitor.visit_expr(&_i . expr);
     // Skipped field _i . semi_token;
@@ -1361,19 +1361,19 @@ pub fn visit_item_trait<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemTrait) {
     // Skipped field _i . ident;
     _visitor.visit_generics(&_i . generics);
     // Skipped field _i . colon_token;
-    for el in (_i . supertraits).iter() { let it = el.item(); _visitor.visit_ty_param_bound(&it) };
+    for el in (_i . supertraits).iter() { let it = el.item(); _visitor.visit_type_param_bound(&it) };
     // Skipped field _i . brace_token;
     for it in (_i . items).iter() { _visitor.visit_trait_item(&it) };
 }
 # [ cfg ( feature = "full" ) ]
-pub fn visit_item_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemTy) {
+pub fn visit_item_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ItemType) {
     for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     _visitor.visit_visibility(&_i . vis);
     // Skipped field _i . type_token;
     // Skipped field _i . ident;
     _visitor.visit_generics(&_i . generics);
     // Skipped field _i . eq_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . semi_token;
 }
 # [ cfg ( feature = "full" ) ]
@@ -1407,7 +1407,7 @@ pub fn visit_local<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Local) {
     // Skipped field _i . eq_token;
     // Skipped field _i . semi_token;
     _visitor.visit_pat(&_i . pat);
-    if let Some(ref it) = _i . ty { _visitor.visit_ty(&* it) };
+    if let Some(ref it) = _i . ty { _visitor.visit_type(&* it) };
     if let Some(ref it) = _i . init { _visitor.visit_expr(&* it) };
     for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
 }
@@ -1464,8 +1464,8 @@ pub fn visit_method_sig<V: Visitor + ?Sized>(_visitor: &mut V, _i: &MethodSig) {
     _visitor.visit_fn_decl(&_i . decl);
 }
 
-pub fn visit_mut_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &MutTy) {
-    _visitor.visit_ty(&_i . ty);
+pub fn visit_mut_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &MutType) {
+    _visitor.visit_type(&_i . ty);
     _visitor.visit_mutability(&_i . mutability);
 }
 
@@ -1493,7 +1493,7 @@ pub fn visit_nested_meta_item<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Nested
 
 pub fn visit_parenthesized_parameter_data<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ParenthesizedParameterData) {
     // Skipped field _i . paren_token;
-    for el in (_i . inputs).iter() { let it = el.item(); _visitor.visit_ty(&it) };
+    for el in (_i . inputs).iter() { let it = el.item(); _visitor.visit_type(&it) };
     _visitor.visit_return_type(&_i . output);
 }
 # [ cfg ( feature = "full" ) ]
@@ -1660,7 +1660,7 @@ pub fn visit_poly_trait_ref<V: Visitor + ?Sized>(_visitor: &mut V, _i: &PolyTrai
 
 pub fn visit_qself<V: Visitor + ?Sized>(_visitor: &mut V, _i: &QSelf) {
     // Skipped field _i . lt_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . position;
     // Skipped field _i . as_token;
     // Skipped field _i . gt_token;
@@ -1682,8 +1682,8 @@ pub fn visit_return_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &ReturnType)
     use ::ReturnType::*;
     match *_i {
         Default => { }
-        Ty(ref _binding_0, ref _binding_1, ) => {
-            _visitor.visit_ty(&* _binding_0);
+        Type(ref _binding_0, ref _binding_1, ) => {
+            _visitor.visit_type(&* _binding_0);
             // Skipped field * _binding_1;
         }
     }
@@ -1744,7 +1744,7 @@ pub fn visit_trait_item_const<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TraitI
     // Skipped field _i . const_token;
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . default;
     // Skipped field _i . semi_token;
 }
@@ -1766,52 +1766,52 @@ pub fn visit_trait_item_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TraitIt
     // Skipped field _i . type_token;
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_ty_param_bound(&it) };
+    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_type_param_bound(&it) };
     // Skipped field _i . default;
     // Skipped field _i . semi_token;
 }
 
-pub fn visit_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Ty) {
-    use ::Ty::*;
+pub fn visit_type<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Type) {
+    use ::Type::*;
     match *_i {
         Slice(ref _binding_0, ) => {
-            _visitor.visit_ty_slice(&* _binding_0);
+            _visitor.visit_type_slice(&* _binding_0);
         }
         Array(ref _binding_0, ) => {
-            _visitor.visit_ty_array(&* _binding_0);
+            _visitor.visit_type_array(&* _binding_0);
         }
         Ptr(ref _binding_0, ) => {
-            _visitor.visit_ty_ptr(&* _binding_0);
+            _visitor.visit_type_ptr(&* _binding_0);
         }
         Rptr(ref _binding_0, ) => {
-            _visitor.visit_ty_rptr(&* _binding_0);
+            _visitor.visit_type_rptr(&* _binding_0);
         }
         BareFn(ref _binding_0, ) => {
-            _visitor.visit_ty_bare_fn(&* _binding_0);
+            _visitor.visit_type_bare_fn(&* _binding_0);
         }
         Never(ref _binding_0, ) => {
-            _visitor.visit_ty_never(&* _binding_0);
+            _visitor.visit_type_never(&* _binding_0);
         }
         Tup(ref _binding_0, ) => {
-            _visitor.visit_ty_tup(&* _binding_0);
+            _visitor.visit_type_tup(&* _binding_0);
         }
         Path(ref _binding_0, ) => {
-            _visitor.visit_ty_path(&* _binding_0);
+            _visitor.visit_type_path(&* _binding_0);
         }
         TraitObject(ref _binding_0, ) => {
-            _visitor.visit_ty_trait_object(&* _binding_0);
+            _visitor.visit_type_trait_object(&* _binding_0);
         }
         ImplTrait(ref _binding_0, ) => {
-            _visitor.visit_ty_impl_trait(&* _binding_0);
+            _visitor.visit_type_impl_trait(&* _binding_0);
         }
         Paren(ref _binding_0, ) => {
-            _visitor.visit_ty_paren(&* _binding_0);
+            _visitor.visit_type_paren(&* _binding_0);
         }
         Group(ref _binding_0, ) => {
-            _visitor.visit_ty_group(&* _binding_0);
+            _visitor.visit_type_group(&* _binding_0);
         }
         Infer(ref _binding_0, ) => {
-            _visitor.visit_ty_infer(&* _binding_0);
+            _visitor.visit_type_infer(&* _binding_0);
         }
         Macro(ref _binding_0, ) => {
             _visitor.visit_macro(&* _binding_0);
@@ -1819,46 +1819,52 @@ pub fn visit_ty<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Ty) {
     }
 }
 
-pub fn visit_ty_array<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyArray) {
+pub fn visit_type_array<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeArray) {
     // Skipped field _i . bracket_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . semi_token;
     _visitor.visit_expr(&_i . amt);
 }
 
-pub fn visit_ty_bare_fn<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyBareFn) {
-    _visitor.visit_bare_fn_ty(&_i . ty);
+pub fn visit_type_bare_fn<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeBareFn) {
+    _visitor.visit_bare_fn_type(&_i . ty);
 }
 
-pub fn visit_ty_group<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyGroup) {
+pub fn visit_type_binding<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeBinding) {
+    // Skipped field _i . ident;
+    // Skipped field _i . eq_token;
+    _visitor.visit_type(&_i . ty);
+}
+
+pub fn visit_type_group<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeGroup) {
     // Skipped field _i . group_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
 }
 
-pub fn visit_ty_impl_trait<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyImplTrait) {
+pub fn visit_type_impl_trait<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeImplTrait) {
     // Skipped field _i . impl_token;
-    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_ty_param_bound(&it) };
+    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_type_param_bound(&it) };
 }
 
-pub fn visit_ty_infer<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyInfer) {
+pub fn visit_type_infer<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeInfer) {
     // Skipped field _i . underscore_token;
 }
 
-pub fn visit_ty_never<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyNever) {
+pub fn visit_type_never<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeNever) {
     // Skipped field _i . bang_token;
 }
 
-pub fn visit_ty_param<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyParam) {
+pub fn visit_type_param<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeParam) {
     for it in (_i . attrs).iter() { _visitor.visit_attribute(&it) };
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_ty_param_bound(&it) };
+    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_type_param_bound(&it) };
     // Skipped field _i . eq_token;
-    if let Some(ref it) = _i . default { _visitor.visit_ty(&* it) };
+    if let Some(ref it) = _i . default { _visitor.visit_type(&* it) };
 }
 
-pub fn visit_ty_param_bound<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyParamBound) {
-    use ::TyParamBound::*;
+pub fn visit_type_param_bound<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeParamBound) {
+    use ::TypeParamBound::*;
     match *_i {
         Trait(ref _binding_0, ref _binding_1, ) => {
             _visitor.visit_poly_trait_ref(&* _binding_0);
@@ -1870,47 +1876,41 @@ pub fn visit_ty_param_bound<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyParamB
     }
 }
 
-pub fn visit_ty_paren<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyParen) {
+pub fn visit_type_paren<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeParen) {
     // Skipped field _i . paren_token;
-    _visitor.visit_ty(&_i . ty);
+    _visitor.visit_type(&_i . ty);
 }
 
-pub fn visit_ty_path<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyPath) {
+pub fn visit_type_path<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypePath) {
     if let Some(ref it) = _i . qself { _visitor.visit_qself(&* it) };
     _visitor.visit_path(&_i . path);
 }
 
-pub fn visit_ty_ptr<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyPtr) {
+pub fn visit_type_ptr<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypePtr) {
     // Skipped field _i . star_token;
     // Skipped field _i . const_token;
-    _visitor.visit_mut_ty(&_i . ty);
+    _visitor.visit_mut_type(&_i . ty);
 }
 
-pub fn visit_ty_rptr<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyRptr) {
+pub fn visit_type_rptr<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeRptr) {
     // Skipped field _i . and_token;
     // Skipped field _i . lifetime;
-    _visitor.visit_mut_ty(&_i . ty);
+    _visitor.visit_mut_type(&_i . ty);
 }
 
-pub fn visit_ty_slice<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TySlice) {
-    _visitor.visit_ty(&_i . ty);
+pub fn visit_type_slice<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeSlice) {
+    _visitor.visit_type(&_i . ty);
     // Skipped field _i . bracket_token;
 }
 
-pub fn visit_ty_trait_object<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyTraitObject) {
-    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_ty_param_bound(&it) };
+pub fn visit_type_trait_object<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeTraitObject) {
+    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_type_param_bound(&it) };
 }
 
-pub fn visit_ty_tup<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TyTup) {
+pub fn visit_type_tup<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeTup) {
     // Skipped field _i . paren_token;
-    for el in (_i . tys).iter() { let it = el.item(); _visitor.visit_ty(&it) };
+    for el in (_i . tys).iter() { let it = el.item(); _visitor.visit_type(&it) };
     // Skipped field _i . lone_comma;
-}
-
-pub fn visit_type_binding<V: Visitor + ?Sized>(_visitor: &mut V, _i: &TypeBinding) {
-    // Skipped field _i . ident;
-    // Skipped field _i . eq_token;
-    _visitor.visit_ty(&_i . ty);
 }
 
 pub fn visit_un_op<V: Visitor + ?Sized>(_visitor: &mut V, _i: &UnOp) {
@@ -2016,9 +2016,9 @@ pub fn visit_visibility<V: Visitor + ?Sized>(_visitor: &mut V, _i: &Visibility) 
 
 pub fn visit_where_bound_predicate<V: Visitor + ?Sized>(_visitor: &mut V, _i: &WhereBoundPredicate) {
     if let Some(ref it) = _i . bound_lifetimes { _visitor.visit_bound_lifetimes(&* it) };
-    _visitor.visit_ty(&_i . bounded_ty);
+    _visitor.visit_type(&_i . bounded_ty);
     // Skipped field _i . colon_token;
-    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_ty_param_bound(&it) };
+    for el in (_i . bounds).iter() { let it = el.item(); _visitor.visit_type_param_bound(&it) };
 }
 
 pub fn visit_where_clause<V: Visitor + ?Sized>(_visitor: &mut V, _i: &WhereClause) {
@@ -2027,9 +2027,9 @@ pub fn visit_where_clause<V: Visitor + ?Sized>(_visitor: &mut V, _i: &WhereClaus
 }
 
 pub fn visit_where_eq_predicate<V: Visitor + ?Sized>(_visitor: &mut V, _i: &WhereEqPredicate) {
-    _visitor.visit_ty(&_i . lhs_ty);
+    _visitor.visit_type(&_i . lhs_ty);
     // Skipped field _i . eq_token;
-    _visitor.visit_ty(&_i . rhs_ty);
+    _visitor.visit_type(&_i . rhs_ty);
 }
 
 pub fn visit_where_predicate<V: Visitor + ?Sized>(_visitor: &mut V, _i: &WherePredicate) {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -53,7 +53,7 @@ fn visit_bare_fn_arg_mut(&mut self, i: &mut BareFnArg) { visit_bare_fn_arg_mut(s
 
 fn visit_bare_fn_arg_name_mut(&mut self, i: &mut BareFnArgName) { visit_bare_fn_arg_name_mut(self, i) }
 
-fn visit_bare_fn_ty_mut(&mut self, i: &mut BareFnTy) { visit_bare_fn_ty_mut(self, i) }
+fn visit_bare_fn_type_mut(&mut self, i: &mut BareFnType) { visit_bare_fn_type_mut(self, i) }
 
 fn visit_bin_op_mut(&mut self, i: &mut BinOp) { visit_bin_op_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -215,7 +215,7 @@ fn visit_item_struct_mut(&mut self, i: &mut ItemStruct) { visit_item_struct_mut(
 # [ cfg ( feature = "full" ) ]
 fn visit_item_trait_mut(&mut self, i: &mut ItemTrait) { visit_item_trait_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
-fn visit_item_ty_mut(&mut self, i: &mut ItemTy) { visit_item_ty_mut(self, i) }
+fn visit_item_type_mut(&mut self, i: &mut ItemType) { visit_item_type_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_item_union_mut(&mut self, i: &mut ItemUnion) { visit_item_union_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
@@ -237,7 +237,7 @@ fn visit_meta_name_value_mut(&mut self, i: &mut MetaNameValue) { visit_meta_name
 # [ cfg ( feature = "full" ) ]
 fn visit_method_sig_mut(&mut self, i: &mut MethodSig) { visit_method_sig_mut(self, i) }
 
-fn visit_mut_ty_mut(&mut self, i: &mut MutTy) { visit_mut_ty_mut(self, i) }
+fn visit_mut_type_mut(&mut self, i: &mut MutType) { visit_mut_type_mut(self, i) }
 
 fn visit_mutability_mut(&mut self, i: &mut Mutability) { visit_mutability_mut(self, i) }
 
@@ -305,39 +305,39 @@ fn visit_trait_item_method_mut(&mut self, i: &mut TraitItemMethod) { visit_trait
 # [ cfg ( feature = "full" ) ]
 fn visit_trait_item_type_mut(&mut self, i: &mut TraitItemType) { visit_trait_item_type_mut(self, i) }
 
-fn visit_ty_mut(&mut self, i: &mut Ty) { visit_ty_mut(self, i) }
+fn visit_type_mut(&mut self, i: &mut Type) { visit_type_mut(self, i) }
 
-fn visit_ty_array_mut(&mut self, i: &mut TyArray) { visit_ty_array_mut(self, i) }
+fn visit_type_array_mut(&mut self, i: &mut TypeArray) { visit_type_array_mut(self, i) }
 
-fn visit_ty_bare_fn_mut(&mut self, i: &mut TyBareFn) { visit_ty_bare_fn_mut(self, i) }
-
-fn visit_ty_group_mut(&mut self, i: &mut TyGroup) { visit_ty_group_mut(self, i) }
-
-fn visit_ty_impl_trait_mut(&mut self, i: &mut TyImplTrait) { visit_ty_impl_trait_mut(self, i) }
-
-fn visit_ty_infer_mut(&mut self, i: &mut TyInfer) { visit_ty_infer_mut(self, i) }
-
-fn visit_ty_never_mut(&mut self, i: &mut TyNever) { visit_ty_never_mut(self, i) }
-
-fn visit_ty_param_mut(&mut self, i: &mut TyParam) { visit_ty_param_mut(self, i) }
-
-fn visit_ty_param_bound_mut(&mut self, i: &mut TyParamBound) { visit_ty_param_bound_mut(self, i) }
-
-fn visit_ty_paren_mut(&mut self, i: &mut TyParen) { visit_ty_paren_mut(self, i) }
-
-fn visit_ty_path_mut(&mut self, i: &mut TyPath) { visit_ty_path_mut(self, i) }
-
-fn visit_ty_ptr_mut(&mut self, i: &mut TyPtr) { visit_ty_ptr_mut(self, i) }
-
-fn visit_ty_rptr_mut(&mut self, i: &mut TyRptr) { visit_ty_rptr_mut(self, i) }
-
-fn visit_ty_slice_mut(&mut self, i: &mut TySlice) { visit_ty_slice_mut(self, i) }
-
-fn visit_ty_trait_object_mut(&mut self, i: &mut TyTraitObject) { visit_ty_trait_object_mut(self, i) }
-
-fn visit_ty_tup_mut(&mut self, i: &mut TyTup) { visit_ty_tup_mut(self, i) }
+fn visit_type_bare_fn_mut(&mut self, i: &mut TypeBareFn) { visit_type_bare_fn_mut(self, i) }
 
 fn visit_type_binding_mut(&mut self, i: &mut TypeBinding) { visit_type_binding_mut(self, i) }
+
+fn visit_type_group_mut(&mut self, i: &mut TypeGroup) { visit_type_group_mut(self, i) }
+
+fn visit_type_impl_trait_mut(&mut self, i: &mut TypeImplTrait) { visit_type_impl_trait_mut(self, i) }
+
+fn visit_type_infer_mut(&mut self, i: &mut TypeInfer) { visit_type_infer_mut(self, i) }
+
+fn visit_type_never_mut(&mut self, i: &mut TypeNever) { visit_type_never_mut(self, i) }
+
+fn visit_type_param_mut(&mut self, i: &mut TypeParam) { visit_type_param_mut(self, i) }
+
+fn visit_type_param_bound_mut(&mut self, i: &mut TypeParamBound) { visit_type_param_bound_mut(self, i) }
+
+fn visit_type_paren_mut(&mut self, i: &mut TypeParen) { visit_type_paren_mut(self, i) }
+
+fn visit_type_path_mut(&mut self, i: &mut TypePath) { visit_type_path_mut(self, i) }
+
+fn visit_type_ptr_mut(&mut self, i: &mut TypePtr) { visit_type_ptr_mut(self, i) }
+
+fn visit_type_rptr_mut(&mut self, i: &mut TypeRptr) { visit_type_rptr_mut(self, i) }
+
+fn visit_type_slice_mut(&mut self, i: &mut TypeSlice) { visit_type_slice_mut(self, i) }
+
+fn visit_type_trait_object_mut(&mut self, i: &mut TypeTraitObject) { visit_type_trait_object_mut(self, i) }
+
+fn visit_type_tup_mut(&mut self, i: &mut TypeTup) { visit_type_tup_mut(self, i) }
 
 fn visit_un_op_mut(&mut self, i: &mut UnOp) { visit_un_op_mut(self, i) }
 
@@ -391,7 +391,7 @@ pub fn visit_angle_bracketed_parameter_data_mut<V: VisitorMut + ?Sized>(_visitor
     // Skipped field _i . turbofish;
     // Skipped field _i . lt_token;
     // Skipped field _i . lifetimes;
-    for mut el in (_i . types).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_mut(&mut it) };
+    for mut el in (_i . types).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_mut(&mut it) };
     for mut el in (_i . bindings).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_binding_mut(&mut it) };
     // Skipped field _i . gt_token;
 }
@@ -399,7 +399,7 @@ pub fn visit_angle_bracketed_parameter_data_mut<V: VisitorMut + ?Sized>(_visitor
 pub fn visit_arg_captured_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ArgCaptured) {
     _visitor.visit_pat_mut(&mut _i . pat);
     // Skipped field _i . colon_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_arg_self_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ArgSelf) {
@@ -445,7 +445,7 @@ pub fn visit_attribute_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut At
 
 pub fn visit_bare_fn_arg_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut BareFnArg) {
     // Skipped field _i . name;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
 }
 
 pub fn visit_bare_fn_arg_name_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut BareFnArgName) {
@@ -460,7 +460,7 @@ pub fn visit_bare_fn_arg_name_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: 
     }
 }
 
-pub fn visit_bare_fn_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut BareFnTy) {
+pub fn visit_bare_fn_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut BareFnType) {
     if let Some(ref mut it) = _i . lifetimes { _visitor.visit_bound_lifetimes_mut(&mut * it) };
     _visitor.visit_unsafety_mut(&mut _i . unsafety);
     if let Some(ref mut it) = _i . abi { _visitor.visit_abi_mut(&mut * it) };
@@ -707,7 +707,7 @@ pub fn visit_expr_call_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Ex
 pub fn visit_expr_cast_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprCast) {
     _visitor.visit_expr_mut(&mut _i . expr);
     // Skipped field _i . as_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_expr_catch_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprCatch) {
@@ -921,7 +921,7 @@ pub fn visit_expr_match_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut E
 pub fn visit_expr_method_call_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprMethodCall) {
     _visitor.visit_expr_mut(&mut _i . expr);
     // Skipped field _i . method;
-    for mut el in (_i . typarams).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_mut(&mut it) };
+    for mut el in (_i . typarams).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_mut(&mut it) };
     for mut el in (_i . args).iter_mut() { let mut it = el.item_mut(); _visitor.visit_expr_mut(&mut it) };
     // Skipped field _i . paren_token;
     // Skipped field _i . dot_token;
@@ -986,7 +986,7 @@ pub fn visit_expr_tup_field_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &m
 pub fn visit_expr_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprType) {
     _visitor.visit_expr_mut(&mut _i . expr);
     // Skipped field _i . colon_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
 }
 
 pub fn visit_expr_unary_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprUnary) {
@@ -1022,7 +1022,7 @@ pub fn visit_field_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Field)
     // Skipped field _i . ident;
     _visitor.visit_visibility_mut(&mut _i . vis);
     for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . colon_token;
 }
 # [ cfg ( feature = "full" ) ]
@@ -1061,7 +1061,7 @@ pub fn visit_fn_arg_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut FnArg
             _visitor.visit_arg_captured_mut(&mut * _binding_0);
         }
         Ignored(ref mut _binding_0, ) => {
-            _visitor.visit_ty_mut(&mut * _binding_0);
+            _visitor.visit_type_mut(&mut * _binding_0);
         }
     }
 }
@@ -1103,7 +1103,7 @@ pub fn visit_foreign_item_static_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _
     _visitor.visit_mutability_mut(&mut _i . mutbl);
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . semi_token;
 }
 
@@ -1111,7 +1111,7 @@ pub fn visit_generics_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Gen
     // Skipped field _i . lt_token;
     // Skipped field _i . gt_token;
     for mut el in (_i . lifetimes).iter_mut() { let mut it = el.item_mut(); _visitor.visit_lifetime_def_mut(&mut it) };
-    for mut el in (_i . ty_params).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_param_mut(&mut it) };
+    for mut el in (_i . ty_params).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_param_mut(&mut it) };
     _visitor.visit_where_clause_mut(&mut _i . where_clause);
 }
 # [ cfg ( feature = "full" ) ]
@@ -1140,7 +1140,7 @@ pub fn visit_impl_item_const_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &
     // Skipped field _i . const_token;
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . eq_token;
     _visitor.visit_expr_mut(&mut _i . expr);
     // Skipped field _i . semi_token;
@@ -1166,7 +1166,7 @@ pub fn visit_impl_item_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &m
     // Skipped field _i . type_token;
     // Skipped field _i . ident;
     // Skipped field _i . eq_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . semi_token;
 }
 # [ cfg ( feature = "full" ) ]
@@ -1216,8 +1216,8 @@ pub fn visit_item_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Item) {
         ForeignMod(ref mut _binding_0, ) => {
             _visitor.visit_item_foreign_mod_mut(&mut * _binding_0);
         }
-        Ty(ref mut _binding_0, ) => {
-            _visitor.visit_item_ty_mut(&mut * _binding_0);
+        Type(ref mut _binding_0, ) => {
+            _visitor.visit_item_type_mut(&mut * _binding_0);
         }
         Enum(ref mut _binding_0, ) => {
             _visitor.visit_item_enum_mut(&mut * _binding_0);
@@ -1249,7 +1249,7 @@ pub fn visit_item_const_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut I
     // Skipped field _i . const_token;
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . eq_token;
     _visitor.visit_expr_mut(&mut _i . expr);
     // Skipped field _i . semi_token;
@@ -1310,7 +1310,7 @@ pub fn visit_item_impl_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut It
     // Skipped field _i . impl_token;
     _visitor.visit_generics_mut(&mut _i . generics);
     // Skipped field _i . trait_;
-    _visitor.visit_ty_mut(&mut _i . self_ty);
+    _visitor.visit_type_mut(&mut _i . self_ty);
     // Skipped field _i . brace_token;
     for mut it in (_i . items).iter_mut() { _visitor.visit_impl_item_mut(&mut it) };
 }
@@ -1337,7 +1337,7 @@ pub fn visit_item_static_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut 
     _visitor.visit_mutability_mut(&mut _i . mutbl);
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . eq_token;
     _visitor.visit_expr_mut(&mut _i . expr);
     // Skipped field _i . semi_token;
@@ -1361,19 +1361,19 @@ pub fn visit_item_trait_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut I
     // Skipped field _i . ident;
     _visitor.visit_generics_mut(&mut _i . generics);
     // Skipped field _i . colon_token;
-    for mut el in (_i . supertraits).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_param_bound_mut(&mut it) };
+    for mut el in (_i . supertraits).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_param_bound_mut(&mut it) };
     // Skipped field _i . brace_token;
     for mut it in (_i . items).iter_mut() { _visitor.visit_trait_item_mut(&mut it) };
 }
 # [ cfg ( feature = "full" ) ]
-pub fn visit_item_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemTy) {
+pub fn visit_item_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ItemType) {
     for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     _visitor.visit_visibility_mut(&mut _i . vis);
     // Skipped field _i . type_token;
     // Skipped field _i . ident;
     _visitor.visit_generics_mut(&mut _i . generics);
     // Skipped field _i . eq_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . semi_token;
 }
 # [ cfg ( feature = "full" ) ]
@@ -1407,7 +1407,7 @@ pub fn visit_local_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Local)
     // Skipped field _i . eq_token;
     // Skipped field _i . semi_token;
     _visitor.visit_pat_mut(&mut _i . pat);
-    if let Some(ref mut it) = _i . ty { _visitor.visit_ty_mut(&mut * it) };
+    if let Some(ref mut it) = _i . ty { _visitor.visit_type_mut(&mut * it) };
     if let Some(ref mut it) = _i . init { _visitor.visit_expr_mut(&mut * it) };
     for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
 }
@@ -1464,8 +1464,8 @@ pub fn visit_method_sig_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut M
     _visitor.visit_fn_decl_mut(&mut _i . decl);
 }
 
-pub fn visit_mut_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut MutTy) {
-    _visitor.visit_ty_mut(&mut _i . ty);
+pub fn visit_mut_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut MutType) {
+    _visitor.visit_type_mut(&mut _i . ty);
     _visitor.visit_mutability_mut(&mut _i . mutability);
 }
 
@@ -1493,7 +1493,7 @@ pub fn visit_nested_meta_item_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: 
 
 pub fn visit_parenthesized_parameter_data_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ParenthesizedParameterData) {
     // Skipped field _i . paren_token;
-    for mut el in (_i . inputs).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_mut(&mut it) };
+    for mut el in (_i . inputs).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_mut(&mut it) };
     _visitor.visit_return_type_mut(&mut _i . output);
 }
 # [ cfg ( feature = "full" ) ]
@@ -1660,7 +1660,7 @@ pub fn visit_poly_trait_ref_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &m
 
 pub fn visit_qself_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut QSelf) {
     // Skipped field _i . lt_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . position;
     // Skipped field _i . as_token;
     // Skipped field _i . gt_token;
@@ -1682,8 +1682,8 @@ pub fn visit_return_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut 
     use ::ReturnType::*;
     match *_i {
         Default => { }
-        Ty(ref mut _binding_0, ref mut _binding_1, ) => {
-            _visitor.visit_ty_mut(&mut * _binding_0);
+        Type(ref mut _binding_0, ref mut _binding_1, ) => {
+            _visitor.visit_type_mut(&mut * _binding_0);
             // Skipped field * _binding_1;
         }
     }
@@ -1744,7 +1744,7 @@ pub fn visit_trait_item_const_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: 
     // Skipped field _i . const_token;
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . default;
     // Skipped field _i . semi_token;
 }
@@ -1766,52 +1766,52 @@ pub fn visit_trait_item_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &
     // Skipped field _i . type_token;
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_param_bound_mut(&mut it) };
+    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_param_bound_mut(&mut it) };
     // Skipped field _i . default;
     // Skipped field _i . semi_token;
 }
 
-pub fn visit_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Ty) {
-    use ::Ty::*;
+pub fn visit_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Type) {
+    use ::Type::*;
     match *_i {
         Slice(ref mut _binding_0, ) => {
-            _visitor.visit_ty_slice_mut(&mut * _binding_0);
+            _visitor.visit_type_slice_mut(&mut * _binding_0);
         }
         Array(ref mut _binding_0, ) => {
-            _visitor.visit_ty_array_mut(&mut * _binding_0);
+            _visitor.visit_type_array_mut(&mut * _binding_0);
         }
         Ptr(ref mut _binding_0, ) => {
-            _visitor.visit_ty_ptr_mut(&mut * _binding_0);
+            _visitor.visit_type_ptr_mut(&mut * _binding_0);
         }
         Rptr(ref mut _binding_0, ) => {
-            _visitor.visit_ty_rptr_mut(&mut * _binding_0);
+            _visitor.visit_type_rptr_mut(&mut * _binding_0);
         }
         BareFn(ref mut _binding_0, ) => {
-            _visitor.visit_ty_bare_fn_mut(&mut * _binding_0);
+            _visitor.visit_type_bare_fn_mut(&mut * _binding_0);
         }
         Never(ref mut _binding_0, ) => {
-            _visitor.visit_ty_never_mut(&mut * _binding_0);
+            _visitor.visit_type_never_mut(&mut * _binding_0);
         }
         Tup(ref mut _binding_0, ) => {
-            _visitor.visit_ty_tup_mut(&mut * _binding_0);
+            _visitor.visit_type_tup_mut(&mut * _binding_0);
         }
         Path(ref mut _binding_0, ) => {
-            _visitor.visit_ty_path_mut(&mut * _binding_0);
+            _visitor.visit_type_path_mut(&mut * _binding_0);
         }
         TraitObject(ref mut _binding_0, ) => {
-            _visitor.visit_ty_trait_object_mut(&mut * _binding_0);
+            _visitor.visit_type_trait_object_mut(&mut * _binding_0);
         }
         ImplTrait(ref mut _binding_0, ) => {
-            _visitor.visit_ty_impl_trait_mut(&mut * _binding_0);
+            _visitor.visit_type_impl_trait_mut(&mut * _binding_0);
         }
         Paren(ref mut _binding_0, ) => {
-            _visitor.visit_ty_paren_mut(&mut * _binding_0);
+            _visitor.visit_type_paren_mut(&mut * _binding_0);
         }
         Group(ref mut _binding_0, ) => {
-            _visitor.visit_ty_group_mut(&mut * _binding_0);
+            _visitor.visit_type_group_mut(&mut * _binding_0);
         }
         Infer(ref mut _binding_0, ) => {
-            _visitor.visit_ty_infer_mut(&mut * _binding_0);
+            _visitor.visit_type_infer_mut(&mut * _binding_0);
         }
         Macro(ref mut _binding_0, ) => {
             _visitor.visit_macro_mut(&mut * _binding_0);
@@ -1819,46 +1819,52 @@ pub fn visit_ty_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Ty) {
     }
 }
 
-pub fn visit_ty_array_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyArray) {
+pub fn visit_type_array_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeArray) {
     // Skipped field _i . bracket_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . semi_token;
     _visitor.visit_expr_mut(&mut _i . amt);
 }
 
-pub fn visit_ty_bare_fn_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyBareFn) {
-    _visitor.visit_bare_fn_ty_mut(&mut _i . ty);
+pub fn visit_type_bare_fn_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeBareFn) {
+    _visitor.visit_bare_fn_type_mut(&mut _i . ty);
 }
 
-pub fn visit_ty_group_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyGroup) {
+pub fn visit_type_binding_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeBinding) {
+    // Skipped field _i . ident;
+    // Skipped field _i . eq_token;
+    _visitor.visit_type_mut(&mut _i . ty);
+}
+
+pub fn visit_type_group_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeGroup) {
     // Skipped field _i . group_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
 }
 
-pub fn visit_ty_impl_trait_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyImplTrait) {
+pub fn visit_type_impl_trait_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeImplTrait) {
     // Skipped field _i . impl_token;
-    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_param_bound_mut(&mut it) };
+    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_param_bound_mut(&mut it) };
 }
 
-pub fn visit_ty_infer_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyInfer) {
+pub fn visit_type_infer_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeInfer) {
     // Skipped field _i . underscore_token;
 }
 
-pub fn visit_ty_never_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyNever) {
+pub fn visit_type_never_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeNever) {
     // Skipped field _i . bang_token;
 }
 
-pub fn visit_ty_param_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyParam) {
+pub fn visit_type_param_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeParam) {
     for mut it in (_i . attrs).iter_mut() { _visitor.visit_attribute_mut(&mut it) };
     // Skipped field _i . ident;
     // Skipped field _i . colon_token;
-    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_param_bound_mut(&mut it) };
+    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_param_bound_mut(&mut it) };
     // Skipped field _i . eq_token;
-    if let Some(ref mut it) = _i . default { _visitor.visit_ty_mut(&mut * it) };
+    if let Some(ref mut it) = _i . default { _visitor.visit_type_mut(&mut * it) };
 }
 
-pub fn visit_ty_param_bound_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyParamBound) {
-    use ::TyParamBound::*;
+pub fn visit_type_param_bound_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeParamBound) {
+    use ::TypeParamBound::*;
     match *_i {
         Trait(ref mut _binding_0, ref mut _binding_1, ) => {
             _visitor.visit_poly_trait_ref_mut(&mut * _binding_0);
@@ -1870,47 +1876,41 @@ pub fn visit_ty_param_bound_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &m
     }
 }
 
-pub fn visit_ty_paren_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyParen) {
+pub fn visit_type_paren_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeParen) {
     // Skipped field _i . paren_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
+    _visitor.visit_type_mut(&mut _i . ty);
 }
 
-pub fn visit_ty_path_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyPath) {
+pub fn visit_type_path_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypePath) {
     if let Some(ref mut it) = _i . qself { _visitor.visit_qself_mut(&mut * it) };
     _visitor.visit_path_mut(&mut _i . path);
 }
 
-pub fn visit_ty_ptr_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyPtr) {
+pub fn visit_type_ptr_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypePtr) {
     // Skipped field _i . star_token;
     // Skipped field _i . const_token;
-    _visitor.visit_mut_ty_mut(&mut _i . ty);
+    _visitor.visit_mut_type_mut(&mut _i . ty);
 }
 
-pub fn visit_ty_rptr_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyRptr) {
+pub fn visit_type_rptr_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeRptr) {
     // Skipped field _i . and_token;
     // Skipped field _i . lifetime;
-    _visitor.visit_mut_ty_mut(&mut _i . ty);
+    _visitor.visit_mut_type_mut(&mut _i . ty);
 }
 
-pub fn visit_ty_slice_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TySlice) {
-    _visitor.visit_ty_mut(&mut _i . ty);
+pub fn visit_type_slice_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeSlice) {
+    _visitor.visit_type_mut(&mut _i . ty);
     // Skipped field _i . bracket_token;
 }
 
-pub fn visit_ty_trait_object_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyTraitObject) {
-    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_param_bound_mut(&mut it) };
+pub fn visit_type_trait_object_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeTraitObject) {
+    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_param_bound_mut(&mut it) };
 }
 
-pub fn visit_ty_tup_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TyTup) {
+pub fn visit_type_tup_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeTup) {
     // Skipped field _i . paren_token;
-    for mut el in (_i . tys).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_mut(&mut it) };
+    for mut el in (_i . tys).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_mut(&mut it) };
     // Skipped field _i . lone_comma;
-}
-
-pub fn visit_type_binding_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut TypeBinding) {
-    // Skipped field _i . ident;
-    // Skipped field _i . eq_token;
-    _visitor.visit_ty_mut(&mut _i . ty);
 }
 
 pub fn visit_un_op_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut UnOp) {
@@ -2016,9 +2016,9 @@ pub fn visit_visibility_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut V
 
 pub fn visit_where_bound_predicate_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut WhereBoundPredicate) {
     if let Some(ref mut it) = _i . bound_lifetimes { _visitor.visit_bound_lifetimes_mut(&mut * it) };
-    _visitor.visit_ty_mut(&mut _i . bounded_ty);
+    _visitor.visit_type_mut(&mut _i . bounded_ty);
     // Skipped field _i . colon_token;
-    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_ty_param_bound_mut(&mut it) };
+    for mut el in (_i . bounds).iter_mut() { let mut it = el.item_mut(); _visitor.visit_type_param_bound_mut(&mut it) };
 }
 
 pub fn visit_where_clause_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut WhereClause) {
@@ -2027,9 +2027,9 @@ pub fn visit_where_clause_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut
 }
 
 pub fn visit_where_eq_predicate_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut WhereEqPredicate) {
-    _visitor.visit_ty_mut(&mut _i . lhs_ty);
+    _visitor.visit_type_mut(&mut _i . lhs_ty);
     // Skipped field _i . eq_token;
-    _visitor.visit_ty_mut(&mut _i . rhs_ty);
+    _visitor.visit_type_mut(&mut _i . rhs_ty);
 }
 
 pub fn visit_where_predicate_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut WherePredicate) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,11 @@ pub use expr::{Arm, BindingMode, Block, CaptureBy, FieldPat, FieldValue, Local,
                PatLit, PatRange, PatSlice, InPlaceKind};
 
 mod generics;
-pub use generics::{Generics, LifetimeDef, TraitBoundModifier, TyParam, TyParamBound,
+pub use generics::{Generics, LifetimeDef, TraitBoundModifier, TypeParam, TypeParamBound,
                    WhereBoundPredicate, WhereClause, WhereEqPredicate, WherePredicate,
                    WhereRegionPredicate, BoundLifetimes};
 #[cfg(feature = "printing")]
-pub use generics::{ImplGenerics, Turbofish, TyGenerics};
+pub use generics::{ImplGenerics, Turbofish, TypeGenerics};
 
 mod ident;
 pub use ident::Ident;
@@ -55,7 +55,7 @@ mod item;
 pub use item::{Constness, Defaultness, FnArg, FnDecl, ForeignItem, ItemForeignMod,
                ImplItem, ImplPolarity, Item, MethodSig, PathListItem,
                TraitItem, ViewPath, ItemExternCrate, ItemUse,
-               ItemStatic, ItemConst, ItemFn, ItemMacro, ItemMod, ItemTy, ItemEnum,
+               ItemStatic, ItemConst, ItemFn, ItemMacro, ItemMod, ItemType, ItemEnum,
                ItemStruct, ItemUnion, ItemTrait, ItemDefaultImpl, ItemImpl,
                PathSimple, PathGlob, PathList, ForeignItemFn, ForeignItemStatic,
                TraitItemConst, TraitItemMacro, TraitItemMethod, TraitItemType,
@@ -83,11 +83,11 @@ mod op;
 pub use op::{BinOp, UnOp};
 
 mod ty;
-pub use ty::{Abi, AbiKind, AngleBracketedParameterData, BareFnArg, BareFnArgName, BareFnTy,
-             ReturnType, MutTy, Mutability, ParenthesizedParameterData, Path,
-             PathParameters, PathSegment, PolyTraitRef, QSelf, Ty, TypeBinding, Unsafety,
-             TySlice, TyArray, TyPtr, TyRptr, TyBareFn, TyNever, TyTup, TyPath,
-             TyTraitObject, TyImplTrait, TyParen, TyInfer, TyGroup};
+pub use ty::{Abi, AbiKind, AngleBracketedParameterData, BareFnArg, BareFnArgName, BareFnType,
+             ReturnType, MutType, Mutability, ParenthesizedParameterData, Path,
+             PathParameters, PathSegment, PolyTraitRef, QSelf, Type, TypeBinding, Unsafety,
+             TypeSlice, TypeArray, TypePtr, TypeRptr, TypeBareFn, TypeNever, TypeTup, TypePath,
+             TypeTraitObject, TypeImplTrait, TypeParen, TypeInfer, TypeGroup};
 #[cfg(feature = "printing")]
 pub use ty::PathTokens;
 

--- a/syn_codegen/src/main.rs
+++ b/syn_codegen/src/main.rs
@@ -285,9 +285,9 @@ mod codegen {
         name.as_ref().to_snake_case().into()
     }
 
-    fn last_segment(ty: &Ty) -> Option<&PathSegment> {
+    fn last_segment(ty: &Type) -> Option<&PathSegment> {
         match *ty {
-            Ty::Path(ref typath) => {
+            Type::Path(ref typath) => {
                 if typath.qself.is_some() {
                     return None;
                 }
@@ -308,7 +308,7 @@ mod codegen {
         Fold,
     }
 
-    fn first_param(params: &PathParameters) -> &Ty {
+    fn first_param(params: &PathParameters) -> &Type {
         let data = match *params {
             PathParameters::AngleBracketed(ref data) => data,
             _ => panic!("Expected at least 1 type parameter here"),
@@ -493,7 +493,7 @@ mod codegen {
         None
     }
 
-    fn visit(ty: &Ty, lookup: &Lookup, kind: Kind, name: &Tokens) -> String {
+    fn visit(ty: &Type, lookup: &Lookup, kind: Kind, name: &Tokens) -> String {
         if let Some(seg) = last_segment(ty) {
             let mut eos_full = false;
             if let Some(res) = option_visit(seg, lookup, kind, name, &mut eos_full) {

--- a/synom/src/helper.rs
+++ b/synom/src/helper.rs
@@ -42,11 +42,11 @@ macro_rules! option {
 /// extern crate syn;
 /// #[macro_use] extern crate synom;
 ///
-/// use syn::{Lifetime, Ty};
+/// use syn::{Lifetime, Type};
 /// use syn::delimited::Delimited;
 /// use syn::tokens::*;
 ///
-/// named!(bound_lifetimes -> (Vec<Lifetime>, Ty), tuple!(
+/// named!(bound_lifetimes -> (Vec<Lifetime>, Type), tuple!(
 ///     opt_vec!(do_parse!(
 ///         keyword!(for) >>
 ///         punct!(<) >>
@@ -54,7 +54,7 @@ macro_rules! option {
 ///         punct!(>) >>
 ///         (lifetimes.into_vec())
 ///     )),
-///     syn!(Ty)
+///     syn!(Type)
 /// ));
 ///
 /// # fn main() {}

--- a/synom/src/lib.rs
+++ b/synom/src/lib.rs
@@ -114,10 +114,10 @@ impl Synom for TokenStream {
 /// ```rust
 /// # extern crate syn;
 /// # #[macro_use] extern crate synom;
-/// # use syn::Ty;
+/// # use syn::Type;
 /// # use synom::delimited::Delimited;
 /// // One or more Rust types separated by commas.
-/// named!(pub comma_separated_types -> Delimited<Ty, Token![,]>,
+/// named!(pub comma_separated_types -> Delimited<Type, Token![,]>,
 ///     call!(Delimited::parse_separated_nonempty)
 /// );
 /// # fn main() {}
@@ -449,7 +449,7 @@ macro_rules! peek {
 /// extern crate syn;
 /// #[macro_use] extern crate synom;
 ///
-/// use syn::{Ident, Ty};
+/// use syn::{Ident, Type};
 ///
 /// #[derive(Debug)]
 /// enum UnitType {
@@ -606,9 +606,9 @@ macro_rules! reject {
 /// extern crate syn;
 /// #[macro_use] extern crate synom;
 ///
-/// use syn::Ty;
+/// use syn::Type;
 ///
-/// named!(two_types -> (Ty, Ty), tuple!(syn!(Ty), syn!(Ty)));
+/// named!(two_types -> (Type, Type), tuple!(syn!(Type), syn!(Type)));
 ///
 /// # fn main() {}
 /// ```

--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -95,7 +95,7 @@ fn test_struct() {
                         pub_token: Default::default(),
                     }),
                     attrs: Vec::new(),
-                    ty: TyPath {
+                    ty: TypePath {
                         qself: None,
                         path: "Ident".into(),
                     }.into(),
@@ -107,7 +107,7 @@ fn test_struct() {
                         pub_token: Default::default(),
                     }),
                     attrs: Vec::new(),
-                    ty: TyPath {
+                    ty: TypePath {
                         qself: None,
                         path: Path {
                             leading_colon: None,
@@ -119,7 +119,7 @@ fn test_struct() {
                                             turbofish: None,
                                             lt_token: Default::default(),
                                             lifetimes: Default::default(),
-                                            types: vec![Ty::from(TyPath {
+                                            types: vec![Type::from(TypePath {
                                                 qself: None,
                                                 path: "Attribute".into(),
                                             })].into(),
@@ -200,7 +200,7 @@ fn test_enum() {
             lt_token: Some(Default::default()),
             gt_token: Some(Default::default()),
             ty_params: vec![
-                TyParam {
+                TypeParam {
                     attrs: Vec::new(),
                     ident: "T".into(),
                     bounds: Default::default(),
@@ -208,7 +208,7 @@ fn test_enum() {
                     colon_token: None,
                     eq_token: None,
                 },
-                TyParam {
+                TypeParam {
                     attrs: Vec::new(),
                     ident: "E".into(),
                     bounds: Default::default(),
@@ -231,7 +231,7 @@ fn test_enum() {
                             ident: None,
                             vis: Visibility::Inherited(VisInherited {}),
                             attrs: Vec::new(),
-                            ty: TyPath { qself: None, path: "T".into() }.into(),
+                            ty: TypePath { qself: None, path: "T".into() }.into(),
                         },
                     ].into(), Default::default()),
                     discriminant: None,
@@ -246,7 +246,7 @@ fn test_enum() {
                             colon_token: None,
                             vis: Visibility::Inherited(VisInherited {}),
                             attrs: Vec::new(),
-                            ty: TyPath { qself: None, path: "E".into() }.into(),
+                            ty: TypePath { qself: None, path: "E".into() }.into(),
                         },
                     ].into(), Default::default()),
                     discriminant: None,
@@ -500,7 +500,7 @@ fn test_pub_restricted() {
                 }),
                 colon_token: None,
                 attrs: vec![],
-                ty: TyPath {
+                ty: TypePath {
                     qself: None,
                     path: "u8".into(),
                 }.into(),

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -32,7 +32,7 @@ fn test_split_for_impl() {
             },
         ].into(),
         ty_params: vec![
-            TyParam {
+            TypeParam {
                 attrs: vec![Attribute {
                     bracket_token: Default::default(),
                     pound_token: Default::default(),
@@ -42,8 +42,8 @@ fn test_split_for_impl() {
                     is_sugared_doc: false,
                 }],
                 ident: "T".into(),
-                bounds: vec![TyParamBound::Region(Lifetime::new(Term::intern("'a"), Span::default()))].into(),
-                default: Some(TyTup {
+                bounds: vec![TypeParamBound::Region(Lifetime::new(Term::intern("'a"), Span::default()))].into(),
+                default: Some(TypeTup {
                     tys: Default::default(),
                     lone_comma: None,
                     paren_token: Default::default(),
@@ -58,12 +58,12 @@ fn test_split_for_impl() {
                 WherePredicate::BoundPredicate(WhereBoundPredicate {
                     bound_lifetimes: None,
                     colon_token: Default::default(),
-                    bounded_ty: TyPath {
+                    bounded_ty: TypePath {
                         qself: None,
                         path: "T".into(),
                     }.into(),
                     bounds: vec![
-                        TyParamBound::Trait(
+                        TypeParamBound::Trait(
                             PolyTraitRef {
                                 bound_lifetimes: None,
                                 trait_ref: "Debug".into(),
@@ -97,24 +97,24 @@ fn test_split_for_impl() {
 #[test]
 fn test_ty_param_bound() {
     let tokens = quote!('a);
-    let expected = TyParamBound::Region(Lifetime::new(Term::intern("'a"), Span::default()));
-    assert_eq!(expected, common::parse::syn::<TyParamBound>(tokens.into()));
+    let expected = TypeParamBound::Region(Lifetime::new(Term::intern("'a"), Span::default()));
+    assert_eq!(expected, common::parse::syn::<TypeParamBound>(tokens.into()));
 
     let tokens = quote!(Debug);
-    let expected = TyParamBound::Trait(
+    let expected = TypeParamBound::Trait(
         PolyTraitRef {
             bound_lifetimes: None,
             trait_ref: "Debug".into(),
         },
         TraitBoundModifier::None);
-    assert_eq!(expected, common::parse::syn::<TyParamBound>(tokens.into()));
+    assert_eq!(expected, common::parse::syn::<TypeParamBound>(tokens.into()));
 
     let tokens = quote!(?Sized);
-    let expected = TyParamBound::Trait(
+    let expected = TypeParamBound::Trait(
         PolyTraitRef {
             bound_lifetimes: None,
             trait_ref: "Sized".into(),
         },
         TraitBoundModifier::Maybe(Default::default()));
-    assert_eq!(expected, common::parse::syn::<TyParamBound>(tokens.into()));
+    assert_eq!(expected, common::parse::syn::<TypeParamBound>(tokens.into()));
 }

--- a/tests/test_precedence.rs
+++ b/tests/test_precedence.rs
@@ -345,7 +345,7 @@ fn syn_brackets(syn_expr: syn::Expr) -> syn::Expr {
             pat
         }
 
-        fn fold_ty(&mut self, ty: Ty) -> Ty {
+        fn fold_type(&mut self, ty: Type) -> Type {
             ty
         }
     }


### PR DESCRIPTION
Rust source code does not abbreviate type -> ty (the way it abbreviates impl and mod, for example). This commit updates the naming in syn to reflect that.