### PR TITLE
Refactor Punctuated<T, P>

### DIFF
--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -245,7 +245,12 @@ where
 #[cfg(feature = "extra-traits")]
 impl<T: Debug, P: Debug> Debug for Punctuated<T, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.inner.fmt(f) // TODO: ???
+        let mut list = f.debug_list();
+        list.entries(&self.inner);
+        for t in self.last.iter() {
+            list.entry(&*t);
+        }
+        list.finish()
     }
 }
 

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -30,7 +30,9 @@
 #[cfg(any(feature = "full", feature = "derive"))]
 use std::iter;
 use std::iter::FromIterator;
+use std::mem;
 use std::ops::{Index, IndexMut};
+use std::option;
 use std::slice;
 use std::vec;
 #[cfg(feature = "extra-traits")]
@@ -52,19 +54,20 @@ use parse_error;
 #[cfg_attr(feature = "extra-traits", derive(Eq, PartialEq, Hash))]
 #[cfg_attr(feature = "clone-impls", derive(Clone))]
 pub struct Punctuated<T, P> {
-    inner: Vec<(T, Option<P>)>,
+    inner: Vec<(T, P)>,
+    last: Option<Box<T>>,
 }
 
 impl<T, P> Punctuated<T, P> {
     /// Creates an empty punctuated sequence.
     pub fn new() -> Punctuated<T, P> {
-        Punctuated { inner: Vec::new() }
+        Punctuated { inner: Vec::new(), last: None }
     }
 
     /// Determines whether this punctuated sequence is empty, meaning it
     /// contains no syntax tree nodes or punctuation.
     pub fn is_empty(&self) -> bool {
-        self.inner.len() == 0
+        self.inner.len() == 0 && self.last.is_none()
     }
 
     /// Returns the number of syntax tree nodes in this punctuated sequence.
@@ -72,33 +75,34 @@ impl<T, P> Punctuated<T, P> {
     /// This is the number of nodes of type `T`, not counting the punctuation of
     /// type `P`.
     pub fn len(&self) -> usize {
-        self.inner.len()
+        self.inner.len() + if self.last.is_some() { 1 } else { 0 }
     }
 
     /// Borrows the first punctuated pair in this sequence.
     pub fn first(&self) -> Option<Pair<&T, &P>> {
-        self.inner.first().map(|&(ref t, ref d)| match *d {
-            Some(ref d) => Pair::Punctuated(t, d),
-            None => Pair::End(t),
-        })
+        self.pairs().next()
     }
 
     /// Borrows the last punctuated pair in this sequence.
     pub fn last(&self) -> Option<Pair<&T, &P>> {
-        self.inner.last().map(|&(ref t, ref d)| match *d {
-            Some(ref d) => Pair::Punctuated(t, d),
-            None => Pair::End(t),
-        })
+        if self.last.is_some() {
+            self.last.as_ref()
+                .map(|t| Pair::End(t.as_ref()))
+        } else {
+            self.inner.last()
+                .map(|&(ref t, ref d)| Pair::Punctuated(t, d))
+        }
     }
 
     /// Mutably borrows the last punctuated pair in this sequence.
     pub fn last_mut(&mut self) -> Option<Pair<&mut T, &mut P>> {
-        self.inner
-            .last_mut()
-            .map(|&mut (ref mut t, ref mut d)| match *d {
-                Some(ref mut d) => Pair::Punctuated(t, d),
-                None => Pair::End(t),
-            })
+        if self.last.is_some() {
+            self.last.as_mut()
+                .map(|t| Pair::End(t.as_mut()))
+        } else {
+            self.inner.last_mut()
+                .map(|&mut (ref mut t, ref mut d)| Pair::Punctuated(t, d))
+        }
     }
 
     /// Returns an iterator over borrowed syntax tree nodes of type `&T`.
@@ -106,6 +110,7 @@ impl<T, P> Punctuated<T, P> {
         Iter {
             inner: Box::new(PrivateIter {
                 inner: self.inner.iter(),
+                last: self.last.as_ref().map(|t| t.as_ref()).into_iter(),
             }),
         }
     }
@@ -116,6 +121,7 @@ impl<T, P> Punctuated<T, P> {
         IterMut {
             inner: Box::new(PrivateIterMut {
                 inner: self.inner.iter_mut(),
+                last: self.last.as_mut().map(|t| t.as_mut()).into_iter(),
             }),
         }
     }
@@ -125,6 +131,7 @@ impl<T, P> Punctuated<T, P> {
     pub fn pairs(&self) -> Pairs<T, P> {
         Pairs {
             inner: self.inner.iter(),
+            last: self.last.as_ref().map(|t| t.as_ref()).into_iter(),
         }
     }
 
@@ -133,6 +140,7 @@ impl<T, P> Punctuated<T, P> {
     pub fn pairs_mut(&mut self) -> PairsMut<T, P> {
         PairsMut {
             inner: self.inner.iter_mut(),
+            last: self.last.as_mut().map(|t| t.as_mut()).into_iter(),
         }
     }
 
@@ -141,6 +149,7 @@ impl<T, P> Punctuated<T, P> {
     pub fn into_pairs(self) -> IntoPairs<T, P> {
         IntoPairs {
             inner: self.inner.into_iter(),
+            last: self.last.map(|t| *t).into_iter(),
         }
     }
 
@@ -158,7 +167,7 @@ impl<T, P> Punctuated<T, P> {
     /// this method is called.
     pub fn push_value(&mut self, value: T) {
         assert!(self.empty_or_trailing());
-        self.inner.push((value, None));
+        self.last = Some(Box::new(value));
     }
 
     /// Appends a trailing punctuation onto the end of this punctuated sequence.
@@ -169,25 +178,26 @@ impl<T, P> Punctuated<T, P> {
     ///
     /// Panics if the sequence is empty or already has a trailing punctuation.
     pub fn push_punct(&mut self, punctuation: P) {
-        assert!(!self.is_empty());
-        let last = self.inner.last_mut().unwrap();
-        assert!(last.1.is_none());
-        last.1 = Some(punctuation);
+        assert!(!self.is_empty()); // redundant
+        assert!(self.last.is_some());
+        let last = mem::replace(&mut self.last, None);
+        self.inner.push((*last.unwrap(), punctuation));
     }
 
     /// Removes the last punctuated pair from this sequence, or `None` if the
     /// sequence is empty.
     pub fn pop(&mut self) -> Option<Pair<T, P>> {
-        self.inner.pop().map(|(t, d)| Pair::new(t, d))
+        if self.last.is_some() {
+            mem::replace(&mut self.last, None).map(|t| Pair::End(*t))
+        } else {
+            self.inner.pop().map(|(t, d)| Pair::Punctuated(t, d))
+        }
     }
 
     /// Determines whether this punctuated sequence ends with a trailing
     /// punctuation.
     pub fn trailing_punct(&self) -> bool {
-        self.inner
-            .last()
-            .map(|last| last.1.is_some())
-            .unwrap_or(false)
+        self.last.is_none() && !self.is_empty()
     }
 
     /// Returns true if either this `Punctuated` is empty, or it has a trailing
@@ -195,10 +205,7 @@ impl<T, P> Punctuated<T, P> {
     ///
     /// Equivalent to `punctuated.is_empty() || punctuated.trailing_punct()`.
     pub fn empty_or_trailing(&self) -> bool {
-        self.inner
-            .last()
-            .map(|last| last.1.is_some())
-            .unwrap_or(true)
+        self.last.is_none()
     }
 }
 
@@ -230,7 +237,7 @@ where
         if index == self.len() {
             self.push(value);
         } else {
-            self.inner.insert(index, (value, Some(Default::default())));
+            self.inner.insert(index, (value, Default::default()));
         }
     }
 }
@@ -238,7 +245,7 @@ where
 #[cfg(feature = "extra-traits")]
 impl<T: Debug, P: Debug> Debug for Punctuated<T, P> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.inner.fmt(f)
+        self.inner.fmt(f) // TODO: ???
     }
 }
 
@@ -274,10 +281,18 @@ impl<T, P> FromIterator<Pair<T, P>> for Punctuated<T, P> {
 
 impl<T, P> Extend<Pair<T, P>> for Punctuated<T, P> {
     fn extend<I: IntoIterator<Item = Pair<T, P>>>(&mut self, i: I) {
+        assert!(self.empty_or_trailing());
+        let mut nomore = false;
         for pair in i {
+            if nomore {
+                panic!("Punctuated extended with items after a Pair::End");
+            }
             match pair {
-                Pair::Punctuated(a, b) => self.inner.push((a, Some(b))),
-                Pair::End(a) => self.inner.push((a, None)),
+                Pair::Punctuated(a, b) => self.inner.push((a, b)),
+                Pair::End(a) => {
+                    self.last = Some(Box::new(a));
+                    nomore = true;
+                }
             }
         }
     }
@@ -290,6 +305,7 @@ impl<T, P> IntoIterator for Punctuated<T, P> {
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             inner: self.inner.into_iter(),
+            last: self.last.map(|t| *t).into_iter(),
         }
     }
 }
@@ -324,17 +340,16 @@ impl<T, P> Default for Punctuated<T, P> {
 ///
 /// [module documentation]: index.html
 pub struct Pairs<'a, T: 'a, P: 'a> {
-    inner: slice::Iter<'a, (T, Option<P>)>,
+    inner: slice::Iter<'a, (T, P)>,
+    last: option::IntoIter<&'a T>,
 }
 
 impl<'a, T, P> Iterator for Pairs<'a, T, P> {
     type Item = Pair<&'a T, &'a P>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|pair| match pair.1 {
-            Some(ref p) => Pair::Punctuated(&pair.0, p),
-            None => Pair::End(&pair.0),
-        })
+        self.inner.next().map(|&(ref t, ref p)| Pair::Punctuated(t, p))
+            .or_else(|| self.last.next().map(|t| Pair::End(t)))
     }
 }
 
@@ -344,17 +359,16 @@ impl<'a, T, P> Iterator for Pairs<'a, T, P> {
 ///
 /// [module documentation]: index.html
 pub struct PairsMut<'a, T: 'a, P: 'a> {
-    inner: slice::IterMut<'a, (T, Option<P>)>,
+    inner: slice::IterMut<'a, (T, P)>,
+    last: option::IntoIter<&'a mut T>,
 }
 
 impl<'a, T, P> Iterator for PairsMut<'a, T, P> {
     type Item = Pair<&'a mut T, &'a mut P>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|pair| match pair.1 {
-            Some(ref mut p) => Pair::Punctuated(&mut pair.0, p),
-            None => Pair::End(&mut pair.0),
-        })
+        self.inner.next().map(|&mut (ref mut t, ref mut p)| Pair::Punctuated(t, p))
+            .or_else(|| self.last.next().map(|t| Pair::End(t)))
     }
 }
 
@@ -364,17 +378,16 @@ impl<'a, T, P> Iterator for PairsMut<'a, T, P> {
 ///
 /// [module documentation]: index.html
 pub struct IntoPairs<T, P> {
-    inner: vec::IntoIter<(T, Option<P>)>,
+    inner: vec::IntoIter<(T, P)>,
+    last: option::IntoIter<T>,
 }
 
 impl<T, P> Iterator for IntoPairs<T, P> {
     type Item = Pair<T, P>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|pair| match pair.1 {
-            Some(p) => Pair::Punctuated(pair.0, p),
-            None => Pair::End(pair.0),
-        })
+        self.inner.next().map(|(t, p)| Pair::Punctuated(t, p))
+            .or_else(|| self.last.next().map(|t| Pair::End(t)))
     }
 }
 
@@ -384,14 +397,15 @@ impl<T, P> Iterator for IntoPairs<T, P> {
 ///
 /// [module documentation]: index.html
 pub struct IntoIter<T, P> {
-    inner: vec::IntoIter<(T, Option<P>)>,
+    inner: vec::IntoIter<(T, P)>,
+    last: option::IntoIter<T>,
 }
 
 impl<T, P> Iterator for IntoIter<T, P> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|pair| pair.0)
+        self.inner.next().map(|pair| pair.0).or_else(|| self.last.next())
     }
 }
 
@@ -405,7 +419,8 @@ pub struct Iter<'a, T: 'a> {
 }
 
 struct PrivateIter<'a, T: 'a, P: 'a> {
-    inner: slice::Iter<'a, (T, Option<P>)>,
+    inner: slice::Iter<'a, (T, P)>,
+    last: option::IntoIter<&'a T>,
 }
 
 #[cfg(any(feature = "full", feature = "derive"))]
@@ -431,7 +446,7 @@ impl<'a, T, P> Iterator for PrivateIter<'a, T, P> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|pair| &pair.0)
+        self.inner.next().map(|pair| &pair.0).or_else(|| self.last.next())
     }
 }
 
@@ -445,7 +460,8 @@ pub struct IterMut<'a, T: 'a> {
 }
 
 struct PrivateIterMut<'a, T: 'a, P: 'a> {
-    inner: slice::IterMut<'a, (T, Option<P>)>,
+    inner: slice::IterMut<'a, (T, P)>,
+    last: option::IntoIter<&'a mut T>,
 }
 
 impl<'a, T> Iterator for IterMut<'a, T> {
@@ -460,7 +476,7 @@ impl<'a, T, P> Iterator for PrivateIterMut<'a, T, P> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(|pair| &mut pair.0)
+        self.inner.next().map(|pair| &mut pair.0).or_else(|| self.last.next())
     }
 }
 
@@ -530,13 +546,27 @@ impl<T, P> Index<usize> for Punctuated<T, P> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.inner[index].0
+        if index == self.len() - 1 {
+            match self.last {
+                Some(ref t) => t,
+                None => &self.inner[index].0
+            }
+        } else {
+            &self.inner[index].0
+        }
     }
 }
 
 impl<T, P> IndexMut<usize> for Punctuated<T, P> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.inner[index].0
+        if index == self.len() - 1 {
+            match self.last {
+                Some(ref mut t) => t,
+                None => &mut self.inner[index].0
+            }
+        } else {
+            &mut self.inner[index].0
+        }
     }
 }
 


### PR DESCRIPTION
Refactor the Punctuated type for additional safety (found a bug in Extend impl) and hopefully performance.

~~Still needs a bit of work. The Debug formatter is currently broken and only prints the internal Vec without the trailing T.~~
The Debug impl is now fixed, which was surprisingly easy.
I'd love a code review, and I wonder if I should rebase both commits into one.