### PR TITLE
Separate unsafe blocks into a ExprKind variant

### DIFF
--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -176,6 +176,8 @@ fn fold_expr_type(&mut self, i: ExprType) -> ExprType { fold_expr_type(self, i) 
 
 fn fold_expr_unary(&mut self, i: ExprUnary) -> ExprUnary { fold_expr_unary(self, i) }
 # [ cfg ( feature = "full" ) ]
+fn fold_expr_unsafe(&mut self, i: ExprUnsafe) -> ExprUnsafe { fold_expr_unsafe(self, i) }
+# [ cfg ( feature = "full" ) ]
 fn fold_expr_while(&mut self, i: ExprWhile) -> ExprWhile { fold_expr_while(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn fold_expr_while_let(&mut self, i: ExprWhileLet) -> ExprWhileLet { fold_expr_while_let(self, i) }
@@ -833,7 +835,6 @@ pub fn fold_expr_binary<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprBinary) ->
 # [ cfg ( feature = "full" ) ]
 pub fn fold_expr_block<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprBlock) -> ExprBlock {
     ExprBlock {
-        unsafety: _visitor.fold_unsafety(_i . unsafety),
         block: _visitor.fold_block(_i . block),
     }
 }
@@ -1058,6 +1059,11 @@ pub fn fold_expr_kind<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprKind) -> Exp
                 full!(_visitor.fold_expr_closure(_binding_0)),
             )
         }
+        Unsafe(_binding_0, ) => {
+            Unsafe (
+                full!(_visitor.fold_expr_unsafe(_binding_0)),
+            )
+        }
         Block(_binding_0, ) => {
             Block (
                 full!(_visitor.fold_expr_block(_binding_0)),
@@ -1276,6 +1282,13 @@ pub fn fold_expr_unary<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprUnary) -> E
     ExprUnary {
         op: _visitor.fold_un_op(_i . op),
         expr: Box::new(_visitor.fold_expr(* _i . expr)),
+    }
+}
+# [ cfg ( feature = "full" ) ]
+pub fn fold_expr_unsafe<V: Folder + ?Sized>(_visitor: &mut V, _i: ExprUnsafe) -> ExprUnsafe {
+    ExprUnsafe {
+        unsafe_token: _i . unsafe_token,
+        block: _visitor.fold_block(_i . block),
     }
 }
 # [ cfg ( feature = "full" ) ]

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -149,6 +149,8 @@ fn visit_expr_type(&mut self, i: &'ast ExprType) { visit_expr_type(self, i) }
 
 fn visit_expr_unary(&mut self, i: &'ast ExprUnary) { visit_expr_unary(self, i) }
 # [ cfg ( feature = "full" ) ]
+fn visit_expr_unsafe(&mut self, i: &'ast ExprUnsafe) { visit_expr_unsafe(self, i) }
+# [ cfg ( feature = "full" ) ]
 fn visit_expr_while(&mut self, i: &'ast ExprWhile) { visit_expr_while(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_expr_while_let(&mut self, i: &'ast ExprWhileLet) { visit_expr_while_let(self, i) }
@@ -687,7 +689,6 @@ pub fn visit_expr_binary<'ast, V: Visitor<'ast> + ?Sized>(_visitor: &mut V, _i: 
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_expr_block<'ast, V: Visitor<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast ExprBlock) {
-    _visitor.visit_unsafety(&_i . unsafety);
     _visitor.visit_block(&_i . block);
 }
 # [ cfg ( feature = "full" ) ]
@@ -845,6 +846,9 @@ pub fn visit_expr_kind<'ast, V: Visitor<'ast> + ?Sized>(_visitor: &mut V, _i: &'
         Closure(ref _binding_0, ) => {
             full!(_visitor.visit_expr_closure(&* _binding_0));
         }
+        Unsafe(ref _binding_0, ) => {
+            full!(_visitor.visit_expr_unsafe(&* _binding_0));
+        }
         Block(ref _binding_0, ) => {
             full!(_visitor.visit_expr_block(&* _binding_0));
         }
@@ -996,6 +1000,11 @@ pub fn visit_expr_type<'ast, V: Visitor<'ast> + ?Sized>(_visitor: &mut V, _i: &'
 pub fn visit_expr_unary<'ast, V: Visitor<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast ExprUnary) {
     _visitor.visit_un_op(&_i . op);
     _visitor.visit_expr(&_i . expr);
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_expr_unsafe<'ast, V: Visitor<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast ExprUnsafe) {
+    // Skipped field _i . unsafe_token;
+    _visitor.visit_block(&_i . block);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_expr_while<'ast, V: Visitor<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast ExprWhile) {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -149,6 +149,8 @@ fn visit_expr_type_mut(&mut self, i: &mut ExprType) { visit_expr_type_mut(self, 
 
 fn visit_expr_unary_mut(&mut self, i: &mut ExprUnary) { visit_expr_unary_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
+fn visit_expr_unsafe_mut(&mut self, i: &mut ExprUnsafe) { visit_expr_unsafe_mut(self, i) }
+# [ cfg ( feature = "full" ) ]
 fn visit_expr_while_mut(&mut self, i: &mut ExprWhile) { visit_expr_while_mut(self, i) }
 # [ cfg ( feature = "full" ) ]
 fn visit_expr_while_let_mut(&mut self, i: &mut ExprWhileLet) { visit_expr_while_let_mut(self, i) }
@@ -687,7 +689,6 @@ pub fn visit_expr_binary_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut 
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_expr_block_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprBlock) {
-    _visitor.visit_unsafety_mut(&mut _i . unsafety);
     _visitor.visit_block_mut(&mut _i . block);
 }
 # [ cfg ( feature = "full" ) ]
@@ -845,6 +846,9 @@ pub fn visit_expr_kind_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Ex
         Closure(ref mut _binding_0, ) => {
             full!(_visitor.visit_expr_closure_mut(&mut * _binding_0));
         }
+        Unsafe(ref mut _binding_0, ) => {
+            full!(_visitor.visit_expr_unsafe_mut(&mut * _binding_0));
+        }
         Block(ref mut _binding_0, ) => {
             full!(_visitor.visit_expr_block_mut(&mut * _binding_0));
         }
@@ -996,6 +1000,11 @@ pub fn visit_expr_type_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut Ex
 pub fn visit_expr_unary_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprUnary) {
     _visitor.visit_un_op_mut(&mut _i . op);
     _visitor.visit_expr_mut(&mut _i . expr);
+}
+# [ cfg ( feature = "full" ) ]
+pub fn visit_expr_unsafe_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprUnsafe) {
+    // Skipped field _i . unsafe_token;
+    _visitor.visit_block_mut(&mut _i . block);
 }
 # [ cfg ( feature = "full" ) ]
 pub fn visit_expr_while_mut<V: VisitorMut + ?Sized>(_visitor: &mut V, _i: &mut ExprWhile) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use expr::{Expr, ExprKind, ExprBox, ExprInPlace, ExprArray, ExprCall,
                ExprAssign, ExprAssignOp, ExprField, ExprTupField, ExprIndex,
                ExprRange, ExprPath, ExprAddrOf, ExprBreak, ExprContinue,
                ExprRet, ExprStruct, ExprRepeat, ExprParen, ExprTry, ExprCatch,
-               ExprGroup, ExprYield};
+               ExprGroup, ExprYield, ExprUnsafe};
 
 #[cfg(feature = "full")]
 pub use expr::{Arm, BindingMode, Block, CaptureBy, FieldPat, FieldValue, Local,

--- a/tests/test_precedence.rs
+++ b/tests/test_precedence.rs
@@ -45,6 +45,7 @@ fn test_simple_precedence() {
         "{ for i in r { } *some_ptr += 1; }",
         "{ loop { break 5; } }",
         "{ if true { () }.mthd() }",
+        "{ for i in unsafe { 20 } { } }",
     ];
 
     let mut failed = 0;

--- a/tests/test_precedence.rs
+++ b/tests/test_precedence.rs
@@ -322,6 +322,7 @@ fn syn_brackets(syn_expr: syn::Expr) -> syn::Expr {
                 ExprKind::Group(_) => unreachable!(),
                 ExprKind::Paren(p) => paren(self, p.expr.node),
                 ExprKind::If(..) |
+                ExprKind::Unsafe(..) |
                 ExprKind::Block(..) |
                 ExprKind::IfLet(..) => {
                     return fold_expr(self, expr);


### PR DESCRIPTION
Fixes #202 

Not sure if this is the best approach - I could also just keep `unsafe { }` and `{ }` having the same AST node kind, and only change the parsers, but `unsafe { }` felt different enough to me that I figured it'd be OK to make it a separate ExprKind.