### PR TITLE
Use Group::span_open and span_close in error spans

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -17,6 +17,7 @@ use proc_macro2::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenS
 use std::marker::PhantomData;
 use std::ptr;
 
+use private;
 use Lifetime;
 
 /// Internal type which is used instead of `TokenTree` to represent a token tree
@@ -342,6 +343,24 @@ impl<'a> Cursor<'a> {
             Entry::Ident(ref t) => t.span(),
             Entry::Punct(ref o) => o.span(),
             Entry::End(..) => Span::call_site(),
+        }
+    }
+}
+
+impl private {
+    #[cfg(procmacro2_semver_exempt)]
+    pub fn open_span_of_group(cursor: Cursor) -> Span {
+        match *cursor.entry() {
+            Entry::Group(ref group, _) => group.span_open(),
+            _ => cursor.span(),
+        }
+    }
+
+    #[cfg(procmacro2_semver_exempt)]
+    pub fn close_span_of_group(cursor: Cursor) -> Span {
+        match *cursor.entry() {
+            Entry::Group(ref group, _) => group.span_close(),
+            _ => cursor.span(),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,8 @@ use quote::ToTokens;
 
 #[cfg(feature = "parsing")]
 use buffer::Cursor;
+#[cfg(all(procmacro2_semver_exempt, feature = "parsing"))]
+use private;
 use thread::ThreadBound;
 
 /// The result of a Syn parser.
@@ -171,7 +173,11 @@ pub fn new_at<T: Display>(scope: Span, cursor: Cursor, message: T) -> Error {
     if cursor.eof() {
         Error::new(scope, format!("unexpected end of input, {}", message))
     } else {
-        Error::new(cursor.span(), message)
+        #[cfg(procmacro2_semver_exempt)]
+        let span = private::open_span_of_group(cursor);
+        #[cfg(not(procmacro2_semver_exempt))]
+        let span = cursor.span();
+        Error::new(span, message)
     }
 }
 

--- a/src/group.rs
+++ b/src/group.rs
@@ -74,9 +74,13 @@ impl private {
 fn parse_delimited(input: ParseStream, delimiter: Delimiter) -> Result<(Span, ParseBuffer)> {
     input.step(|cursor| {
         if let Some((content, span, rest)) = cursor.group(delimiter) {
-            let unexpected = private::get_unexpected(input);
+            #[cfg(procmacro2_semver_exempt)]
+            let scope = private::close_span_of_group(*cursor);
+            #[cfg(not(procmacro2_semver_exempt))]
+            let scope = span;
             let nested = private::advance_step_cursor(cursor, content);
-            let content = private::new_parse_buffer(span, nested, unexpected);
+            let unexpected = private::get_unexpected(input);
+            let content = private::new_parse_buffer(scope, nested, unexpected);
             Ok(((span, content), rest))
         } else {
             let message = match delimiter {


### PR DESCRIPTION
#### Macro 1:

```rust
input.parse::<Ident>()?;
```

Before:

```console
error: expected identifier
 --> src/main.rs:3:4
  |
3 | m!([a]);
  |    ^^^
```

After:

```console
error: expected identifier
 --> src/main.rs:3:4
  |
3 | m!([a]);
  |    ^
```

#### Macro 2:

```rust
let content;
bracketed!(content in input);
content.parse::<Ident>()?;
content.parse::<Ident>()?;
```

Before:

```console
error: unexpected end of input, expected identifier
 --> src/main.rs:3:4
  |
3 | m!([a]);
  |    ^^^
```

After:

```console
error: unexpected end of input, expected identifier
 --> src/main.rs:3:6
  |
3 | m!([a]);
  |      ^
```