### PR TITLE
Compiler now tracks whether module declarations are inline

### DIFF
--- a/tests/common/eq.rs
+++ b/tests/common/eq.rs
@@ -292,7 +292,7 @@ spanless_eq_struct!(Local; pat ty init id span attrs);
 spanless_eq_struct!(Mac_; path delim tts);
 spanless_eq_struct!(MacroDef; tokens legacy);
 spanless_eq_struct!(MethodSig; header decl);
-spanless_eq_struct!(Mod; inner items);
+spanless_eq_struct!(Mod; inner items inline);
 spanless_eq_struct!(MutTy; ty mutbl);
 spanless_eq_struct!(ParenthesisedArgs; span inputs output);
 spanless_eq_struct!(Pat; id node span);


### PR DESCRIPTION
```console
error[E0027]: pattern does not mention field `inline`                          
   --> tests/common/eq.rs:140:57                                               
    |                                                                          
140 |                 let $name { $($field,)* $($ignore: _,)* } = self;        
    |                                                         ^ missing field `inline`
...                                                                            
295 | spanless_eq_struct!(Mod; inner items);                                   
    | -------------------------------------- in this macro invocation          
                                                                               
error[E0027]: pattern does not mention field `inline`                          
   --> tests/common/eq.rs:141:65                                               
    |                                                                          
141 |                 let $name { $($field: $other,)* $($ignore: _,)* } = other;
    |                                                                 ^ missing field `inline`
...                                                                            
295 | spanless_eq_struct!(Mod; inner items);                                   
    | -------------------------------------- in this macro invocation
```

Change in nightly: https://github.com/rust-lang/rust/pull/52319