### PR TITLE
Ignore .sh-requiring tests on Windows

### DIFF
--- a/tests/test_precedence.rs
+++ b/tests/test_precedence.rs
@@ -86,6 +86,7 @@ fn test_simple_precedence() {
 
 /// Test expressions from rustc, like in `test_round_trip`.
 #[test]
+#[cfg_attr(target_os = "windows", ignore = "requires nix .sh")]
 fn test_rustc_precedence() {
     common::clone_rust();
     let abort_after = common::abort_after();

--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -34,6 +34,7 @@ mod common;
 use common::eq::SpanlessEq;
 
 #[test]
+#[cfg_attr(target_os = "windows", ignore = "requires nix .sh")]
 fn test_round_trip() {
     common::clone_rust();
     let abort_after = common::abort_after();


### PR DESCRIPTION
Closes #572 using the simplest approach.