### PR TITLE
Download test suite as tgz rather than git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: false
 language: rust
 
-cache:
-  directories:
-    - tests/rust
-
 rust:
   - nightly
   - stable

--- a/tests/clone.sh
+++ b/tests/clone.sh
@@ -1,24 +1,16 @@
 #!/bin/bash
 
-REMOTE=rust
-REPO=https://github.com/rust-lang/rust
 REV=63d66494aff57411bfec1dd2a3a5f1af900feab6
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 mkdir -p rust
-cd rust
+touch rust/COMMIT
 
-git init
-
-if git remote | grep --fixed-strings --line-regexp --quiet "$REMOTE"; then
-    git remote set-url "$REMOTE" "$REPO"
-else
-    git remote add "$REMOTE" "$REPO"
+if [ "$(cat rust/COMMIT)" != "$REV" ]; then
+    rm -rf rust
+    mkdir rust
+    curl -L "https://github.com/rust-lang/rust/archive/${REV}.tar.gz" \
+        | tar xz --directory rust --strip-components 1
+    echo "$REV" > rust/COMMIT
 fi
-
-if ! git cat-file -t "$REV" >/dev/null 2>&1; then
-    git fetch "$REMOTE" master
-fi
-
-git checkout "$REV"


### PR DESCRIPTION
This is a faster download, smaller on disk, and saves time in the cache steps on Travis.