### PR TITLE
readme: fix example of custom derive

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ proc-macro = true
 
 ```rust
 extern crate proc_macro;
+extern crate quote;
+extern crate syn;
 
 use proc_macro::TokenStream;
 use quote::quote;


### PR DESCRIPTION
The example was missing the `extern crate` statement
for the `quote` and for the `syn` crates.