### PR TITLE
Add a feature for linking to proc_macro.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "examples/dump-syntax/main.rs"
 required-features = ["full", "parsing", "extra-traits"]
 
 [features]
-default = ["derive", "parsing", "printing", "clone-impls"]
+default = ["derive", "parsing", "printing", "clone-impls", "proc-macro"]
 derive = []
 full = []
 parsing = []
@@ -25,11 +25,12 @@ visit-mut = []
 fold = []
 clone-impls = []
 extra-traits = []
+proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro"]
 
 [dependencies]
-proc-macro2 = "0.3"
-#quote = { version = "0.5", optional = true }
-quote = { git = 'https://github.com/dtolnay/quote', optional = true }
+proc-macro2 = { version = "0.3", default-features = false }
+#quote = { version = "0.5", optional = true, default-features = false }
+quote = { git = 'https://github.com/dtolnay/quote', optional = true, default-features = false }
 unicode-xid = "0.1"
 
 [dev-dependencies]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -127,6 +127,7 @@
 // and caution should be used when editing it. The public-facing interface is
 // 100% safe but the implementation is fragile internally.
 
+#[cfg(feature = "proc-macro")]
 use proc_macro as pm;
 use proc_macro2::{Delimiter, Literal, Span, Term, TokenStream};
 use proc_macro2::{Group, TokenTree, Op};
@@ -219,6 +220,7 @@ impl TokenBuffer {
 
     /// Creates a `TokenBuffer` containing all the tokens from the input
     /// `TokenStream`.
+    #[cfg(feature = "proc-macro")]
     pub fn new(stream: pm::TokenStream) -> TokenBuffer {
         Self::new2(stream.into())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,6 +262,7 @@
                   redundant_closure, needless_pass_by_value, redundant_field_names))]
 
 extern crate proc_macro2;
+#[cfg(feature = "proc-macro")]
 extern crate proc_macro;
 extern crate unicode_xid;
 
@@ -572,7 +573,7 @@ pub use error::parse_error;
 /// #
 /// # fn main() {}
 /// ```
-#[cfg(feature = "parsing")]
+#[cfg(all(feature = "parsing", feature = "proc-macro"))]
 pub fn parse<T>(tokens: proc_macro::TokenStream) -> Result<T, ParseError>
 where
     T: Synom,

--- a/src/synom.rs
+++ b/src/synom.rs
@@ -149,6 +149,7 @@
 //!
 //! *This module is available if Syn is built with the `"parsing"` feature.*
 
+#[cfg(feature = "proc-macro")]
 use proc_macro;
 use proc_macro2;
 
@@ -225,6 +226,7 @@ pub trait Parser: Sized {
     fn parse2(self, tokens: proc_macro2::TokenStream) -> Result<Self::Output, ParseError>;
 
     /// Parse tokens of source code into the chosen syntax tree node.
+    #[cfg(feature = "proc-macro")]
     fn parse(self, tokens: proc_macro::TokenStream) -> Result<Self::Output, ParseError> {
         self.parse2(tokens.into())
     }


### PR DESCRIPTION
This feature is enabled by default for backwards compatibility, but
it can be disabled in order to break the runtime dependency on the
dynamic library libproc_macro in the rustc toolchain.

This PR assumes that there is a version 0.5.0 or higher of `quote` on crates.io that includes dtolnay/quote#62. That is not yet the case (see https://github.com/dtolnay/quote/pull/62#issuecomment-368087621)