### PR TITLE
Implement Parse for meta item types

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -180,8 +180,10 @@ impl Attribute {
     pub fn parse_meta(&self) -> Result<Meta> {
         use quote::ToTokens;
 
-        let mut tts = self.path.clone().into_token_stream();
-        tts.extend(self.tts.clone());
+        let mut tts = TokenStream::new();
+
+        self.path.to_tokens(&mut tts);
+        self.tts.to_tokens(&mut tts);
 
         ::parse2(tts)
     }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -473,6 +473,48 @@ ast_enum_of_structs! {
     }
 }
 
+/// Conventional argument type associated with an invocation of an attribute
+/// macro.
+///
+/// For example if we are developing an attribute macro that is intended to be
+/// invoked on function items as follows:
+///
+/// ```rust
+/// # const IGNORE: &str = stringify! {
+/// #[my_attribute(path = "/v1/refresh")]
+/// # };
+/// pub fn refresh() {
+///     /* ... */
+/// }
+/// ```
+///
+/// The implementation of this macro would want to parse its attribute arguments
+/// as type `AttributeArgs`.
+///
+/// ```rust
+/// #[macro_use]
+/// extern crate syn;
+///
+/// extern crate proc_macro;
+///
+/// use proc_macro::TokenStream;
+/// use syn::{AttributeArgs, ItemFn};
+///
+/// # const IGNORE: &str = stringify! {
+/// #[proc_macro_attribute]
+/// # };
+/// pub fn my_attribute(args: TokenStream, input: TokenStream) -> TokenStream {
+///     let args = parse_macro_input!(args as AttributeArgs);
+///     let input = parse_macro_input!(input as ItemFn);
+///
+///     /* ... */
+/// #   "".parse().unwrap()
+/// }
+/// #
+/// # fn main() {}
+/// ```
+pub type AttributeArgs = Vec<NestedMeta>;
+
 pub trait FilterAttrs<'a> {
     type Ret: Iterator<Item = &'a Attribute>;
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -550,9 +550,9 @@ pub mod parsing {
             let nested = content.parse_terminated(NestedMeta::parse)?;
 
             Ok(MetaList {
-                ident,
-                paren_token,
-                nested,
+                ident: ident,
+                paren_token: paren_token,
+                nested: nested,
             })
         }
     }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -174,6 +174,18 @@ impl Attribute {
         None
     }
 
+    /// Parses the tokens after the path as a [`Meta`](enum.Meta.html) if
+    /// possible.
+    #[cfg(feature = "parsing")]
+    pub fn parse_meta(&self) -> Result<Meta> {
+        use quote::ToTokens;
+
+        let mut tts = self.path.clone().into_token_stream();
+        tts.extend(self.tts.clone());
+
+        ::parse2(tts)
+    }
+
     /// Parses zero or more outer attributes from the stream.
     ///
     /// *This function is available if Syn is built with the `"parsing"`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ pub use ident::Ident;
 #[cfg(any(feature = "full", feature = "derive"))]
 mod attr;
 #[cfg(any(feature = "full", feature = "derive"))]
-pub use attr::{AttrStyle, Attribute, Meta, MetaList, MetaNameValue, NestedMeta};
+pub use attr::{AttrStyle, Attribute, AttributeArgs, Meta, MetaList, MetaNameValue, NestedMeta};
 
 #[cfg(any(feature = "full", feature = "derive"))]
 mod data;

--- a/src/parse_macro_input.rs
+++ b/src/parse_macro_input.rs
@@ -79,9 +79,9 @@ impl<T: Parse> ParseMacroInput for T {
 ////////////////////////////////////////////////////////////////////////////////
 // Any other types that we want `parse_macro_input!` to be able to parse.
 
-use NestedMeta;
+use AttributeArgs;
 
-impl ParseMacroInput for Vec<NestedMeta> {
+impl ParseMacroInput for AttributeArgs {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut metas = Vec::new();
 

--- a/src/parse_macro_input.rs
+++ b/src/parse_macro_input.rs
@@ -1,0 +1,102 @@
+/// Parse the input TokenStream of a macro, triggering a compile error if the
+/// tokens fail to parse.
+///
+/// Refer to the [`parse` module] documentation for more details about parsing
+/// in Syn.
+///
+/// [`parse` module]: parse/index.html
+///
+/// # Intended usage
+///
+/// ```rust
+/// #[macro_use]
+/// extern crate syn;
+///
+/// extern crate proc_macro;
+///
+/// use proc_macro::TokenStream;
+/// use syn::parse::{Parse, ParseStream, Result};
+///
+/// struct MyMacroInput {
+///     /* ... */
+/// }
+///
+/// impl Parse for MyMacroInput {
+///     fn parse(input: ParseStream) -> Result<Self> {
+///         /* ... */
+/// #       Ok(MyMacroInput {})
+///     }
+/// }
+///
+/// # const IGNORE: &str = stringify! {
+/// #[proc_macro]
+/// # };
+/// pub fn my_macro(tokens: TokenStream) -> TokenStream {
+///     let input = parse_macro_input!(tokens as MyMacroInput);
+///
+///     /* ... */
+/// #   "".parse().unwrap()
+/// }
+/// #
+/// # fn main() {}
+/// ```
+#[macro_export]
+macro_rules! parse_macro_input {
+    ($tokenstream:ident as $ty:ty) => {
+        match $crate::parse_macro_input::parse::<$ty>($tokenstream) {
+            $crate::export::Ok(data) => data,
+            $crate::export::Err(err) => {
+                return $crate::export::TokenStream::from(err.to_compile_error());
+            }
+        };
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Can parse any type that implements Parse.
+
+use parse::{Parse, ParseStream, Parser, Result};
+use proc_macro::TokenStream;
+
+// Not public API.
+#[doc(hidden)]
+pub fn parse<T: ParseMacroInput>(token_stream: TokenStream) -> Result<T> {
+    T::parse.parse(token_stream)
+}
+
+// Not public API.
+#[doc(hidden)]
+pub trait ParseMacroInput: Sized {
+    fn parse(input: ParseStream) -> Result<Self>;
+}
+
+impl<T: Parse> ParseMacroInput for T {
+    fn parse(input: ParseStream) -> Result<Self> {
+        <T as Parse>::parse(input)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Any other types that we want `parse_macro_input!` to be able to parse.
+
+use NestedMeta;
+
+impl ParseMacroInput for Vec<NestedMeta> {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut metas = Vec::new();
+
+        loop {
+            if input.is_empty() {
+                break;
+            }
+            let value = input.parse()?;
+            metas.push(value);
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        Ok(metas)
+    }
+}

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -139,9 +139,7 @@ impl<T: Parse> ParseQuote for T {
 ////////////////////////////////////////////////////////////////////////////////
 // Any other types that we want `parse_quote!` to be able to parse.
 
-use NestedMeta;
 use punctuated::Punctuated;
-use token;
 #[cfg(any(feature = "full", feature = "derive"))]
 use {attr, Attribute};
 
@@ -159,15 +157,5 @@ impl ParseQuote for Attribute {
 impl<T: Parse, P: Parse> ParseQuote for Punctuated<T, P> {
     fn parse(input: ParseStream) -> Result<Self> {
         Self::parse_terminated(input)
-    }
-}
-
-impl ParseQuote for Vec<NestedMeta> {
-    fn parse(input: ParseStream) -> Result<Self> {
-        let items = input.parse_terminated::<_, token::Comma>(<NestedMeta as Parse>::parse)?
-            .into_iter()
-            .collect();
-
-        Ok(items)
     }
 }

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -139,7 +139,9 @@ impl<T: Parse> ParseQuote for T {
 ////////////////////////////////////////////////////////////////////////////////
 // Any other types that we want `parse_quote!` to be able to parse.
 
+use NestedMeta;
 use punctuated::Punctuated;
+use token;
 #[cfg(any(feature = "full", feature = "derive"))]
 use {attr, Attribute};
 
@@ -157,5 +159,15 @@ impl ParseQuote for Attribute {
 impl<T: Parse, P: Parse> ParseQuote for Punctuated<T, P> {
     fn parse(input: ParseStream) -> Result<Self> {
         Self::parse_terminated(input)
+    }
+}
+
+impl ParseQuote for Vec<NestedMeta> {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let items = input.parse_terminated::<_, token::Comma>(<NestedMeta as Parse>::parse)?
+            .into_iter()
+            .collect();
+
+        Ok(items)
     }
 }

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -290,5 +290,7 @@ fn run_test<T: Into<Meta>>(input: &str, expected: T) {
     let attrs = Attribute::parse_outer.parse_str(input).unwrap();
     assert_eq!(attrs.len(), 1);
     let attr = attrs.into_iter().next().unwrap();
-    assert_eq!(expected.into(), attr.interpret_meta().unwrap());
+    let expected = expected.into();
+    assert_eq!(expected, attr.interpret_meta().unwrap());
+    assert_eq!(expected, attr.parse_meta().unwrap());
 }

--- a/tests/test_meta_item.rs
+++ b/tests/test_meta_item.rs
@@ -10,7 +10,6 @@
 
 extern crate proc_macro2;
 extern crate syn;
-#[macro_use]
 extern crate quote;
 
 use proc_macro2::{Ident, Literal, Span};
@@ -302,60 +301,6 @@ fn test_parse_nested_meta() {
     );
 
     assert_eq!(expected, syn::parse_str(raw).unwrap());
-}
-
-#[test]
-fn test_parse_quote_nested_meta() {
-    let actual: Vec<NestedMeta> = parse_quote!(5);
-
-    let expected = vec![
-        NestedMeta::Literal(lit(Literal::i32_unsuffixed(5)))
-    ];
-
-    assert_eq!(expected, actual);
-
-    let actual: Vec<NestedMeta> = parse_quote!(list(name2 = 6));
-
-    let expected = vec![
-        NestedMeta::Meta(
-            MetaList {
-                ident: ident("list").into(),
-                paren_token: Default::default(),
-                nested: punctuated![NestedMeta::Meta(
-                    MetaNameValue {
-                        ident: ident("name2").into(),
-                        eq_token: Default::default(),
-                        lit: lit(Literal::i32_unsuffixed(6)),
-                    }
-                    .into(),
-                )],
-            }
-            .into(),
-        )
-    ];
-
-    assert_eq!(expected, actual);
-
-    let actual: Vec<NestedMeta> = parse_quote!(5, list(name2 = 6));
-
-    let expected = vec![
-        NestedMeta::Literal(lit(Literal::i32_unsuffixed(5))),
-        NestedMeta::Meta(
-            MetaList {
-                ident: ident("list").into(),
-                paren_token: Default::default(),
-                nested: punctuated![NestedMeta::Meta(
-                    MetaNameValue {
-                        ident: ident("name2").into(),
-                        eq_token: Default::default(),
-                        lit: lit(Literal::i32_unsuffixed(6)),
-                    }
-                    .into(),
-                )],
-            }
-            .into(),
-        )
-    ];
 }
 
 fn run_test<T: Into<Meta>>(input: &str, expected: T) {


### PR DESCRIPTION
The various meta item types have been missing `Parse` implementations.
This makes parsing the argument to Rust's proc macros difficult.

This patch provides Parse implementation for:

* Meta
* MetaList
* MetaNameValue
* NestedMeta

A first step towards the goals stated in #359.