### PR TITLE
Add a feature to synom for verbose parsing logging

### DIFF
--- a/synom/Cargo.toml
+++ b/synom/Cargo.toml
@@ -22,6 +22,10 @@ default = []
 clone-impls = []
 extra-traits = []
 
+# NOTE: This feature is very verbose - it will cause every call!() expression to
+# be logged to stderr. It exists mostly as a debugging tool.
+verbose-trace = []
+
 [dev-dependencies.syn]
 version = "0.11"
 path = ".."

--- a/synom/src/cursor.rs
+++ b/synom/src/cursor.rs
@@ -347,11 +347,10 @@ impl<'a> Cursor<'a> {
 // pretty useless.
 impl<'a> fmt::Debug for Cursor<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Cursor")
-            .field("ptr", &self.ptr)
-            .field("scope", &self.scope)
-            // Dummy `entry` field to show data behind the `ptr` ptr.
-            .field("entry", self.entry())
+        // Print what the cursor is currently looking at.
+        // This will look like Cursor("some remaining tokens here")
+        f.debug_tuple("Cursor")
+            .field(&self.token_stream().to_string())
             .finish()
     }
 }

--- a/synom/src/lib.rs
+++ b/synom/src/lib.rs
@@ -151,12 +151,30 @@ macro_rules! named {
     };
 }
 
+#[cfg(feature = "verbose-trace")]
+#[macro_export]
+macro_rules! call {
+    ($i:expr, $fun:expr $(, $args:expr)*) => {
+        {
+            let i = $i;
+            eprintln!(concat!(" -> ", stringify!($fun), " @ {:?}"), i);
+            let r = $fun(i $(, $args)*);
+            match r {
+                Ok((i, _)) => eprintln!(concat!("OK  ", stringify!($fun), " @ {:?}"), i),
+                Err(_) => eprintln!(concat!("ERR ", stringify!($fun), " @ {:?}"), i),
+            }
+            r
+        }
+    };
+}
+
 /// Invoke the given parser function with the passed in arguments.
 ///
 /// - **Syntax:** `call!(FUNCTION, ARGS...)`
 ///
 ///   where the signature of the function is `fn(&[U], ARGS...) -> IPResult<&[U], T>`
 /// - **Output:** `T`, the result of invoking the function `FUNCTION`
+#[cfg(not(feature = "verbose-trace"))]
 #[macro_export]
 macro_rules! call {
     ($i:expr, $fun:expr $(, $args:expr)*) => {


### PR DESCRIPTION
I'm not sure if we want this to be in the tree, but I've written code which does something like this to debug why and where a parse is failing multiple times.

I intentionally don't expose this as a feature on syn, as I don't want --all-features on syn to pick it up ('cause we use that for tests), but this unfortunately makes it a bit hard to use this feature when testing. I usually edit synom's Cargo.toml when I want to turn it on.