### PR TITLE
Don't parse a plus sign when parsing a function type's return type.

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -295,7 +295,7 @@ pub mod parsing {
     impl Synom for ParenthesizedGenericArguments {
         named!(parse -> Self, do_parse!(
             data: parens!(Punctuated::parse_terminated) >>
-            output: syn!(ReturnType) >>
+            output: call!(ReturnType::without_plus) >>
             (ParenthesizedGenericArguments {
                 paren_token: data.0,
                 inputs: data.1,


### PR DESCRIPTION
This applies to both `fn() -> ReturnType + NotAllowed` and `Fn() -> ReturnType + SeparateTrait`.

Fixes #428.