### PR TITLE
Sync with Rust post C-variadic PR

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1092,6 +1092,14 @@ pub mod parsing {
             let content;
             let paren_token = parenthesized!(content in input);
             let inputs = content.parse_terminated(FnArg::parse)?;
+            let variadic: Option<Token![...]> = match inputs.last() {
+                Some(punctuated::Pair::End(&FnArg::Captured(ArgCaptured {
+                    ty: Type::Verbatim(TypeVerbatim { ref tts }), ..
+                }))) => {
+                    parse2(tts.clone()).ok()
+                }
+                _ => None
+            };
 
             let output: ReturnType = input.parse()?;
             let where_clause: Option<WhereClause> = input.parse()?;
@@ -1114,7 +1122,7 @@ pub mod parsing {
                     paren_token: paren_token,
                     inputs: inputs,
                     output: output,
-                    variadic: None,
+                    variadic: variadic,
                     generics: Generics {
                         where_clause: where_clause,
                         ..generics
@@ -1179,7 +1187,27 @@ pub mod parsing {
         Ok(ArgCaptured {
             pat: input.parse()?,
             colon_token: input.parse()?,
-            ty: input.parse()?,
+            ty: match input.parse::<Token![...]>() {
+                Ok(dot3) => {
+                    let mut args = vec![
+                        TokenTree::Punct(Punct::new('.', Spacing::Joint)),
+                        TokenTree::Punct(Punct::new('.', Spacing::Joint)),
+                        TokenTree::Punct(Punct::new('.', Spacing::Alone)),
+                    ];
+                    let tokens = TokenStream::from_iter(
+                        args.into_iter().zip(&dot3.spans).map(|(mut arg, span)| {
+                            arg.set_span(*span);
+                            arg
+                        }
+                    ));
+                    Type::Verbatim(TypeVerbatim {
+                        tts: tokens
+                    })
+                }
+                Err(_) => {
+                   input.parse()?
+                }
+            },
         })
     }
 
@@ -2593,8 +2621,7 @@ mod printing {
 
     impl ToTokens for ForeignItemVerbatim {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.tts.to_tokens(tokens);
-        }
+            self.tts.to_tokens(tokens); }
     }
 
     impl ToTokens for MethodSig {

--- a/tests/clone.sh
+++ b/tests/clone.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REV=e2f221c75932de7a29845c8d6f1f73536ad00c41
+REV=1999a2288123173b2e487865c9a04386173025f7
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/tests/common/eq.rs
+++ b/tests/common/eq.rs
@@ -275,7 +275,7 @@ spanless_eq_struct!(EnumDef; variants);
 spanless_eq_struct!(Expr; id node span attrs);
 spanless_eq_struct!(Field; ident expr span is_shorthand attrs);
 spanless_eq_struct!(FieldPat; ident pat is_shorthand attrs);
-spanless_eq_struct!(FnDecl; inputs output variadic);
+spanless_eq_struct!(FnDecl; inputs output c_variadic);
 spanless_eq_struct!(FnHeader; unsafety asyncness constness abi);
 spanless_eq_struct!(ForeignItem; ident attrs node id span vis);
 spanless_eq_struct!(ForeignMod; abi items);
@@ -373,7 +373,7 @@ spanless_eq_enum!(PatKind; Wild Ident(0 1 2) Struct(0 1 2) TupleStruct(0 1 2)
     Paren(0) Mac(0));
 spanless_eq_enum!(TyKind; Slice(0) Array(0 1) Ptr(0) Rptr(0 1) BareFn(0) Never
     Tup(0) Path(0 1) TraitObject(0 1) ImplTrait(0 1) Paren(0) Typeof(0) Infer
-    ImplicitSelf Mac(0) Err);
+    ImplicitSelf Mac(0) Err CVarArgs);
 
 impl SpanlessEq for Ident {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
rust-lang/rust#57760 "Support defining C compatible variadic
functions" changes the `FnDecl` and `FnSig` member `variadic` to
`c_variadic` and adds the `TyKind` variant `CVarArgs`. Update
`syn` to handle these changes.

Depends On: rust-lang/rust#57760