### PR TITLE
Fix syn's tests with doc comment lex fixes

### DIFF
--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -189,10 +189,10 @@ fn test_enum() {
                 tts: TokenStream::from_iter(vec![
                     op('='),
                     lit(Literal::string(
-                        "/// See the std::result module documentation for details.",
+                        " See the std::result module documentation for details.",
                     )),
                 ]),
-                is_sugared_doc: true,
+                is_sugared_doc: false,
             },
             Attribute {
                 bracket_token: Default::default(),
@@ -329,7 +329,7 @@ fn test_enum() {
             ident: "doc".into(),
             eq_token: Default::default(),
             lit: Lit::Str(LitStr::new(
-                "/// See the std::result module documentation for details.",
+                " See the std::result module documentation for details.",
                 Span::call_site(),
             )),
         }.into(),


### PR DESCRIPTION
* Don't expect `is_sugared_doc` to be true
* Ensure we don't expect `///` in doc comment values
* When testing against libsyntax, process streams like `foo! { /** ... */ }` by
  manually expanding the `DocComment` token that libsyntax parses. The
  `proc-macro2` crate will expand that as a doc attribute unconditionally.