### PR TITLE
Call the right quote from parse_quote on sufficiently new compilers

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,47 @@
+use std::env;
+use std::process::Command;
+use std::str::{self, FromStr};
+
+// The rustc-cfg strings below are *not* public API. Please let us know by
+// opening a GitHub issue if your build environment requires some way to enable
+// these cfgs other than by executing our build script.
+fn main() {
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    // Macro modularization allows re-exporting the `quote!` macro in 1.30+.
+    if minor >= 30 {
+        println!("cargo:rustc-cfg=syn_can_call_macro_by_path");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = match env::var_os("RUSTC") {
+        Some(rustc) => rustc,
+        None => return None,
+    };
+
+    let output = match Command::new(rustc).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return None,
+    };
+
+    let version = match str::from_utf8(&output.stdout) {
+        Ok(version) => version,
+        Err(_) => return None,
+    };
+
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+
+    let next = match pieces.next() {
+        Some(next) => next,
+        None => return None,
+    };
+
+    u32::from_str(next).ok()
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -8,6 +8,9 @@ pub use std::marker::Copy;
 pub use std::option::Option::{None, Some};
 pub use std::result::Result::{Err, Ok};
 
+#[cfg(feature = "printing")]
+pub extern crate quote;
+
 pub use proc_macro2::{Span, TokenStream as TokenStream2};
 
 pub use span::IntoSpans;

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -38,8 +38,14 @@
 /// parameter `T` in the input generics.
 ///
 /// ```
-/// #[macro_use]
-/// extern crate quote;
+#[cfg_attr(
+    not(syn_can_call_macro_by_path),
+    doc = " #[macro_use]"
+)]
+#[cfg_attr(
+    not(syn_can_call_macro_by_path),
+    doc = " extern crate quote;"
+)]
 /// #[macro_use]
 /// extern crate syn;
 ///
@@ -76,10 +82,29 @@
 /// Panics if the tokens fail to parse as the expected syntax tree type. The
 /// caller is responsible for ensuring that the input tokens are syntactically
 /// valid.
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! parse_quote {
     ($($tt:tt)*) => {
-        $crate::parse_quote::parse($crate::export::From::from(quote!($($tt)*)))
+        $crate::parse_quote::parse($crate::export::From::from(quote_impl!($($tt)*)))
+    };
+}
+
+#[cfg(not(syn_can_call_macro_by_path))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! quote_impl {
+    ($($tt:tt)*) => {
+        // Require caller to have their own `#[macro_use] extern crate quote`.
+        quote!($($tt)*)
+    };
+}
+
+#[cfg(syn_can_call_macro_by_path)]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! quote_impl {
+    ($($tt:tt)*) => {
+        $crate::export::quote::quote!($($tt)*)
     };
 }
 


### PR DESCRIPTION
Fixes https://github.com/dtolnay/syn/issues/505#issuecomment-425401600.