### PR TITLE
Implement AsRef<Path> for Ident

### DIFF
--- a/src/ident.rs
+++ b/src/ident.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
+use std::path::Path;
 
 use proc_macro2::Term;
 use unicode_xid::UnicodeXID;
@@ -198,6 +199,18 @@ impl From<String> for Ident {
 impl AsRef<str> for Ident {
     fn as_ref(&self) -> &str {
         self.term.as_str()
+    }
+}
+
+impl AsRef<Path> for Ident {
+    fn as_ref(&self) -> &Path {
+        Path::new(
+            match self.term.as_str() {
+                "self" => ".",
+                "super" => "..",
+                other => other,
+            }
+        )
     }
 }
 


### PR DESCRIPTION
This will make it a bit easier to create paths to source files from `Ident`s.

Example use case: traversing an `ItemUse` statement will give you a `Vec<Ident>` path to an item. To get the path to the module file, you can simply do:

```
let mut buf = PathBuf::from(SRC_DIR);
buf.extend(path);
buf.set_extension("rs");
```

whereas before you had to do:

```
let mut buf = PathBuf::from(SRC_DIR);
buf.extend(path.into_iter().map(AsRef::as_ref));
buf.set_extension("rs");
```

To support this use case, `self` and `super` idents will give the paths `.` and `..`.