### PR TITLE
Ignore proc-macro feature on wasm-target

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -127,7 +127,7 @@
 // and caution should be used when editing it. The public-facing interface is
 // 100% safe but the implementation is fragile internally.
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 use proc_macro as pm;
 use proc_macro2::{Delimiter, Ident, Literal, Span, TokenStream};
 use proc_macro2::{Group, Punct, TokenTree};
@@ -223,7 +223,7 @@ impl TokenBuffer {
     ///
     /// *This method is available if Syn is built with both the `"parsing"` and
     /// `"proc-macro"` features.*
-    #[cfg(feature = "proc-macro")]
+    #[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
     pub fn new(stream: pm::TokenStream) -> TokenBuffer {
         Self::new2(stream.into())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@
     )
 )]
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 extern crate proc_macro;
 extern crate proc_macro2;
 extern crate unicode_xid;
@@ -629,7 +629,7 @@ pub use error::parse_error;
 /// #
 /// # fn main() {}
 /// ```
-#[cfg(all(feature = "parsing", feature = "proc-macro"))]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "parsing", feature = "proc-macro"))]
 pub fn parse<T>(tokens: proc_macro::TokenStream) -> Result<T, ParseError>
 where
     T: Synom,

--- a/src/synom.rs
+++ b/src/synom.rs
@@ -150,7 +150,7 @@
 //!
 //! *This module is available if Syn is built with the `"parsing"` feature.*
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
 use proc_macro;
 use proc_macro2::{Delimiter, Group, Ident, Literal, Punct, TokenStream, TokenTree};
 
@@ -315,7 +315,7 @@ pub trait Parser: Sized {
     ///
     /// *This method is available if Syn is built with both the `"parsing"` and
     /// `"proc-macro"` features.*
-    #[cfg(feature = "proc-macro")]
+    #[cfg(all(not(all(target_arch = "wasm32", target_os = "unknown")), feature = "proc-macro"))]
     fn parse(self, tokens: proc_macro::TokenStream) -> Result<Self::Output, ParseError> {
         self.parse2(tokens.into())
     }


### PR DESCRIPTION
This causes the proc-macro feature to be ignored for wasm-targets where proc-macro is not available. Currently, if a crate is to be built on wasm that depends on `syn`, the proc-macro feature from an actual proc-macro leaks into the build-environment of `syn`, causing the build to fail.

This patch enables me to build (and run) my crate on wasm-targets.

I'd be nice if this could be bumped into a 0.14 release. This is a concerted effort with [proc-macro2](https://github.com/alexcrichton/proc-macro2/pull/111), `syn`, `quote` and [stdweb](https://github.com/koute/stdweb/issues/257); all of which need patching to compile on wasm.