### PR TITLE
allow 'proc' as identifier, as per RFC-2420

### DIFF
--- a/src/ident.rs
+++ b/src/ident.rs
@@ -22,10 +22,11 @@ fn accept_as_ident(ident: &Ident) -> bool {
         "_"
         // Based on https://doc.rust-lang.org/grammar.html#keywords
         // and https://github.com/rust-lang/rfcs/blob/master/text/2421-unreservations-2018.md
+        // and https://github.com/rust-lang/rfcs/blob/master/text/2420-unreserve-proc.md
         | "abstract" | "as" | "become" | "box" | "break" | "const"
         | "continue" | "crate" | "do" | "else" | "enum" | "extern" | "false" | "final"
         | "fn" | "for" | "if" | "impl" | "in" | "let" | "loop" | "macro" | "match"
-        | "mod" | "move" | "mut" | "override" | "priv" | "proc" | "pub"
+        | "mod" | "move" | "mut" | "override" | "priv" | "pub"
         | "ref" | "return" | "Self" | "self" | "static" | "struct"
         | "super" | "trait" | "true" | "type" | "typeof" | "unsafe" | "unsized" | "use"
         | "virtual" | "where" | "while" | "yield" => false,


### PR DESCRIPTION
'proc' keyword was unreserved, as described in https://github.com/rust-lang/rfcs/blob/master/text/2420-unreserve-proc.md.

BTWt, the tests in this crate seem to be badly broken. When testes with `cargo test`, it throws a whole bunch of errors - tested on current nightly.
