### PR TITLE
preserve spans in macros to generate better rustdoc [src] links

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,10 @@ fn main() {
         println!("cargo:rustc-cfg=syn_can_use_associated_constants");
     }
 
+    if compiler.minor >= 20 {
+        println!("cargo:rustc-cfg=syn_can_match_ident_after_attrs");
+    }
+
     // Macro modularization allows re-exporting the `quote!` macro in 1.30+.
     if compiler.minor >= 30 {
         println!("cargo:rustc-cfg=syn_can_call_macro_by_path");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,7 @@ extern crate unicode_xid;
 #[cfg(feature = "printing")]
 extern crate quote;
 
+#[cfg(any(feature = "full", feature = "derive"))]
 #[macro_use]
 mod macros;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -187,6 +187,23 @@ macro_rules! ast_enum_of_structs {
     )
 }
 
+// Unfortunately, at this time, we can't make the generated enum here have the
+// correct span. The way that the span for the overall enum decl is calculated
+// is using `lo.to(prev_span)` [1].
+//
+// If the beginning and ending spans of the enum item don't have the same macro
+// context, fallback code is run [2]. This code chooses the span within the
+// macro context to avoid firing spurious diagnostics [3].
+//
+// This means `[src]` links in rustdoc will point to the macro, instead of the
+// actual declaration, if either the first or last token of our declaration has
+// a span from the macro. With `macro_rules!` there is no way to preserve the
+// span of a `{}` block while changing its contents, so we're forced to have the
+// span of our final token point to our macro.
+//
+// [1]: https://github.com/rust-lang/rust/blob/9a90d03ad171856dc016c2dcc19292ec49a8a26f/src/libsyntax/parse/parser.rs#L7377
+// [2]: https://github.com/rust-lang/rust/blob/9a90d03ad171856dc016c2dcc19292ec49a8a26f/src/libsyntax_pos/lib.rs#L467-L478
+// [3]: https://github.com/rust-lang/rust/pull/47942
 #[cfg(syn_can_match_ident_after_attrs)]
 macro_rules! ast_enum_of_structs {
     (

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -94,24 +94,38 @@ macro_rules! ast_struct {
 
 #[cfg(not(syn_can_match_ident_after_attrs))]
 macro_rules! ast_enum {
+    // Drop the `#no_visit` attribute, if present.
     (
         $(#[$enum_attr:meta])*
-        pub enum $name:ident $(# $tags:ident)* { $($variants:tt)* }
+        pub enum $name:ident #no_visit $($rest:tt)*
+    ) => (
+        ast_enum! { $(#[$enum_attr])* pub enum $name $($rest)* }
+    );
+
+    (
+        $(#[$enum_attr:meta])*
+        pub enum $name:ident $($rest:tt)*
     ) => (
         $(#[$enum_attr])*
-            #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
+        #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
         #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        pub enum $name {
-            $($variants)*
-        }
-    )
+        pub enum $name $($rest)*
+    );
 }
 
 #[cfg(syn_can_match_ident_after_attrs)]
 macro_rules! ast_enum {
+    // Drop the `#no_visit` attribute, if present.
     (
         $(#[$enum_attr:meta])*
-        $pub:ident $enum:ident $name:ident $(# $tags:ident)* { $($variants:tt)* }
+        $pub:ident $enum:ident $name:ident #no_visit $($rest:tt)*
+    ) => (
+        ast_enum! { $(#[$enum_attr])* $pub $enum $name $($rest)* }
+    );
+
+    (
+        $(#[$enum_attr:meta])*
+        $pub:ident $enum:ident $name:ident $($rest:tt)*
     ) => (
         check_keyword_matches!(pub $pub);
         check_keyword_matches!(enum $enum);
@@ -119,10 +133,8 @@ macro_rules! ast_enum {
         $(#[$enum_attr])*
         #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
         #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        $pub $enum $name {
-            $($variants)*
-        }
-    )
+        $pub $enum $name $($rest)*
+    );
 }
 
 #[cfg(not(syn_can_match_ident_after_attrs))]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,140 +1,65 @@
-#[cfg(not(syn_can_match_ident_after_attrs))]
 macro_rules! ast_struct {
     (
-        $(#[$attr:meta])*
-        pub struct $name:ident #full $($rest:tt)*
+        @@ [$($attrs_pub:tt)*]
+        struct $name:ident #full $($rest:tt)*
     ) => {
         #[cfg(feature = "full")]
-        $(#[$attr])*
         #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
         #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        pub struct $name $($rest)*
+        $($attrs_pub)* struct $name $($rest)*
 
         #[cfg(not(feature = "full"))]
-        $(#[$attr])*
         #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
         #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        pub struct $name {
+        $($attrs_pub)* struct $name {
             _noconstruct: (),
         }
     };
 
     (
-        $(#[$attr:meta])*
-        pub struct $name:ident #manual_extra_traits $($rest:tt)*
+        @@ [$($attrs_pub:tt)*]
+        struct $name:ident #manual_extra_traits $($rest:tt)*
     ) => {
-        $(#[$attr])*
         #[cfg_attr(feature = "extra-traits", derive(Debug))]
         #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        pub struct $name $($rest)*
+        $($attrs_pub)* struct $name $($rest)*
     };
 
     (
-        $(#[$attr:meta])*
-        pub struct $name:ident $($rest:tt)*
+        @@ [$($attrs_pub:tt)*]
+        struct $name:ident $($rest:tt)*
     ) => {
-        $(#[$attr])*
         #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
         #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        pub struct $name $($rest)*
+        $($attrs_pub)* struct $name $($rest)*
+    };
+
+    ($($t:tt)*) => {
+        strip_attrs_pub!(ast_struct!($($t)*));
     };
 }
 
-#[cfg(syn_can_match_ident_after_attrs)]
-macro_rules! ast_struct {
-    (
-        $(#[$attr:meta])*
-        $pub:ident $struct:ident $name:ident #full $($rest:tt)*
-    ) => {
-        check_keyword_matches!(pub $pub);
-        check_keyword_matches!(struct $struct);
-
-        #[cfg(feature = "full")]
-        $(#[$attr])*
-        #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
-        #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        $pub $struct $name $($rest)*
-
-        #[cfg(not(feature = "full"))]
-        $(#[$attr])*
-        #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
-        #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        $pub $struct $name {
-            _noconstruct: (),
-        }
-    };
-
-    (
-        $(#[$attr:meta])*
-        $pub:ident $struct:ident $name:ident #manual_extra_traits $($rest:tt)*
-    ) => {
-        check_keyword_matches!(pub $pub);
-        check_keyword_matches!(struct $struct);
-
-        $(#[$attr])*
-        #[cfg_attr(feature = "extra-traits", derive(Debug))]
-        #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        $pub $struct $name $($rest)*
-    };
-
-    (
-        $(#[$attr:meta])*
-        $pub:ident $struct:ident $name:ident $($rest:tt)*
-    ) => {
-        check_keyword_matches!(pub $pub);
-        check_keyword_matches!(struct $struct);
-
-        $(#[$attr])*
-        #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
-        #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        $pub $struct $name $($rest)*
-    };
-}
-
-
-#[cfg(not(syn_can_match_ident_after_attrs))]
 macro_rules! ast_enum {
     // Drop the `#no_visit` attribute, if present.
     (
-        $(#[$enum_attr:meta])*
-        pub enum $name:ident #no_visit $($rest:tt)*
+        @@ [$($attrs_pub:tt)*]
+        enum $name:ident #no_visit $($rest:tt)*
     ) => (
-        ast_enum! { $(#[$enum_attr])* pub enum $name $($rest)* }
+        ast_enum!(@@ [$($attrs_pub)*] enum $name $($rest)*);
     );
 
     (
-        $(#[$enum_attr:meta])*
-        pub enum $name:ident $($rest:tt)*
+        @@ [$($attrs_pub:tt)*]
+        enum $name:ident $($rest:tt)*
     ) => (
-        $(#[$enum_attr])*
         #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
         #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        pub enum $name $($rest)*
-    );
-}
-
-#[cfg(syn_can_match_ident_after_attrs)]
-macro_rules! ast_enum {
-    // Drop the `#no_visit` attribute, if present.
-    (
-        $(#[$enum_attr:meta])*
-        $pub:ident $enum:ident $name:ident #no_visit $($rest:tt)*
-    ) => (
-        ast_enum! { $(#[$enum_attr])* $pub $enum $name $($rest)* }
+        $($attrs_pub)* enum $name $($rest)*
     );
 
-    (
-        $(#[$enum_attr:meta])*
-        $pub:ident $enum:ident $name:ident $($rest:tt)*
-    ) => (
-        check_keyword_matches!(pub $pub);
-        check_keyword_matches!(enum $enum);
-
-        $(#[$enum_attr])*
-        #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
-        #[cfg_attr(feature = "clone-impls", derive(Clone))]
-        $pub $enum $name $($rest)*
-    );
+    ($($t:tt)*) => {
+        strip_attrs_pub!(ast_enum!($($t)*));
+    };
 }
 
 #[cfg(not(syn_can_match_ident_after_attrs))]
@@ -314,6 +239,22 @@ macro_rules! maybe_ast_struct {
     ) => ();
 
     ($($rest:tt)*) => (ast_struct! { $($rest)* });
+}
+
+#[cfg(not(syn_can_match_ident_after_attrs))]
+macro_rules! strip_attrs_pub {
+    ($mac:ident!($(#[$m:meta])* pub $($t:tt)*)) => {
+        $mac!(@@ [$(#[$m])* pub] $($t)*);
+    };
+}
+
+#[cfg(syn_can_match_ident_after_attrs)]
+macro_rules! strip_attrs_pub {
+    ($mac:ident!($(#[$m:meta])* $pub:ident $($t:tt)*)) => {
+        check_keyword_matches!(pub $pub);
+
+        $mac!(@@ [$(#[$m])* $pub] $($t)*);
+    };
 }
 
 #[cfg(syn_can_match_ident_after_attrs)]


### PR DESCRIPTION
Make rustdoc generate the correct `[src]` links by perserving spans in our macros.

`__check` makes sure you don't write the wrong keywords.