### PR TITLE
Make turbofish optional

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2261,7 +2261,7 @@ pub mod parsing {
             #[cfg(feature = "full")]
             let attrs = input.call(Attribute::parse_outer)?;
 
-            let (qself, path) = path::parsing::qpath(input, true)?;
+            let (qself, path) = path::parsing::qpath(input)?;
 
             Ok(ExprPath {
                 attrs: attrs,
@@ -2546,7 +2546,7 @@ pub mod parsing {
 
     #[cfg(feature = "full")]
     fn pat_path_or_macro_or_struct_or_range(input: ParseStream) -> Result<Pat> {
-        let (qself, path) = path::parsing::qpath(input, true)?;
+        let (qself, path) = path::parsing::qpath(input)?;
 
         if input.peek(Token![..]) {
             return pat_range(input, qself, path).map(Pat::Range);

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -628,7 +628,7 @@ pub mod parsing {
 
     impl Parse for TypePath {
         fn parse(input: ParseStream) -> Result<Self> {
-            let (qself, mut path) = path::parsing::qpath(input, false)?;
+            let (qself, mut path) = path::parsing::qpath(input)?;
 
             if path.segments.last().unwrap().value().arguments.is_empty()
                 && input.peek(token::Paren)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -51,6 +51,8 @@ pub fn base_dir_filter(entry: &DirEntry) -> bool {
     }
 
     match path_string.as_ref() {
+        // Until rustc has implemented RFC 2544
+        "tests/rust/src/test/ui/bastion-of-the-turbofish.rs" |
         // Deprecated placement syntax
         "tests/rust/src/test/run-pass/new-box-syntax.rs" |
         "tests/rust/src/test/ui/obsolete-in-place/bad.rs" |


### PR DESCRIPTION
Implements https://github.com/rust-lang/rfcs/pull/2544 which is in proposed-FCP.

This simple implementation works but diagnostics are somewhat worse than before. Consider the following input in which the user is missing part of the second type parameter. The parser backtracks to reparse the first type parameter as an expression, concluding that it is supposed to be something like `&('a: loop {})` and suggesting that the user write the missing colon after their loop label.

We may be able to build out a system for collecting both errors and emitting whichever one happened after parsing the larger number of tokens.

#### Before:

```console
error: expected identifier
 --> src/main.rs:4:38
  |
4 |     let _ = f::<&'a fn(), for<'a> serde::>();
  |                                          ^
```

#### After, without turbofish:

```console
error: expected `:`
 --> src/main.rs:4:19
  |
4 |     let _ = f<&'a fn(), for<'a> serde::>();
  |                   ^^
```