### PR TITLE
Make Attribute::interprete_meta understand booleans

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -133,6 +133,17 @@ impl Attribute {
                         eq_token: Token![=]([tts[0].span]),
                         lit: Lit::new(lit.clone(), tts[1].span),
                     }));
+                } else if let TokenNode::Term(ref term) = tts[1].kind {
+                    match term.as_str() {
+                        v @ "true" | v @ "false" => {
+                            return Some(Meta::NameValue(MetaNameValue {
+                                ident: *name,
+                                eq_token: Token![=]([tts[0].span]),
+                                lit: Lit::Bool(LitBool { value: v == "true", span: tts[1].span }),
+                            }));
+                        },
+                        _ => {}
+                    }
                 }
             }
         }
@@ -161,6 +172,18 @@ fn nested_meta_item_from_tokens(tts: &[TokenTree]) -> Option<(NestedMeta, &[Toke
                             lit: Lit::new(lit.clone(), tts[2].span),
                         };
                         return Some((Meta::NameValue(pair).into(), &tts[3..]));
+                    } else if let TokenNode::Term(ref term) = tts[2].kind {
+                        match term.as_str() {
+                            v @ "true" | v @ "false" => {
+                                let pair = MetaNameValue {
+                                    ident: Ident::new(sym.as_str(), tts[0].span),
+                                    eq_token: Token![=]([tts[1].span]),
+                                    lit: Lit::Bool(LitBool { value: v == "true", span: tts[2].span }),
+                                };
+                                return Some((Meta::NameValue(pair).into(), &tts[3..]));
+                            },
+                            _ => {}
+                        }
                     }
                 }
             }

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -40,6 +40,26 @@ fn test_meta_item_name_value() {
 }
 
 #[test]
+fn test_meta_item_bool_value() {
+    run_test(
+        "#[foo = true]",
+        MetaNameValue {
+            ident: "foo".into(),
+            eq_token: Default::default(),
+            lit: Lit::Bool(LitBool { value: true, span: Span::def_site() }),
+        },
+    );
+    run_test(
+        "#[foo = false]",
+        MetaNameValue {
+            ident: "foo".into(),
+            eq_token: Default::default(),
+            lit: Lit::Bool(LitBool { value: false, span: Span::def_site() }),
+        },
+    )
+}
+
+#[test]
 fn test_meta_item_list_lit() {
     run_test(
         "#[foo(5)]",
@@ -76,6 +96,26 @@ fn test_meta_item_list_name_value() {
                         ident: "bar".into(),
                         eq_token: Default::default(),
                         lit: lit(Literal::integer(5)),
+                    }.into(),
+                ),
+            ],
+        },
+    )
+}
+
+#[test]
+fn test_meta_item_list_bool_value() {
+    run_test(
+        "#[foo(bar = true)]",
+        MetaList {
+            ident: "foo".into(),
+            paren_token: Default::default(),
+            nested: punctuated![
+                NestedMeta::Meta(
+                    MetaNameValue {
+                        ident: "bar".into(),
+                        eq_token: Default::default(),
+                        lit: Lit::Bool(LitBool { value: true, span: Span::def_site() }),
                     }.into(),
                 ),
             ],


### PR DESCRIPTION
So proc_macro2::Literal doesn't have any boolean related variant which
means that a boolean value is put in a TokenNode::Term and not a
TokenNode::Literal which in turn means that those values were ignored
and resulted in an impossibility to parse booleans in an attribute.

Fixes #346