### PR TITLE
Add unsafe ParseBuffer::join, the opposite of fork

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -848,6 +848,121 @@ impl<'a> ParseBuffer<'a> {
         }
     }
 
+    /// Join this parse stream up with a forked parse stream.
+    ///
+    /// This is the opposite operation to [`ParseStream::fork`].
+    /// You can fork a parse stream, perform some speculative parsing, then join
+    /// the original stream to the fork to "commit" the parsing from the fork to
+    /// the main stream.
+    ///
+    /// If you can avoid doing this, you should, as it limits the ability to
+    /// generate useful errors. That said, it is often the only way to parse
+    /// syntax of the form `A* B*` for arbitrary syntax `A` and `B`. The problem
+    /// is that when the fork fails to parse an `A`, it's impossible to tell
+    /// whether that was because of a syntax error and the user meant to provide
+    /// an `A`, or that the `A`s are finished and its time to start parsing `B`s.
+    /// Use with care.
+    ///
+    /// # Example
+    ///
+    /// Let's show the example from [`ParseStream::fork`] of `pub(restricted)`
+    /// syntax, but using the fork for the speculative parsing instead of just
+    /// using it to peek at what's coming.
+    ///
+    /// The fork will speculatively attempt to parse the `(restricted)` part of
+    /// `pub(restricted)`. If successful, the main stream will be joined up;
+    /// otherwise, control flow returns to the main parse stream without the
+    /// speculative parsing committed to the main stream.
+    ///
+    /// ```edition2018
+    /// use syn::{parenthesized, token, Ident, Path, Result, Token};
+    /// use syn::ext::IdentExt;
+    /// use syn::parse::{Parse, ParseStream};
+    ///
+    /// struct PubVisibility {
+    ///     pub_token: Token![pub],
+    ///     restricted: Option<Restricted>,
+    /// }
+    ///
+    /// struct Restricted {
+    ///     paren_token: token::Paren,
+    ///     in_token: Option<Token![in]>,
+    ///     path: Path,
+    /// }
+    ///
+    /// impl Parse for PubVisibility {
+    ///     fn parse(input: ParseStream) -> Result<Self> {
+    ///         Ok(PubVisibility {
+    ///             pub_token: input.parse()?,
+    ///             restricted: {
+    ///                 let fork = input.fork();
+    ///                 if let Ok(restricted) = fork.parse() {
+    ///                     // guarantee fork is derived from input
+    ///                     unsafe { input.join(&fork) };
+    ///                     Some(restricted)
+    ///                 } else {
+    ///                     None
+    ///                 }
+    ///             }
+    ///         })
+    ///     }
+    /// }
+    ///
+    /// impl Parse for Restricted {
+    ///     fn parse(input: ParseStream) -> Result<Self> {
+    ///         let content;
+    ///         let paren_token = parenthesized!(content in input);
+    ///
+    ///         let la = content.lookahead1();
+    ///         if la.peek(Token![crate])
+    ///             || la.peek(Token![self])
+    ///             || la.peek(Token![super])
+    ///         {
+    ///             Ok(Restricted {
+    ///                 paren_token: paren_token,
+    ///                 in_token: None,
+    ///                 path: Path::from(content.call(Ident::parse_any)?),
+    ///             })
+    ///         } else if la.peek(Token![in]) {
+    ///             Ok(Restricted {
+    ///                 paren_token: paren_token,
+    ///                 in_token: Some(content.parse()?),
+    ///                 path: content.call(Path::parse_mod_style)?,
+    ///             })
+    ///         } else {
+    ///             // never seen due to if let in <Parse for PubVisibility>
+    ///             Err(la.error())
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// The forked stream that this joins with must be derived by forking this parse stream.
+    /// This _will_ be checked in the future by a panic.
+    ///
+    /// [`ParseStream::fork`]: #method.fork
+    pub unsafe fn join(&self, fork: &Self) {
+        #[cfg(procmacro2_semver_exempt)]
+        {
+            // This guarantees that the fork is derived from this parse stream,
+            // but is not a stable method. Instead, we leave the method unsafe
+            // and require the user to ensure that this holds.
+            //
+            // SAFETY TODO(CAD97): does this actually hold?
+            //
+            // It's definitely true that `self.scope.eq(&fork.scope)` follows from
+            // fork was derived from self. Is the reverse implication true,
+            // especially in face of `parse_from_str`?
+            assert!(
+                self.scope.eq(&fork.scope),
+                "Fork was not derived from parse stream it was joined to"
+            );
+        };
+        self.cell.set(fork.cursor())
+    }
+
     /// Triggers an error at the current position of the parse stream.
     ///
     /// # Example


### PR DESCRIPTION
Addresses (some of?) #479 by allowing speculative parsing without leaving the `ParseStream` land.

The method as is currently in the PR is unsafe, as it requires the user to guarantee that the fork is indeed forked from the parse stream it is being joined to. This could potentially be guaranteed by examining the state of the two parse streams' `Span`s, but doing so is not stable.

This could potentially be made to panic safely by making `self.scope` a `Rc` and using `Rc::ptr_eq` to make sure that the base and the fork are both using the same root `Rc`'d scope. The second commit (TBD) implements this approach.