### PR TITLE
Document `proc-macro` feature

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -220,6 +220,9 @@ impl TokenBuffer {
 
     /// Creates a `TokenBuffer` containing all the tokens from the input
     /// `TokenStream`.
+    ///
+    /// *This method is available if Syn is built with both the `"parsing"` and
+    /// `"proc-macro"` features.*
     #[cfg(feature = "proc-macro")]
     pub fn new(stream: pm::TokenStream) -> TokenBuffer {
         Self::new2(stream.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,8 @@
 //!   types.
 //! - **`extra-traits`** — Debug, Eq, PartialEq, Hash impls for all syntax tree
 //!   types.
+//! - **`proc-macro`** *(enabled by default)* — Runtime dependency on the
+//!   dynamic library libproc_macro from rustc toolchain.
 
 // Syn types in rustdoc of other crates get linked to here.
 #![doc(html_root_url = "https://docs.rs/syn/0.13.1")]
@@ -540,7 +542,8 @@ pub use error::parse_error;
 ///
 /// [`syn::parse2`]: fn.parse2.html
 ///
-/// *This function is available if Syn is built with the `"parsing"` feature.*
+/// *This function is available if Syn is built with both the `"parsing"` and
+/// `"proc-macro"` features.*
 ///
 /// # Examples
 ///

--- a/src/synom.rs
+++ b/src/synom.rs
@@ -226,6 +226,9 @@ pub trait Parser: Sized {
     fn parse2(self, tokens: proc_macro2::TokenStream) -> Result<Self::Output, ParseError>;
 
     /// Parse tokens of source code into the chosen syntax tree node.
+    ///
+    /// *This method is available if Syn is built with both the `"parsing"` and
+    /// `"proc-macro"` features.*
     #[cfg(feature = "proc-macro")]
     fn parse(self, tokens: proc_macro::TokenStream) -> Result<Self::Output, ParseError> {
         self.parse2(tokens.into())


### PR DESCRIPTION
When making this PR I found at least three ways to document the fact that some methods have more feature requirements in addition to those on the type/trait itself:
- Mention every feature needed for all methods:
  ```rust
  /// ... `"parsing"` ...
  impl ... {
      /// ... `"parsing"` ...
      fn unaffected_method(...) { ... }

      /// ... `"parsing"` and `"proc-macro"` ...
      #[cfg(feature = "proc-macro")]
      fn affected_method(...) { ... }

      /// ... `"parsing"` ...
      fn other_unaffected_method(...) { ... }
  }
  ```
- Mention every feature only for methods with additional requirements, features for other methods are inferred from required features for type/trait:
  ```rust
  /// ... `"parsing"` ...
  impl ... {
      fn unaffected_method(...) { ... }

      /// ... `"parsing"` and `"proc-macro"` ...
      #[cfg(feature = "proc-macro")]
      fn affected_method(...) { ... }

      fn other_unaffected_method(...) { ... }
  }
  ```
- Only mention additional features, other ones are implied from required for type/trait:
  ```rust
  /// ... `"parsing"` ...
  impl ... {
      fn unaffected_method(...) { ... }

      /// ... `"proc-macro"` ...
      #[cfg(feature = "proc-macro")]
      fn affected_method(...) { ... }

      fn other_unaffected_method(...) { ... }
  }
  ```

This PR uses the second suggestion because it is the most explicit from the less intrusive ones — the first one can require a lot of doc changes throughout the codebase and the third may be misunderstood as "this method only needs the features written in its docs, not those needed for the type/trait" (which shouldn't work anyway, but will surely baffle library user when rustc just spits "cannot find type/trait \`...\` in this scope" without mentioning anything about features at all), also there is a chance to simply overlook relevant data when it has been split away far enough.