### PR TITLE
Parser struct approach to error reporting

### DIFF
--- a/examples/unstable/Cargo.toml
+++ b/examples/unstable/Cargo.toml
@@ -11,7 +11,5 @@ name = "unstable"
 path = "src/main.rs"
 
 [dependencies]
-syn = { path = "../../", features = ["full", "unstable"] }
-
-[patch.crates-io]
-proc-macro2 = { path = "../../../proc-macro2" }
+syn = { path = "../../", features = ["full"] }
+proc-macro2 = "0.1"

--- a/examples/unstable/Cargo.toml
+++ b/examples/unstable/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "unstable"
+version = "0.1.0"
+authors = ["Sergio Benitez <sb@sergio.bz>"]
+
+[lib]
+proc-macro = true
+
+[[bin]]
+name = "unstable"
+path = "src/main.rs"
+
+[dependencies]
+syn = { path = "../../", features = ["full", "unstable"] }
+
+[patch.crates-io]
+proc-macro2 = { path = "../../../proc-macro2" }

--- a/examples/unstable/Cargo.toml
+++ b/examples/unstable/Cargo.toml
@@ -2,14 +2,11 @@
 name = "unstable"
 version = "0.1.0"
 authors = ["Sergio Benitez <sb@sergio.bz>"]
+publish = false
 
 [lib]
 proc-macro = true
 
-[[bin]]
-name = "unstable"
-path = "src/main.rs"
-
 [dependencies]
 syn = { path = "../../", features = ["full"] }
-proc-macro2 = "0.1"
+proc-macro2 = { version = "0.4", features = ["nightly"] }

--- a/examples/unstable/src/lib.rs
+++ b/examples/unstable/src/lib.rs
@@ -1,0 +1,91 @@
+#![feature(proc_macro, core_intrinsics)]
+
+extern crate syn;
+extern crate proc_macro;
+
+use proc_macro::{TokenStream, Span, Diagnostic};
+
+use syn::*;
+use syn::spanned::Spanned;
+use syn::synom::{Synom, Cursor, SynomBuffer};
+
+struct Parser {
+    buffer: Box<SynomBuffer>,
+    cursor: Cursor<'static>,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let buffer = Box::new(SynomBuffer::new(tokens.into()));
+        let cursor = unsafe {
+            let buffer: &'static SynomBuffer = ::std::mem::transmute(&*buffer);
+            buffer.begin()
+        };
+
+        Parser {
+            buffer: buffer,
+            cursor: cursor,
+        }
+    }
+
+    fn current_span(&self) -> Span {
+        self.cursor.current_span()
+            .map(|sp| sp.into_inner())
+            .unwrap_or_else(|| Span::def_site())
+    }
+
+    fn parse<T: Synom>(&mut self) -> Result<T, Diagnostic> {
+        let (cursor, val) = T::parse(self.cursor)
+            .map_err(|e| {
+                let expected = match T::description() {
+                    Some(desc) => desc,
+                    None => unsafe { ::std::intrinsics::type_name::<T>() }
+                };
+
+                self.current_span().error(format!("{}: expected {}", e, expected))
+            })?;
+
+        self.cursor = cursor;
+        Ok(val)
+    }
+
+    fn eof(&mut self) -> Result<(), Diagnostic> {
+        if !self.cursor.is_eof() {
+            return Err(self.current_span()
+                       .error("trailing characters; expected eof"));
+        }
+
+        Ok(())
+    }
+}
+
+fn eval(input: TokenStream) -> Result<TokenStream, Diagnostic> {
+    let mut parser = Parser::new(input);
+
+    let a = parser.parse::<ExprTuple>()?;
+    parser.parse::<token::Eq>()?;
+    let b = parser.parse::<ExprTuple>()?;
+    parser.eof()?;
+
+    let (a_len, b_len) = (a.elems.len(), b.elems.len());
+    if a_len != b_len {
+        let diag = b.span()
+            .error(format!("expected {} element(s), got {}", a_len, b_len))
+            .span_note(a.span(), "because of this");
+
+        return Err(diag);
+    }
+
+    Ok("println!(\"All good!\")".parse().unwrap())
+}
+
+#[proc_macro]
+pub fn demo(input: TokenStream) -> TokenStream {
+    match eval(input) {
+        Ok(val) => val,
+        Err(diag) => {
+            diag.emit();
+            "".parse().unwrap()
+        }
+    }
+}

--- a/examples/unstable/src/lib.rs
+++ b/examples/unstable/src/lib.rs
@@ -10,22 +10,22 @@ use syn::synom::Synom;
 use syn::{token, ExprTuple};
 
 struct Parser {
-    buffer: Box<TokenBuffer>,
     cursor: Cursor<'static>,
+
+    #[allow(dead_code)]
+    buffer: Box<TokenBuffer>,
 }
 
 impl Parser {
     fn new(tokens: TokenStream) -> Parser {
-        let buffer = Box::new(TokenBuffer::new(tokens.into()));
+        let buffer = Box::new(TokenBuffer::new(tokens));
         let cursor = unsafe {
-            let buffer: &'static TokenBuffer = std::mem::transmute(&*buffer);
+            let buffer: *const TokenBuffer = &*buffer;
+            let buffer: &'static TokenBuffer = &*buffer;
             buffer.begin()
         };
 
-        Parser {
-            buffer: buffer,
-            cursor: cursor,
-        }
+        Parser { cursor, buffer }
     }
 
     fn current_span(&self) -> Span {

--- a/examples/unstable/src/lib.rs
+++ b/examples/unstable/src/lib.rs
@@ -1,23 +1,24 @@
-#![feature(proc_macro, core_intrinsics)]
+#![feature(core_intrinsics, proc_macro_diagnostic)]
 
 extern crate syn;
 extern crate proc_macro;
 
 use syn::*;
-use syn::synom::{Synom, Cursor, SynomBuffer};
+use syn::synom::Synom;
+use syn::buffer::{Cursor, TokenBuffer};
 use syn::spanned::Spanned;
 use proc_macro::{TokenStream, Span, Diagnostic};
 
 struct Parser {
-    buffer: Box<SynomBuffer>,
+    buffer: Box<TokenBuffer>,
     cursor: Cursor<'static>,
 }
 
 impl Parser {
     fn new(tokens: TokenStream) -> Parser {
-        let buffer = Box::new(SynomBuffer::new(tokens.into()));
+        let buffer = Box::new(TokenBuffer::new(tokens.into()));
         let cursor = unsafe {
-            let buffer: &'static SynomBuffer = ::std::mem::transmute(&*buffer);
+            let buffer: &'static TokenBuffer = ::std::mem::transmute(&*buffer);
             buffer.begin()
         };
 

--- a/examples/unstable/src/lib.rs
+++ b/examples/unstable/src/lib.rs
@@ -7,7 +7,7 @@ use proc_macro::{Diagnostic, Span, TokenStream};
 use syn::buffer::{Cursor, TokenBuffer};
 use syn::spanned::Spanned;
 use syn::synom::Synom;
-use syn::*;
+use syn::{token, ExprTuple};
 
 struct Parser {
     buffer: Box<TokenBuffer>,

--- a/examples/unstable/src/main.rs
+++ b/examples/unstable/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(proc_macro_non_items)]
+
 #[macro_use]
 extern crate unstable;
 

--- a/examples/unstable/src/main.rs
+++ b/examples/unstable/src/main.rs
@@ -1,0 +1,11 @@
+#[macro_use]
+extern crate unstable;
+
+pub fn main() {
+    demo!((a, b) = (1, 2, 3));
+    demo!((a, b, c) = (1, 2, 3));
+    demo!((c) = (1, 2, 3));
+    demo!((c) ? (1, 2, 3));
+    demo!(c = (1, 2, 3));
+    demo!((a, b, c) = (1, 2, 3) hi);
+}


### PR DESCRIPTION
This is based on Sergio's work in https://github.com/SergioBenitez/syn/commit/b49a4b4d65c5c08dce0c587ade687cded684ec20. Custom error messages like the following:

```console
error: expected 2 element(s), got 3
 --> src/main.rs:7:20
  |
7 |     demo!((a, b) = (1, 2, 3));
  |                    ^^^^^^^^^
  |
note: because of this
 --> src/main.rs:7:11
  |
7 |     demo!((a, b) = (1, 2, 3));
  |           ^^^^^^

error: expected 1 element(s), got 3
 --> src/main.rs:9:17
  |
9 |     demo!((c) = (1, 2, 3));
  |                 ^^^^^^^^^
  |
note: because of this
 --> src/main.rs:9:11
  |
9 |     demo!((c) = (1, 2, 3));
  |           ^^^

error: failed to parse: expected `=`
  --> src/main.rs:10:15
   |
10 |     demo!((c) ? (1, 2, 3));
   |               ^

error: failed to parse: expected tuple
  --> src/main.rs:11:11
   |
11 |     demo!(c = (1, 2, 3));
   |           ^

error: trailing characters; expected eof
  --> src/main.rs:12:33
   |
12 |     demo!((a, b, c) = (1, 2, 3) hi);
   |                                 ^^
```

Relevant to #47.