### PR TITLE
Fix building on wasm32 target.

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -12,7 +12,10 @@ pub use proc_macro2::{Span, TokenStream as TokenStream2};
 
 pub use span::IntoSpans;
 
-#[cfg(feature = "proc-macro")]
+#[cfg(all(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    feature = "proc-macro"
+))]
 pub use proc_macro::TokenStream;
 
 #[cfg(feature = "printing")]


### PR DESCRIPTION
Hi,

#469 fixed building on wasm32 target but a later commit added code which broke it again. This PR changes the `cfg` attribute to match what #469 does.

Before:

```
$ cargo build --target wasm32-unknown-unknown
   Compiling syn v0.15.4 (file:///.../syn)
error[E0432]: unresolved import `proc_macro`
  --> src/export.rs:16:9
   |
16 | pub use proc_macro::TokenStream;
   |         ^^^^^^^^^^ Maybe a missing `extern crate proc_macro;`?

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `syn`.
```

After:

```
$ cargo build --target wasm32-unknown-unknown
   Compiling syn v0.15.4 (file:///.../syn)
    Finished dev [unoptimized + debuginfo] target(s) in 1.90s
```

I've tried compiling with all the feature combinations that are in `.travis.yml` with wasm32-unknown-unknown and they all work.

Not sure how I can add wasm32 target to travis.yml. I can look into it if you want.