### PR TITLE
Prototype for support of custom keywords

### DIFF
--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -1,0 +1,81 @@
+use buffer::Cursor;
+use token::Token;
+
+pub trait Keyword {
+    fn ident() -> &'static str;
+
+    fn display() -> &'static str;
+}
+
+impl<K: Keyword> Token for K {
+    fn peek(cursor: Cursor) -> bool {
+        if let Some((ident, _rest)) = cursor.ident() {
+            ident == K::ident()
+        } else {
+            false
+        }
+    }
+
+    fn display() -> &'static str {
+        K::display()
+    }
+}
+
+#[macro_export]
+macro_rules! custom_keyword {
+    ($ident:ident) => {
+        custom_keyword_internal!({ pub(in self) } $ident);
+    };
+    (pub $ident:ident) => {
+        custom_keyword_internal!({ pub } $ident);
+    };
+    (pub(crate) $ident:ident) => {
+        custom_keyword_internal!({ pub(crate) } $ident);
+    };
+    (pub(super) $ident:ident) => {
+        custom_keyword_internal!({ pub(super) } $ident);
+    };
+    (pub(self) $ident:ident) => {
+        custom_keyword_internal!({ pub(self) } $ident);
+    };
+    (pub(in $path:path) $ident:ident) => {
+        custom_keyword_internal!({ pub(in $path) } $ident);
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! custom_keyword_internal {
+    ({ $($vis:tt)* } $ident:ident) => {
+        $($vis)* struct $ident {
+            inner: $crate::Ident
+        }
+
+        impl $crate::parse::Keyword for $ident {
+            fn ident() -> &'static str {
+                stringify!($ident)
+            }
+
+            fn display() -> &'static str {
+                concat!("`", stringify!($ident), "`")
+            }
+        }
+
+        impl $crate::parse::Parse for $ident {
+            fn parse(input: $crate::parse::ParseStream) -> $crate::parse::Result<$ident> {
+                input.step(|cursor| {
+                    if let Some((ident, rest)) = cursor.ident() {
+                        if ident == stringify!($ident) {
+                            return Ok(($ident { inner: ident }, rest));
+                        }
+                    }
+                    Err(cursor.error(concat!("expected `", stringify!($ident), "`")))
+                })
+            }
+        }
+
+        $($vis)* fn $ident(marker: $crate::parse::TokenMarker) -> $ident {
+            match marker {}
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,6 +571,9 @@ pub mod export;
 mod lookahead;
 
 #[cfg(feature = "parsing")]
+mod keyword;
+
+#[cfg(feature = "parsing")]
 pub mod parse;
 
 mod span;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -214,7 +214,8 @@ use punctuated::Punctuated;
 use token::Token;
 
 pub use error::{Error, Result};
-pub use lookahead::{Lookahead1, Peek};
+pub use lookahead::{Lookahead1, Peek, TokenMarker};
+pub use keyword::Keyword;
 
 /// Parsing interface implemented by all types that can be parsed in a default
 /// way from a token stream.

--- a/src/token.rs
+++ b/src/token.rs
@@ -118,7 +118,7 @@ use lit::{Lit, LitBool, LitByte, LitByteStr, LitChar, LitFloat, LitInt, LitStr};
 #[cfg(feature = "parsing")]
 use lookahead;
 #[cfg(feature = "parsing")]
-use parse::{Parse, ParseStream};
+use parse::{Keyword, Parse, ParseStream};
 use span::IntoSpans;
 
 /// Marker trait for types that represent single tokens.
@@ -142,6 +142,9 @@ mod private {
 
 #[cfg(feature = "parsing")]
 impl private::Sealed for Ident {}
+
+#[cfg(feature = "parsing")]
+impl<K: Keyword> private::Sealed for K {}
 
 #[cfg(feature = "parsing")]
 fn peek_impl(cursor: Cursor, peek: fn(ParseStream) -> bool) -> bool {


### PR DESCRIPTION
First prototype for support of custom keywords with syn's new parsing
API. Documentation and tests aren't present for now as I'm mainly
reaching for feedback.

This patch introduces a new Keyword trait, a new macro custom_keyword!
and exposes the existing TokenMarker enum. The Keyword trait
automatically implements the Token trait, making it possible to peek on
custom keywords (this is why I had to make TokenMarker public).

The custom macro generates a structure storing an Ident and implementing
the Keyword and Parse traits. A function with the same name as the
structure is also generated in order to use it like any predefined
keyword.

Unresolved questions:

* Making TokenMarker public is the only way I found to allow custom_keyword to implement the Peek trait. Is it possible and/or dangerous ?
* Via its blanket impls, Keyword is highjacking the fact that the Token trait is currently sealed. Could this have implications that I'm not foreseeing ?

Ref: #476 

```rust
// Example usage, parsing `key = "value"`
custom_keyword!(key);

struct KeyPair {
    key: key,
    equals: Token![=],
    value: syn::LitStr,
}

impl syn::parse::Parse for KeyPair {
    fn parse(input: syn::parse::ParseStream) -> syn::parse::Result<Self> {
        Ok(KeyPair {
            key: input.parse()?,
            equals: input.parse()?,
            value: input.parse()?,
        })
    }
}
```

```rust
// More complex example parsing either:
// - `key_str = "literal string"`
// - `key_bool = true` or `key_bool = false`
custom_keyword!(key_str);
custom_keyword!(key_bool);

enum Pairs {
    Str { key: key_str, equals: Token![=], value: syn::LitStr },
    Bool { key: key_bool, equals: Token![=], value: syn::LitBool }
}

impl syn::parse::Parse for Pairs {
    fn parse(input: syn::parse::ParseStream) -> syn::parse::Result<Self> {
        let lookahead = input.lookahead1();
        if lookahead.peek(key_str) {
            Ok(Pairs::Str {
                key: input.parse()?,
                equals: input.parse()?,
                value: input.parse()?,
            })
        } else if lookahead.peek(key_bool) {
            Ok(Pairs::Bool {
                key: input.parse()?,
                equals: input.parse()?,
                value: input.parse()?,
            })
        } else {
            Err(lookahead.error())
        }
    }
}
```
