### PR TITLE
Export syn::Error and syn::Result from crate root

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -81,8 +81,8 @@ ast_struct! {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{Attribute, Ident};
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::{Attribute, Ident, Result};
+    /// use syn::parse::{Parse, ParseStream};
     ///
     /// // Parses a unit struct with attributes.
     /// //

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,7 @@ use proc_macro2::{
 #[cfg(feature = "printing")]
 use quote::ToTokens;
 
+#[cfg(feature = "parsing")]
 use buffer::Cursor;
 use thread::ThreadBound;
 
@@ -172,6 +173,7 @@ impl Error {
     }
 }
 
+#[cfg(feature = "parsing")]
 pub fn new_at<T: Display>(scope: Span, cursor: Cursor, message: T) -> Error {
     if cursor.eof() {
         Error::new(scope, format!("unexpected end of input, {}", message))

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,8 +61,8 @@ impl Error {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{Ident, LitStr};
-    /// use syn::parse::{Error, ParseStream, Result};
+    /// use syn::{Error, Ident, LitStr, Result};
+    /// use syn::parse::ParseStream;
     ///
     /// // Parses input that looks like `name = "string"` where the key must be
     /// // the identifier `name` and the value may be any string literal.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2303,8 +2303,8 @@ pub mod parsing {
         /// #[macro_use]
         /// extern crate syn;
         ///
-        /// use syn::{token, Attribute, Block, Ident, Stmt};
-        /// use syn::parse::{Parse, ParseStream, Result};
+        /// use syn::{token, Attribute, Block, Ident, Result, Stmt};
+        /// use syn::parse::{Parse, ParseStream};
         ///
         /// // Parse a function with no generics or parameter list.
         /// //

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -21,9 +21,9 @@ pub trait IdentExt: Sized + private::Sealed {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::Ident;
+    /// use syn::{Error, Ident, Result};
     /// use syn::ext::IdentExt;
-    /// use syn::parse::{Error, ParseStream, Result};
+    /// use syn::parse::ParseStream;
     ///
     /// // Parses input that looks like `name = NAME` where `NAME` can be
     /// // any identifier.

--- a/src/group.rs
+++ b/src/group.rs
@@ -101,8 +101,8 @@ fn parse_delimited(input: ParseStream, delimiter: Delimiter) -> Result<(Span, Pa
 /// #[macro_use]
 /// extern crate syn;
 ///
-/// use syn::{token, Ident, Type};
-/// use syn::parse::{Parse, ParseStream, Result};
+/// use syn::{token, Ident, Result, Type};
+/// use syn::parse::{Parse, ParseStream};
 /// use syn::punctuated::Punctuated;
 ///
 /// // Parse a simplified tuple struct syntax like:
@@ -161,8 +161,8 @@ macro_rules! parenthesized {
 /// #
 /// #[macro_use]
 /// extern crate syn;
-/// use syn::{token, Ident, Type};
-/// use syn::parse::{Parse, ParseStream, Result};
+/// use syn::{token, Ident, Result, Type};
+/// use syn::parse::{Parse, ParseStream};
 /// use syn::punctuated::Punctuated;
 ///
 /// // Parse a simplified struct syntax like:
@@ -246,8 +246,8 @@ macro_rules! braced {
 /// extern crate proc_macro2;
 ///
 /// use proc_macro2::TokenStream;
-/// use syn::token;
-/// use syn::parse::{Parse, ParseStream, Result};
+/// use syn::{token, Result};
+/// use syn::parse::{Parse, ParseStream};
 ///
 /// // Parse an outer attribute like:
 /// //

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -52,8 +52,8 @@
 /// #[macro_use]
 /// extern crate syn;
 ///
-/// use syn::{LitBool, LitStr};
-/// use syn::parse::{Parse, ParseStream, Result};
+/// use syn::{LitBool, LitStr, Result};
+/// use syn::parse::{Parse, ParseStream};
 ///
 /// mod kw {
 ///     custom_keyword!(bool);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,7 +565,6 @@ mod span;
 #[cfg(all(any(feature = "full", feature = "derive"), feature = "printing"))]
 mod print;
 
-#[cfg(feature = "parsing")]
 mod thread;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -576,9 +575,7 @@ struct private;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "parsing")]
 mod error;
-#[cfg(feature = "parsing")]
 pub use error::{Error, Result};
 
 /// Parse tokens of source code into the chosen syntax tree node.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -664,8 +664,7 @@ pub fn parse2<T: parse::Parse>(tokens: proc_macro2::TokenStream) -> Result<T> {
 /// ```rust
 /// # extern crate syn;
 /// #
-/// use syn::Expr;
-/// use syn::parse::Result;
+/// use syn::{Expr, Result};
 ///
 /// fn run() -> Result<()> {
 ///     let code = "assert_eq!(u8::max_value(), 255)";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,7 +579,7 @@ struct private;
 #[cfg(feature = "parsing")]
 mod error;
 #[cfg(feature = "parsing")]
-use error::Error;
+pub use error::{Error, Result};
 
 /// Parse tokens of source code into the chosen syntax tree node.
 ///
@@ -632,7 +632,7 @@ use error::Error;
     feature = "parsing",
     feature = "proc-macro"
 ))]
-pub fn parse<T: parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T, Error> {
+pub fn parse<T: parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T> {
     parse::Parser::parse(T::parse, tokens)
 }
 
@@ -649,7 +649,7 @@ pub fn parse<T: parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T, Erro
 ///
 /// *This function is available if Syn is built with the `"parsing"` feature.*
 #[cfg(feature = "parsing")]
-pub fn parse2<T: parse::Parse>(tokens: proc_macro2::TokenStream) -> Result<T, Error> {
+pub fn parse2<T: parse::Parse>(tokens: proc_macro2::TokenStream) -> Result<T> {
     parse::Parser::parse2(T::parse, tokens)
 }
 
@@ -680,7 +680,7 @@ pub fn parse2<T: parse::Parse>(tokens: proc_macro2::TokenStream) -> Result<T, Er
 /// # fn main() { run().unwrap() }
 /// ```
 #[cfg(feature = "parsing")]
-pub fn parse_str<T: parse::Parse>(s: &str) -> Result<T, Error> {
+pub fn parse_str<T: parse::Parse>(s: &str) -> Result<T> {
     parse::Parser::parse_str(T::parse, s)
 }
 
@@ -723,7 +723,7 @@ pub fn parse_str<T: parse::Parse>(s: &str) -> Result<T, Error> {
 /// # fn main() { run().unwrap() }
 /// ```
 #[cfg(all(feature = "parsing", feature = "full"))]
-pub fn parse_file(mut content: &str) -> Result<File, Error> {
+pub fn parse_file(mut content: &str) -> Result<File> {
     // Strip the BOM if it is present
     const BOM: &'static str = "\u{feff}";
     if content.starts_with(BOM) {

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -134,8 +134,7 @@ impl LitStr {
     /// # extern crate syn;
     /// #
     /// use proc_macro2::Span;
-    /// use syn::{Attribute, Ident, Lit, Meta, MetaNameValue, Path};
-    /// use syn::parse::{Error, Result};
+    /// use syn::{Attribute, Error, Ident, Lit, Meta, MetaNameValue, Path, Result};
     ///
     /// // Parses the path from an attribute that looks like:
     /// //

--- a/src/lookahead.rs
+++ b/src/lookahead.rs
@@ -25,8 +25,8 @@ use token::Token;
 /// #[macro_use]
 /// extern crate syn;
 ///
-/// use syn::{ConstParam, Ident, Lifetime, LifetimeDef, TypeParam};
-/// use syn::parse::{Parse, ParseStream, Result};
+/// use syn::{ConstParam, Ident, Lifetime, LifetimeDef, Result, TypeParam};
+/// use syn::parse::{Parse, ParseStream};
 ///
 /// // A generic parameter, a single one of the comma-separated elements inside
 /// // angle brackets in:

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -40,8 +40,8 @@
 //! extern crate proc_macro;
 //!
 //! use proc_macro::TokenStream;
-//! use syn::{token, Field, Ident};
-//! use syn::parse::{Parse, ParseStream, Result};
+//! use syn::{token, Field, Ident, Result};
+//! use syn::parse::{Parse, ParseStream};
 //! use syn::punctuated::Punctuated;
 //!
 //! enum Item {
@@ -117,7 +117,7 @@
 //! ```
 //! use syn::Type;
 //!
-//! # fn run_parser() -> Result<(), syn::parse::Error> {
+//! # fn run_parser() -> syn::Result<()> {
 //! let t: Type = syn::parse_str("std::collections::HashMap<String, Value>")?;
 //! #     Ok(())
 //! # }
@@ -149,9 +149,8 @@
 //! # extern crate proc_macro;
 //! # extern crate syn;
 //! #
-//! # use syn::parse::Result;
 //! # use syn::punctuated::Punctuated;
-//! # use syn::{PathSegment, Token};
+//! # use syn::{PathSegment, Result, Token};
 //! #
 //! # fn f(tokens: proc_macro::TokenStream) -> Result<()> {
 //! #
@@ -180,7 +179,7 @@
 //! use syn::punctuated::Punctuated;
 //! use syn::{Attribute, Expr, PathSegment};
 //!
-//! # fn run_parsers() -> Result<(), syn::parse::Error> {
+//! # fn run_parsers() -> syn::Result<()> {
 //! #     let tokens = TokenStream::new().into();
 //! // Parse a nonempty sequence of path segments separated by `::` punctuation
 //! // with no trailing punctuation.
@@ -305,7 +304,8 @@ impl<'a> Debug for ParseBuffer<'a> {
 /// # extern crate syn;
 /// #
 /// use proc_macro2::TokenTree;
-/// use syn::parse::{ParseStream, Result};
+/// use syn::Result;
+/// use syn::parse::ParseStream;
 ///
 /// // This function advances the stream past the next occurrence of `@`. If
 /// // no `@` is present in the stream, the stream position is unchanged and
@@ -441,8 +441,8 @@ impl<'a> ParseBuffer<'a> {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{Attribute, Ident};
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::{Attribute, Ident, Result};
+    /// use syn::parse::{Parse, ParseStream};
     ///
     /// // Parses a unit struct with attributes.
     /// //
@@ -497,8 +497,8 @@ impl<'a> ParseBuffer<'a> {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{token, Generics, Ident, TypeParamBound};
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::{token, Generics, Ident, Result, TypeParamBound};
+    /// use syn::parse::{Parse, ParseStream};
     /// use syn::punctuated::Punctuated;
     ///
     /// // Parses a trait definition containing no associated items.
@@ -569,8 +569,8 @@ impl<'a> ParseBuffer<'a> {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{Ident, ItemUnion, Macro};
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::{Ident, ItemUnion, Macro, Result};
+    /// use syn::parse::{Parse, ParseStream};
     ///
     /// // Parses either a union or a macro invocation.
     /// enum UnionOrMacro {
@@ -618,8 +618,8 @@ impl<'a> ParseBuffer<'a> {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{token, Ident, Type};
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::{token, Ident, Result, Type};
+    /// use syn::parse::{Parse, ParseStream};
     /// use syn::punctuated::Punctuated;
     ///
     /// // Parse a simplified tuple struct syntax like:
@@ -671,8 +671,8 @@ impl<'a> ParseBuffer<'a> {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{token, Ident, Item};
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::{token, Ident, Item, Result};
+    /// use syn::parse::{Parse, ParseStream};
     ///
     /// // Parses a Rust `mod m { ... }` containing zero or more items.
     /// struct Mod {
@@ -715,8 +715,8 @@ impl<'a> ParseBuffer<'a> {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{ConstParam, Ident, Lifetime, LifetimeDef, TypeParam};
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::{ConstParam, Ident, Lifetime, LifetimeDef, Result, TypeParam};
+    /// use syn::parse::{Parse, ParseStream};
     ///
     /// // A generic parameter, a single one of the comma-separated elements inside
     /// // angle brackets in:
@@ -767,8 +767,8 @@ impl<'a> ParseBuffer<'a> {
     /// once.
     ///
     /// ```
-    /// # use syn::Expr;
-    /// # use syn::parse::{ParseStream, Result};
+    /// # use syn::{Expr, Result};
+    /// # use syn::parse::ParseStream;
     /// #
     /// # fn bad(input: ParseStream) -> Result<Expr> {
     /// // Do not do this.
@@ -824,9 +824,9 @@ impl<'a> ParseBuffer<'a> {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::{token, Ident, Path};
+    /// use syn::{token, Ident, Path, Result};
     /// use syn::ext::IdentExt;
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::parse::{Parse, ParseStream};
     ///
     /// struct PubVisibility {
     ///     pub_token: Token![pub],
@@ -900,8 +900,8 @@ impl<'a> ParseBuffer<'a> {
     /// #[macro_use]
     /// extern crate syn;
     ///
-    /// use syn::Expr;
-    /// use syn::parse::{Parse, ParseStream, Result};
+    /// use syn::{Expr, Result};
+    /// use syn::parse::{Parse, ParseStream};
     ///
     /// // Some kind of loop: `while` or `for` or `loop`.
     /// struct Loop {
@@ -943,7 +943,8 @@ impl<'a> ParseBuffer<'a> {
     /// # extern crate syn;
     /// #
     /// use proc_macro2::TokenTree;
-    /// use syn::parse::{ParseStream, Result};
+    /// use syn::Result;
+    /// use syn::parse::ParseStream;
     ///
     /// // This function advances the stream past the next occurrence of `@`. If
     /// // no `@` is present in the stream, the stream position is unchanged and

--- a/src/parse_macro_input.rs
+++ b/src/parse_macro_input.rs
@@ -15,7 +15,8 @@
 /// extern crate proc_macro;
 ///
 /// use proc_macro::TokenStream;
-/// use syn::parse::{Parse, ParseStream, Result};
+/// use syn::Result;
+/// use syn::parse::{Parse, ParseStream};
 ///
 /// struct MyMacroInput {
 ///     /* ... */

--- a/src/path.rs
+++ b/src/path.rs
@@ -370,8 +370,8 @@ pub mod parsing {
         /// #[macro_use]
         /// extern crate syn;
         ///
-        /// use syn::Path;
-        /// use syn::parse::{Parse, ParseStream, Result};
+        /// use syn::{Path, Result};
+        /// use syn::parse::{Parse, ParseStream};
         ///
         /// // A simplified single `use` statement like:
         /// //

--- a/src/token.rs
+++ b/src/token.rs
@@ -56,8 +56,8 @@
 //! ```
 //! # extern crate syn;
 //! #
-//! use syn::Attribute;
-//! use syn::parse::{Parse, ParseStream, Result};
+//! use syn::{Attribute, Result};
+//! use syn::parse::{Parse, ParseStream};
 //! #
 //! # enum ItemStatic {}
 //!

--- a/tests/test_ident.rs
+++ b/tests/test_ident.rs
@@ -13,9 +13,9 @@ mod features;
 
 use proc_macro2::{Ident, Span, TokenStream};
 use std::str::FromStr;
-use syn::parse::Error;
+use syn::Result;
 
-fn parse(s: &str) -> Result<Ident, Error> {
+fn parse(s: &str) -> Result<Ident> {
     syn::parse2(TokenStream::from_str(s).unwrap())
 }
 


### PR DESCRIPTION
Previously accessible as `syn::parse::Error` and `syn::parse::Result`.

I haven't fully made up my mind about this, but these have turned into a fairly nice general-purpose proc macro error type beyond just parsing. For example a derive macro that accepts attributes may want to use `syn::Error` as the error type for reporting a nonsensical application of some attribute, which is not exactly a parsing issue.

```rust
#[derive(Serialize)]
#[serde(untagged)]
struct S;
```

```console
error: #[serde(untagged)] can only be used on enums
 --> src/lib.rs:5:9
  |
5 | #[serde(untagged)]
  |         ^^^^^^^^
```