### PR TITLE
Bring back `VariantData::fields` and `VariantData::fields_mut`

### DIFF
--- a/src/derive.rs
+++ b/src/derive.rs
@@ -77,37 +77,21 @@ ast_enum_of_structs! {
 
 impl Fields {
     /// Returns an iterator over the fields
-    pub fn iter(&self) -> MaybeEmpty<Iter<Field, Token![,]>> {
+    pub fn iter(&self) -> Iter<Field, Token![,]> {
         match *self {
-            Fields::Unit => MaybeEmpty::None,
-            Fields::Named(FieldsNamed { ref named, .. }) => MaybeEmpty::Some(named.iter()),
-            Fields::Unnamed(FieldsUnnamed { ref unnamed, .. }) => MaybeEmpty::Some(unnamed.iter()),
+            Fields::Unit => Iter::empty(),
+            Fields::Named(FieldsNamed { ref named, .. }) => named.iter(),
+            Fields::Unnamed(FieldsUnnamed { ref unnamed, .. }) => unnamed.iter(),
         }
     }
 }
 
 impl<'a> IntoIterator for &'a Fields {
     type Item = &'a Field;
-    type IntoIter = MaybeEmpty<Iter<'a, Field, Token![,]>>;
+    type IntoIter = Iter<'a, Field, Token![,]>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-pub enum MaybeEmpty<T> {
-    Some(T),
-    None,
-}
-
-impl<T: Iterator> Iterator for MaybeEmpty<T> {
-    type Item = T::Item;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match *self {
-            MaybeEmpty::Some(ref mut x) => x.next(),
-            MaybeEmpty::None => None,
-        }
     }
 }
 

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use super::*;
-use punctuated::{Iter, IterMut, Punctuated};
+use punctuated::{Iter, Punctuated};
 
 ast_struct! {
     /// Data structure sent to a `proc_macro_derive` macro.
@@ -75,23 +75,23 @@ ast_enum_of_structs! {
     do_not_generate_to_tokens
 }
 
-impl DataStruct {
-    /// Returns an iterator over the fields of this struct
-    pub fn fields(&self) -> MaybeEmpty<Iter<Field, Token![,]>> {
-        match self.fields {
+impl Fields {
+    /// Returns an iterator over the fields
+    pub fn iter(&self) -> MaybeEmpty<Iter<Field, Token![,]>> {
+        match *self {
             Fields::Unit => MaybeEmpty::None,
             Fields::Named(FieldsNamed { ref named, .. }) => MaybeEmpty::Some(named.iter()),
             Fields::Unnamed(FieldsUnnamed { ref unnamed, .. }) => MaybeEmpty::Some(unnamed.iter()),
         }
     }
+}
 
-    /// Returns an iterator over mutable references to the fields of this struct
-    pub fn fields_mut(&mut self) -> MaybeEmpty<IterMut<Field, Token![,]>> {
-        match self.fields {
-            Fields::Unit => MaybeEmpty::None,
-            Fields::Named(FieldsNamed { ref mut named, .. }) => MaybeEmpty::Some(named.iter_mut()),
-            Fields::Unnamed(FieldsUnnamed { ref mut unnamed, .. }) => MaybeEmpty::Some(unnamed.iter_mut()),
-        }
+impl<'a> IntoIterator for &'a Fields {
+    type Item = &'a Field;
+    type IntoIter = MaybeEmpty<Iter<'a, Field, Token![,]>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -398,6 +398,14 @@ pub struct Iter<'a, T: 'a, P: 'a> {
     inner: slice::Iter<'a, (T, Option<P>)>,
 }
 
+impl<'a, T: 'a, P: 'a> Iter<'a, T, P> {
+    pub(crate) fn empty() -> Self {
+        Self {
+            inner: [].iter(),
+        }
+    }
+}
+
 impl<'a, T, P> Iterator for Iter<'a, T, P> {
     type Item = &'a T;
 

--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -637,7 +637,7 @@ fn test_fields_on_unit_struct() {
         _ => panic!("expected a struct"),
     };
 
-    assert_eq!(0, struct_body.fields().count());
+    assert_eq!(0, struct_body.fields.iter().count());
 }
 
 #[test]
@@ -671,7 +671,7 @@ fn test_fields_on_named_struct() {
     ];
     let expected = expected.iter().collect::<Vec<_>>();
 
-    assert_eq!(expected, struct_body.fields().collect::<Vec<_>>());
+    assert_eq!(expected, struct_body.fields.iter().collect::<Vec<_>>());
 }
 
 #[test]
@@ -702,81 +702,5 @@ fn test_fields_on_tuple_struct() {
     ];
     let expected = expected.iter().collect::<Vec<_>>();
 
-    assert_eq!(expected, struct_body.fields().collect::<Vec<_>>());
-}
-
-#[test]
-fn test_fields_mut_on_unit_struct() {
-    let raw = "struct S;";
-    let mut struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
-        Data::Struct(body) => body,
-        _ => panic!("expected a struct"),
-    };
-
-    assert_eq!(0, struct_body.fields_mut().count());
-}
-
-#[test]
-fn test_fields_mut_on_named_struct() {
-    let raw = "struct S {
-        foo: i32,
-        pub bar: String,
-    }";
-    let mut struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
-        Data::Struct(body) => body,
-        _ => panic!("expected a struct"),
-    };
-
-    let mut expected = vec![
-        Field {
-            attrs: vec![],
-            vis: Visibility::Inherited,
-            ident: Some(Ident::from("foo")),
-            colon_token: Some(Default::default()),
-            ty: syn::parse_str("i32").unwrap(),
-        },
-        Field {
-            attrs: vec![],
-            vis: Visibility::Public(VisPublic {
-                pub_token: Default::default(),
-            }),
-            ident: Some(Ident::from("bar")),
-            colon_token: Some(Default::default()),
-            ty: syn::parse_str("String").unwrap(),
-        },
-    ];
-    let expected = expected.iter_mut().collect::<Vec<_>>();
-
-    assert_eq!(expected, struct_body.fields_mut().collect::<Vec<_>>());
-}
-
-#[test]
-fn test_fields_mut_on_tuple_struct() {
-    let raw = "struct S(i32, pub String);";
-    let mut struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
-        Data::Struct(body) => body,
-        _ => panic!("expected a struct"),
-    };
-
-    let mut expected = vec![
-        Field {
-            attrs: vec![],
-            vis: Visibility::Inherited,
-            ident: None,
-            colon_token: None,
-            ty: syn::parse_str("i32").unwrap(),
-        },
-        Field {
-            attrs: vec![],
-            vis: Visibility::Public(VisPublic {
-                pub_token: Default::default(),
-            }),
-            ident: None,
-            colon_token: None,
-            ty: syn::parse_str("String").unwrap(),
-        },
-    ];
-    let expected = expected.iter_mut().collect::<Vec<_>>();
-
-    assert_eq!(expected, struct_body.fields_mut().collect::<Vec<_>>());
+    assert_eq!(expected, struct_body.fields.iter().collect::<Vec<_>>());
 }

--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -628,3 +628,155 @@ fn test_pub_restricted_in_super() {
 
     assert_eq!(expected, actual);
 }
+
+#[test]
+fn test_fields_on_unit_struct() {
+    let raw = "struct S;";
+    let struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
+        Data::Struct(body) => body,
+        _ => panic!("expected a struct"),
+    };
+
+    assert_eq!(0, struct_body.fields().count());
+}
+
+#[test]
+fn test_fields_on_named_struct() {
+    let raw = "struct S {
+        foo: i32,
+        pub bar: String,
+    }";
+    let struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
+        Data::Struct(body) => body,
+        _ => panic!("expected a struct"),
+    };
+
+    let expected = vec![
+        Field {
+            attrs: vec![],
+            vis: Visibility::Inherited,
+            ident: Some(Ident::from("foo")),
+            colon_token: Some(Default::default()),
+            ty: syn::parse_str("i32").unwrap(),
+        },
+        Field {
+            attrs: vec![],
+            vis: Visibility::Public(VisPublic {
+                pub_token: Default::default(),
+            }),
+            ident: Some(Ident::from("bar")),
+            colon_token: Some(Default::default()),
+            ty: syn::parse_str("String").unwrap(),
+        },
+    ];
+    let expected = expected.iter().collect::<Vec<_>>();
+
+    assert_eq!(expected, struct_body.fields().collect::<Vec<_>>());
+}
+
+#[test]
+fn test_fields_on_tuple_struct() {
+    let raw = "struct S(i32, pub String);";
+    let struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
+        Data::Struct(body) => body,
+        _ => panic!("expected a struct"),
+    };
+
+    let expected = vec![
+        Field {
+            attrs: vec![],
+            vis: Visibility::Inherited,
+            ident: None,
+            colon_token: None,
+            ty: syn::parse_str("i32").unwrap(),
+        },
+        Field {
+            attrs: vec![],
+            vis: Visibility::Public(VisPublic {
+                pub_token: Default::default(),
+            }),
+            ident: None,
+            colon_token: None,
+            ty: syn::parse_str("String").unwrap(),
+        },
+    ];
+    let expected = expected.iter().collect::<Vec<_>>();
+
+    assert_eq!(expected, struct_body.fields().collect::<Vec<_>>());
+}
+
+#[test]
+fn test_fields_mut_on_unit_struct() {
+    let raw = "struct S;";
+    let mut struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
+        Data::Struct(body) => body,
+        _ => panic!("expected a struct"),
+    };
+
+    assert_eq!(0, struct_body.fields_mut().count());
+}
+
+#[test]
+fn test_fields_mut_on_named_struct() {
+    let raw = "struct S {
+        foo: i32,
+        pub bar: String,
+    }";
+    let mut struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
+        Data::Struct(body) => body,
+        _ => panic!("expected a struct"),
+    };
+
+    let mut expected = vec![
+        Field {
+            attrs: vec![],
+            vis: Visibility::Inherited,
+            ident: Some(Ident::from("foo")),
+            colon_token: Some(Default::default()),
+            ty: syn::parse_str("i32").unwrap(),
+        },
+        Field {
+            attrs: vec![],
+            vis: Visibility::Public(VisPublic {
+                pub_token: Default::default(),
+            }),
+            ident: Some(Ident::from("bar")),
+            colon_token: Some(Default::default()),
+            ty: syn::parse_str("String").unwrap(),
+        },
+    ];
+    let expected = expected.iter_mut().collect::<Vec<_>>();
+
+    assert_eq!(expected, struct_body.fields_mut().collect::<Vec<_>>());
+}
+
+#[test]
+fn test_fields_mut_on_tuple_struct() {
+    let raw = "struct S(i32, pub String);";
+    let mut struct_body = match syn::parse_str::<DeriveInput>(raw).unwrap().data {
+        Data::Struct(body) => body,
+        _ => panic!("expected a struct"),
+    };
+
+    let mut expected = vec![
+        Field {
+            attrs: vec![],
+            vis: Visibility::Inherited,
+            ident: None,
+            colon_token: None,
+            ty: syn::parse_str("i32").unwrap(),
+        },
+        Field {
+            attrs: vec![],
+            vis: Visibility::Public(VisPublic {
+                pub_token: Default::default(),
+            }),
+            ident: None,
+            colon_token: None,
+            ty: syn::parse_str("String").unwrap(),
+        },
+    ];
+    let expected = expected.iter_mut().collect::<Vec<_>>();
+
+    assert_eq!(expected, struct_body.fields_mut().collect::<Vec<_>>());
+}


### PR DESCRIPTION
These methods were removed in syn 0.12. They seem like an odd removal,
since they're pretty widely used in the wild. This adds these methods
back. Though `Fields` is the closest structurally to `VariantData`, I've
opted to put it on `DataStruct` instead, as it's in the location most
people will look for it. `fields.fields()` also reads really poorly.

Fixes #316