### PR TITLE
Require proc-macro2 ^0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ extra-traits = []
 proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro"]
 
 [dependencies]
-proc-macro2 = { version = "0.4.1", default-features = false }
+proc-macro2 = { version = "0.4.2", default-features = false }
 quote = { version = "0.6", optional = true, default-features = false }
 unicode-xid = "0.1"
 


### PR DESCRIPTION
`proc-macro` 0.4.1 no longer works after https://github.com/dtolnay/syn/commit/446f7d6da0592127e7a89f8621d879967c24448d.