### PR TITLE
Generate JSON file of all syn types

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -12,6 +12,10 @@ failure = "0.1"
 inflections = "1.1"
 proc-macro2 = "0.4"
 rustfmt-nightly = { git = "https://github.com/rust-lang-nursery/rustfmt" }
+serde = "1.0.87"
+serde_derive = "1.0.87"
+serde_json = "1.0.38"
+toml = "0.4.10"
 
 [workspace]
 # Prefer that `cargo clean` in syn's directory does not require a rebuild of

--- a/codegen/src/json.rs
+++ b/codegen/src/json.rs
@@ -1,0 +1,39 @@
+use crate::types;
+
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+
+pub fn generate(types: &[types::TypeDef]) {
+    let codegen_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let mut f = File::open(codegen_root.join("../Cargo.toml")).unwrap();
+    let mut s = String::new();
+    f.read_to_string(&mut s).unwrap();
+
+    let manifest: Manifest = toml::from_str(&s).unwrap();
+
+    let f = ::std::fs::File::create(codegen_root.join("../syn.json")).unwrap();
+
+    serde_json::to_writer_pretty(f, &Introspect {
+        version: &manifest.package.version,
+        types,
+    }).unwrap();
+}
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    package: Package,
+}
+
+#[derive(Debug, Deserialize)]
+struct Package {
+    version: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Introspect<'a> {
+    /// The `syn` version used to generate the introspection file
+    version: &'a str,
+    types: &'a [types::TypeDef],
+}

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -20,12 +20,19 @@ extern crate quote;
 extern crate rustfmt_nightly as rustfmt;
 #[macro_use]
 extern crate syn;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate toml;
 
 mod gen;
+mod json;
 mod parse;
 mod types;
 
 fn main() {
     let types = parse::parse();
     gen::generate(&types);
+    json::generate(&types);
 }

--- a/codegen/src/types.rs
+++ b/codegen/src/types.rs
@@ -1,12 +1,13 @@
 use std::ops;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TypeDef {
     Struct(Struct),
     Enum(Enum),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Struct {
     ident: String,
     features: Features,
@@ -14,26 +15,27 @@ pub struct Struct {
     all_fields_pub: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Enum {
     ident: String,
     features: Features,
     variants: Vec<Variant>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Variant {
     ident: String,
     fields: Vec<Type>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Field {
     ident: String,
     ty: Type,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Type {
     /// Type defined by `syn`
     Item(String),
@@ -58,13 +60,13 @@ pub enum Type {
     Tuple(Vec<Type>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Token {
     repr: String,
     ty: String,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Serialize)]
 pub struct Features {
     any: Vec<String>,
 }
@@ -167,10 +169,6 @@ impl Token {
 
     pub fn repr(&self) -> &str {
         &self.repr
-    }
-
-    pub fn ty(&self) -> &str {
-        &self.ty
     }
 }
 

--- a/syn.json
+++ b/syn.json
@@ -1,0 +1,9691 @@
+{
+  "version": "0.15.26",
+  "types": [
+    {
+      "struct": {
+        "ident": "Abi",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "extern_token",
+            "ty": {
+              "token": {
+                "repr": "extern",
+                "ty": "Extern"
+              }
+            }
+          },
+          {
+            "ident": "name",
+            "ty": {
+              "option": {
+                "item": "LitStr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "AngleBracketedGenericArguments",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "colon2_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "::",
+                  "ty": "Colon2"
+                }
+              }
+            }
+          },
+          {
+            "ident": "lt_token",
+            "ty": {
+              "token": {
+                "repr": "<",
+                "ty": "Lt"
+              }
+            }
+          },
+          {
+            "ident": "args",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "GenericArgument"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "gt_token",
+            "ty": {
+              "token": {
+                "repr": ">",
+                "ty": "Gt"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ArgCaptured",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "pat",
+            "ty": {
+              "item": "Pat"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "item": "Type"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ArgSelf",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "self_token",
+            "ty": {
+              "token": {
+                "repr": "self",
+                "ty": "SelfValue"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ArgSelfRef",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "and_token",
+            "ty": {
+              "token": {
+                "repr": "&",
+                "ty": "And"
+              }
+            }
+          },
+          {
+            "ident": "lifetime",
+            "ty": {
+              "option": {
+                "item": "Lifetime"
+              }
+            }
+          },
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "self_token",
+            "ty": {
+              "token": {
+                "repr": "self",
+                "ty": "SelfValue"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Arm",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "leading_vert",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "|",
+                  "ty": "Or"
+                }
+              }
+            }
+          },
+          {
+            "ident": "pats",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Pat"
+                },
+                {
+                  "repr": "|",
+                  "ty": "Or"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "guard",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": "if",
+                      "ty": "If"
+                    }
+                  },
+                  {
+                    "box": {
+                      "item": "Expr"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "fat_arrow_token",
+            "ty": {
+              "token": {
+                "repr": "=>",
+                "ty": "FatArrow"
+              }
+            }
+          },
+          {
+            "ident": "body",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "comma",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "AttrStyle",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Outer",
+            "fields": []
+          },
+          {
+            "ident": "Inner",
+            "fields": [
+              {
+                "token": {
+                  "repr": "!",
+                  "ty": "Bang"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "Attribute",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "pound_token",
+            "ty": {
+              "token": {
+                "repr": "#",
+                "ty": "Pound"
+              }
+            }
+          },
+          {
+            "ident": "style",
+            "ty": {
+              "item": "AttrStyle"
+            }
+          },
+          {
+            "ident": "bracket_token",
+            "ty": {
+              "token_group": "Bracket"
+            }
+          },
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          },
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "BareFnArg",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "name",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "item": "BareFnArgName"
+                  },
+                  {
+                    "token": {
+                      "repr": ":",
+                      "ty": "Colon"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "item": "Type"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "BareFnArgName",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Named",
+            "fields": [
+              {
+                "item": "Ident"
+              }
+            ]
+          },
+          {
+            "ident": "Wild",
+            "fields": [
+              {
+                "token": {
+                  "repr": "_",
+                  "ty": "Underscore"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "enum": {
+        "ident": "BinOp",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Add",
+            "fields": [
+              {
+                "token": {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Sub",
+            "fields": [
+              {
+                "token": {
+                  "repr": "-",
+                  "ty": "Sub"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Mul",
+            "fields": [
+              {
+                "token": {
+                  "repr": "*",
+                  "ty": "Star"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Div",
+            "fields": [
+              {
+                "token": {
+                  "repr": "/",
+                  "ty": "Div"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Rem",
+            "fields": [
+              {
+                "token": {
+                  "repr": "%",
+                  "ty": "Rem"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "And",
+            "fields": [
+              {
+                "token": {
+                  "repr": "&&",
+                  "ty": "AndAnd"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Or",
+            "fields": [
+              {
+                "token": {
+                  "repr": "||",
+                  "ty": "OrOr"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "BitXor",
+            "fields": [
+              {
+                "token": {
+                  "repr": "^",
+                  "ty": "Caret"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "BitAnd",
+            "fields": [
+              {
+                "token": {
+                  "repr": "&",
+                  "ty": "And"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "BitOr",
+            "fields": [
+              {
+                "token": {
+                  "repr": "|",
+                  "ty": "Or"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Shl",
+            "fields": [
+              {
+                "token": {
+                  "repr": "<<",
+                  "ty": "Shl"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Shr",
+            "fields": [
+              {
+                "token": {
+                  "repr": ">>",
+                  "ty": "Shr"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Eq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "==",
+                  "ty": "EqEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Lt",
+            "fields": [
+              {
+                "token": {
+                  "repr": "<",
+                  "ty": "Lt"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Le",
+            "fields": [
+              {
+                "token": {
+                  "repr": "<=",
+                  "ty": "Le"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Ne",
+            "fields": [
+              {
+                "token": {
+                  "repr": "!=",
+                  "ty": "Ne"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Ge",
+            "fields": [
+              {
+                "token": {
+                  "repr": ">=",
+                  "ty": "Ge"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Gt",
+            "fields": [
+              {
+                "token": {
+                  "repr": ">",
+                  "ty": "Gt"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "AddEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "+=",
+                  "ty": "AddEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "SubEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "-=",
+                  "ty": "SubEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "MulEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "*=",
+                  "ty": "MulEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "DivEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "/=",
+                  "ty": "DivEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "RemEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "%=",
+                  "ty": "RemEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "BitXorEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "^=",
+                  "ty": "CaretEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "BitAndEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "&=",
+                  "ty": "AndEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "BitOrEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "|=",
+                  "ty": "OrEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "ShlEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": "<<=",
+                  "ty": "ShlEq"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "ShrEq",
+            "fields": [
+              {
+                "token": {
+                  "repr": ">>=",
+                  "ty": "ShrEq"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "Binding",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "item": "Type"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Block",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "stmts",
+            "ty": {
+              "vec": {
+                "item": "Stmt"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "BoundLifetimes",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "for_token",
+            "ty": {
+              "token": {
+                "repr": "for",
+                "ty": "For"
+              }
+            }
+          },
+          {
+            "ident": "lt_token",
+            "ty": {
+              "token": {
+                "repr": "<",
+                "ty": "Lt"
+              }
+            }
+          },
+          {
+            "ident": "lifetimes",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "LifetimeDef"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "gt_token",
+            "ty": {
+              "token": {
+                "repr": ">",
+                "ty": "Gt"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ConstParam",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "const_token",
+            "ty": {
+              "token": {
+                "repr": "const",
+                "ty": "Const"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "item": "Type"
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "=",
+                  "ty": "Eq"
+                }
+              }
+            }
+          },
+          {
+            "ident": "default",
+            "ty": {
+              "option": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Constraint",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Data",
+        "features": {
+          "any": [
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Struct",
+            "fields": [
+              {
+                "item": "DataStruct"
+              }
+            ]
+          },
+          {
+            "ident": "Enum",
+            "fields": [
+              {
+                "item": "DataEnum"
+              }
+            ]
+          },
+          {
+            "ident": "Union",
+            "fields": [
+              {
+                "item": "DataUnion"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "DataEnum",
+        "features": {
+          "any": [
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "enum_token",
+            "ty": {
+              "token": {
+                "repr": "enum",
+                "ty": "Enum"
+              }
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "variants",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Variant"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "DataStruct",
+        "features": {
+          "any": [
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "struct_token",
+            "ty": {
+              "token": {
+                "repr": "struct",
+                "ty": "Struct"
+              }
+            }
+          },
+          {
+            "ident": "fields",
+            "ty": {
+              "item": "Fields"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "DataUnion",
+        "features": {
+          "any": [
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "union_token",
+            "ty": {
+              "token": {
+                "repr": "union",
+                "ty": "Union"
+              }
+            }
+          },
+          {
+            "ident": "fields",
+            "ty": {
+              "item": "FieldsNamed"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "DeriveInput",
+        "features": {
+          "any": [
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "data",
+            "ty": {
+              "item": "Data"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Expr",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Box",
+            "fields": [
+              {
+                "item": "ExprBox"
+              }
+            ]
+          },
+          {
+            "ident": "InPlace",
+            "fields": [
+              {
+                "item": "ExprInPlace"
+              }
+            ]
+          },
+          {
+            "ident": "Array",
+            "fields": [
+              {
+                "item": "ExprArray"
+              }
+            ]
+          },
+          {
+            "ident": "Call",
+            "fields": [
+              {
+                "item": "ExprCall"
+              }
+            ]
+          },
+          {
+            "ident": "MethodCall",
+            "fields": [
+              {
+                "item": "ExprMethodCall"
+              }
+            ]
+          },
+          {
+            "ident": "Tuple",
+            "fields": [
+              {
+                "item": "ExprTuple"
+              }
+            ]
+          },
+          {
+            "ident": "Binary",
+            "fields": [
+              {
+                "item": "ExprBinary"
+              }
+            ]
+          },
+          {
+            "ident": "Unary",
+            "fields": [
+              {
+                "item": "ExprUnary"
+              }
+            ]
+          },
+          {
+            "ident": "Lit",
+            "fields": [
+              {
+                "item": "ExprLit"
+              }
+            ]
+          },
+          {
+            "ident": "Cast",
+            "fields": [
+              {
+                "item": "ExprCast"
+              }
+            ]
+          },
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "ExprType"
+              }
+            ]
+          },
+          {
+            "ident": "Let",
+            "fields": [
+              {
+                "item": "ExprLet"
+              }
+            ]
+          },
+          {
+            "ident": "If",
+            "fields": [
+              {
+                "item": "ExprIf"
+              }
+            ]
+          },
+          {
+            "ident": "While",
+            "fields": [
+              {
+                "item": "ExprWhile"
+              }
+            ]
+          },
+          {
+            "ident": "ForLoop",
+            "fields": [
+              {
+                "item": "ExprForLoop"
+              }
+            ]
+          },
+          {
+            "ident": "Loop",
+            "fields": [
+              {
+                "item": "ExprLoop"
+              }
+            ]
+          },
+          {
+            "ident": "Match",
+            "fields": [
+              {
+                "item": "ExprMatch"
+              }
+            ]
+          },
+          {
+            "ident": "Closure",
+            "fields": [
+              {
+                "item": "ExprClosure"
+              }
+            ]
+          },
+          {
+            "ident": "Unsafe",
+            "fields": [
+              {
+                "item": "ExprUnsafe"
+              }
+            ]
+          },
+          {
+            "ident": "Block",
+            "fields": [
+              {
+                "item": "ExprBlock"
+              }
+            ]
+          },
+          {
+            "ident": "Assign",
+            "fields": [
+              {
+                "item": "ExprAssign"
+              }
+            ]
+          },
+          {
+            "ident": "AssignOp",
+            "fields": [
+              {
+                "item": "ExprAssignOp"
+              }
+            ]
+          },
+          {
+            "ident": "Field",
+            "fields": [
+              {
+                "item": "ExprField"
+              }
+            ]
+          },
+          {
+            "ident": "Index",
+            "fields": [
+              {
+                "item": "ExprIndex"
+              }
+            ]
+          },
+          {
+            "ident": "Range",
+            "fields": [
+              {
+                "item": "ExprRange"
+              }
+            ]
+          },
+          {
+            "ident": "Path",
+            "fields": [
+              {
+                "item": "ExprPath"
+              }
+            ]
+          },
+          {
+            "ident": "Reference",
+            "fields": [
+              {
+                "item": "ExprReference"
+              }
+            ]
+          },
+          {
+            "ident": "Break",
+            "fields": [
+              {
+                "item": "ExprBreak"
+              }
+            ]
+          },
+          {
+            "ident": "Continue",
+            "fields": [
+              {
+                "item": "ExprContinue"
+              }
+            ]
+          },
+          {
+            "ident": "Return",
+            "fields": [
+              {
+                "item": "ExprReturn"
+              }
+            ]
+          },
+          {
+            "ident": "Macro",
+            "fields": [
+              {
+                "item": "ExprMacro"
+              }
+            ]
+          },
+          {
+            "ident": "Struct",
+            "fields": [
+              {
+                "item": "ExprStruct"
+              }
+            ]
+          },
+          {
+            "ident": "Repeat",
+            "fields": [
+              {
+                "item": "ExprRepeat"
+              }
+            ]
+          },
+          {
+            "ident": "Paren",
+            "fields": [
+              {
+                "item": "ExprParen"
+              }
+            ]
+          },
+          {
+            "ident": "Group",
+            "fields": [
+              {
+                "item": "ExprGroup"
+              }
+            ]
+          },
+          {
+            "ident": "Try",
+            "fields": [
+              {
+                "item": "ExprTry"
+              }
+            ]
+          },
+          {
+            "ident": "Async",
+            "fields": [
+              {
+                "item": "ExprAsync"
+              }
+            ]
+          },
+          {
+            "ident": "TryBlock",
+            "fields": [
+              {
+                "item": "ExprTryBlock"
+              }
+            ]
+          },
+          {
+            "ident": "Yield",
+            "fields": [
+              {
+                "item": "ExprYield"
+              }
+            ]
+          },
+          {
+            "ident": "Verbatim",
+            "fields": [
+              {
+                "item": "ExprVerbatim"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprArray",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "bracket_token",
+            "ty": {
+              "token_group": "Bracket"
+            }
+          },
+          {
+            "ident": "elems",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Expr"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprAssign",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "left",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "right",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprAssignOp",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "left",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "op",
+            "ty": {
+              "item": "BinOp"
+            }
+          },
+          {
+            "ident": "right",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprAsync",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "async_token",
+            "ty": {
+              "token": {
+                "repr": "async",
+                "ty": "Async"
+              }
+            }
+          },
+          {
+            "ident": "capture",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "move",
+                  "ty": "Move"
+                }
+              }
+            }
+          },
+          {
+            "ident": "block",
+            "ty": {
+              "item": "Block"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprBinary",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "left",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "op",
+            "ty": {
+              "item": "BinOp"
+            }
+          },
+          {
+            "ident": "right",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprBlock",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "label",
+            "ty": {
+              "option": {
+                "item": "Label"
+              }
+            }
+          },
+          {
+            "ident": "block",
+            "ty": {
+              "item": "Block"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprBox",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "box_token",
+            "ty": {
+              "token": {
+                "repr": "box",
+                "ty": "Box"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprBreak",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "break_token",
+            "ty": {
+              "token": {
+                "repr": "break",
+                "ty": "Break"
+              }
+            }
+          },
+          {
+            "ident": "label",
+            "ty": {
+              "option": {
+                "item": "Lifetime"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "option": {
+                "box": {
+                  "item": "Expr"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprCall",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "func",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "args",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Expr"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprCast",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "as_token",
+            "ty": {
+              "token": {
+                "repr": "as",
+                "ty": "As"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprClosure",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "asyncness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "async",
+                  "ty": "Async"
+                }
+              }
+            }
+          },
+          {
+            "ident": "movability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "static",
+                  "ty": "Static"
+                }
+              }
+            }
+          },
+          {
+            "ident": "capture",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "move",
+                  "ty": "Move"
+                }
+              }
+            }
+          },
+          {
+            "ident": "or1_token",
+            "ty": {
+              "token": {
+                "repr": "|",
+                "ty": "Or"
+              }
+            }
+          },
+          {
+            "ident": "inputs",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "FnArg"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "or2_token",
+            "ty": {
+              "token": {
+                "repr": "|",
+                "ty": "Or"
+              }
+            }
+          },
+          {
+            "ident": "output",
+            "ty": {
+              "item": "ReturnType"
+            }
+          },
+          {
+            "ident": "body",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprContinue",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "continue_token",
+            "ty": {
+              "token": {
+                "repr": "continue",
+                "ty": "Continue"
+              }
+            }
+          },
+          {
+            "ident": "label",
+            "ty": {
+              "option": {
+                "item": "Lifetime"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprField",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "base",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "dot_token",
+            "ty": {
+              "token": {
+                "repr": ".",
+                "ty": "Dot"
+              }
+            }
+          },
+          {
+            "ident": "member",
+            "ty": {
+              "item": "Member"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprForLoop",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "label",
+            "ty": {
+              "option": {
+                "item": "Label"
+              }
+            }
+          },
+          {
+            "ident": "for_token",
+            "ty": {
+              "token": {
+                "repr": "for",
+                "ty": "For"
+              }
+            }
+          },
+          {
+            "ident": "pat",
+            "ty": {
+              "box": {
+                "item": "Pat"
+              }
+            }
+          },
+          {
+            "ident": "in_token",
+            "ty": {
+              "token": {
+                "repr": "in",
+                "ty": "In"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "body",
+            "ty": {
+              "item": "Block"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprGroup",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "group_token",
+            "ty": {
+              "token_group": "Group"
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprIf",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "if_token",
+            "ty": {
+              "token": {
+                "repr": "if",
+                "ty": "If"
+              }
+            }
+          },
+          {
+            "ident": "cond",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "then_branch",
+            "ty": {
+              "item": "Block"
+            }
+          },
+          {
+            "ident": "else_branch",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": "else",
+                      "ty": "Else"
+                    }
+                  },
+                  {
+                    "box": {
+                      "item": "Expr"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprInPlace",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "place",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "arrow_token",
+            "ty": {
+              "token": {
+                "repr": "<-",
+                "ty": "LArrow"
+              }
+            }
+          },
+          {
+            "ident": "value",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprIndex",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "bracket_token",
+            "ty": {
+              "token_group": "Bracket"
+            }
+          },
+          {
+            "ident": "index",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprLet",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "let_token",
+            "ty": {
+              "token": {
+                "repr": "let",
+                "ty": "Let"
+              }
+            }
+          },
+          {
+            "ident": "pats",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Pat"
+                },
+                {
+                  "repr": "|",
+                  "ty": "Or"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprLit",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "lit",
+            "ty": {
+              "item": "Lit"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprLoop",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "label",
+            "ty": {
+              "option": {
+                "item": "Label"
+              }
+            }
+          },
+          {
+            "ident": "loop_token",
+            "ty": {
+              "token": {
+                "repr": "loop",
+                "ty": "Loop"
+              }
+            }
+          },
+          {
+            "ident": "body",
+            "ty": {
+              "item": "Block"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprMacro",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "mac",
+            "ty": {
+              "item": "Macro"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprMatch",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "match_token",
+            "ty": {
+              "token": {
+                "repr": "match",
+                "ty": "Match"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "arms",
+            "ty": {
+              "vec": {
+                "item": "Arm"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprMethodCall",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "receiver",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "dot_token",
+            "ty": {
+              "token": {
+                "repr": ".",
+                "ty": "Dot"
+              }
+            }
+          },
+          {
+            "ident": "method",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "turbofish",
+            "ty": {
+              "option": {
+                "item": "MethodTurbofish"
+              }
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "args",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Expr"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprParen",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprPath",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "qself",
+            "ty": {
+              "option": {
+                "item": "QSelf"
+              }
+            }
+          },
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprRange",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "from",
+            "ty": {
+              "option": {
+                "box": {
+                  "item": "Expr"
+                }
+              }
+            }
+          },
+          {
+            "ident": "limits",
+            "ty": {
+              "item": "RangeLimits"
+            }
+          },
+          {
+            "ident": "to",
+            "ty": {
+              "option": {
+                "box": {
+                  "item": "Expr"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprReference",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "and_token",
+            "ty": {
+              "token": {
+                "repr": "&",
+                "ty": "And"
+              }
+            }
+          },
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprRepeat",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "bracket_token",
+            "ty": {
+              "token_group": "Bracket"
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          },
+          {
+            "ident": "len",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprReturn",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "return_token",
+            "ty": {
+              "token": {
+                "repr": "return",
+                "ty": "Return"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "option": {
+                "box": {
+                  "item": "Expr"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprStruct",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "fields",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "FieldValue"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "dot2_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "..",
+                  "ty": "Dot2"
+                }
+              }
+            }
+          },
+          {
+            "ident": "rest",
+            "ty": {
+              "option": {
+                "box": {
+                  "item": "Expr"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprTry",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "question_token",
+            "ty": {
+              "token": {
+                "repr": "?",
+                "ty": "Question"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprTryBlock",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "try_token",
+            "ty": {
+              "token": {
+                "repr": "try",
+                "ty": "Try"
+              }
+            }
+          },
+          {
+            "ident": "block",
+            "ty": {
+              "item": "Block"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprTuple",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "elems",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Expr"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprType",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprUnary",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "op",
+            "ty": {
+              "item": "UnOp"
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprUnsafe",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "unsafe_token",
+            "ty": {
+              "token": {
+                "repr": "unsafe",
+                "ty": "Unsafe"
+              }
+            }
+          },
+          {
+            "ident": "block",
+            "ty": {
+              "item": "Block"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprVerbatim",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprWhile",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "label",
+            "ty": {
+              "option": {
+                "item": "Label"
+              }
+            }
+          },
+          {
+            "ident": "while_token",
+            "ty": {
+              "token": {
+                "repr": "while",
+                "ty": "While"
+              }
+            }
+          },
+          {
+            "ident": "cond",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "body",
+            "ty": {
+              "item": "Block"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ExprYield",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "yield_token",
+            "ty": {
+              "token": {
+                "repr": "yield",
+                "ty": "Yield"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "option": {
+                "box": {
+                  "item": "Expr"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Field",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "option": {
+                "item": "Ident"
+              }
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "item": "Type"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "FieldPat",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "member",
+            "ty": {
+              "item": "Member"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "pat",
+            "ty": {
+              "box": {
+                "item": "Pat"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "FieldValue",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "member",
+            "ty": {
+              "item": "Member"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "item": "Expr"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Fields",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Named",
+            "fields": [
+              {
+                "item": "FieldsNamed"
+              }
+            ]
+          },
+          {
+            "ident": "Unnamed",
+            "fields": [
+              {
+                "item": "FieldsUnnamed"
+              }
+            ]
+          },
+          {
+            "ident": "Unit",
+            "fields": []
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "FieldsNamed",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "named",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Field"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "FieldsUnnamed",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "unnamed",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Field"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "File",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "shebang",
+            "ty": {
+              "option": {
+                "std": "String"
+              }
+            }
+          },
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "items",
+            "ty": {
+              "vec": {
+                "item": "Item"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "FnArg",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "SelfRef",
+            "fields": [
+              {
+                "item": "ArgSelfRef"
+              }
+            ]
+          },
+          {
+            "ident": "SelfValue",
+            "fields": [
+              {
+                "item": "ArgSelf"
+              }
+            ]
+          },
+          {
+            "ident": "Captured",
+            "fields": [
+              {
+                "item": "ArgCaptured"
+              }
+            ]
+          },
+          {
+            "ident": "Inferred",
+            "fields": [
+              {
+                "item": "Pat"
+              }
+            ]
+          },
+          {
+            "ident": "Ignored",
+            "fields": [
+              {
+                "item": "Type"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "FnDecl",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "fn_token",
+            "ty": {
+              "token": {
+                "repr": "fn",
+                "ty": "Fn"
+              }
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "inputs",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "FnArg"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "variadic",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "...",
+                  "ty": "Dot3"
+                }
+              }
+            }
+          },
+          {
+            "ident": "output",
+            "ty": {
+              "item": "ReturnType"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "ForeignItem",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Fn",
+            "fields": [
+              {
+                "item": "ForeignItemFn"
+              }
+            ]
+          },
+          {
+            "ident": "Static",
+            "fields": [
+              {
+                "item": "ForeignItemStatic"
+              }
+            ]
+          },
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "ForeignItemType"
+              }
+            ]
+          },
+          {
+            "ident": "Macro",
+            "fields": [
+              {
+                "item": "ForeignItemMacro"
+              }
+            ]
+          },
+          {
+            "ident": "Verbatim",
+            "fields": [
+              {
+                "item": "ForeignItemVerbatim"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "ForeignItemFn",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "decl",
+            "ty": {
+              "box": {
+                "item": "FnDecl"
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ForeignItemMacro",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "mac",
+            "ty": {
+              "item": "Macro"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ForeignItemStatic",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "static_token",
+            "ty": {
+              "token": {
+                "repr": "static",
+                "ty": "Static"
+              }
+            }
+          },
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ForeignItemType",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "type_token",
+            "ty": {
+              "token": {
+                "repr": "type",
+                "ty": "Type"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ForeignItemVerbatim",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "GenericArgument",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Lifetime",
+            "fields": [
+              {
+                "item": "Lifetime"
+              }
+            ]
+          },
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "Type"
+              }
+            ]
+          },
+          {
+            "ident": "Binding",
+            "fields": [
+              {
+                "item": "Binding"
+              }
+            ]
+          },
+          {
+            "ident": "Constraint",
+            "fields": [
+              {
+                "item": "Constraint"
+              }
+            ]
+          },
+          {
+            "ident": "Const",
+            "fields": [
+              {
+                "item": "Expr"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "enum": {
+        "ident": "GenericMethodArgument",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "Type"
+              }
+            ]
+          },
+          {
+            "ident": "Const",
+            "fields": [
+              {
+                "item": "Expr"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "enum": {
+        "ident": "GenericParam",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "TypeParam"
+              }
+            ]
+          },
+          {
+            "ident": "Lifetime",
+            "fields": [
+              {
+                "item": "LifetimeDef"
+              }
+            ]
+          },
+          {
+            "ident": "Const",
+            "fields": [
+              {
+                "item": "ConstParam"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "Generics",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "lt_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "<",
+                  "ty": "Lt"
+                }
+              }
+            }
+          },
+          {
+            "ident": "params",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "GenericParam"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "gt_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ">",
+                  "ty": "Gt"
+                }
+              }
+            }
+          },
+          {
+            "ident": "where_clause",
+            "ty": {
+              "option": {
+                "item": "WhereClause"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Ident",
+        "features": {
+          "any": []
+        },
+        "fields": [],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "ImplItem",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Const",
+            "fields": [
+              {
+                "item": "ImplItemConst"
+              }
+            ]
+          },
+          {
+            "ident": "Method",
+            "fields": [
+              {
+                "item": "ImplItemMethod"
+              }
+            ]
+          },
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "ImplItemType"
+              }
+            ]
+          },
+          {
+            "ident": "Existential",
+            "fields": [
+              {
+                "item": "ImplItemExistential"
+              }
+            ]
+          },
+          {
+            "ident": "Macro",
+            "fields": [
+              {
+                "item": "ImplItemMacro"
+              }
+            ]
+          },
+          {
+            "ident": "Verbatim",
+            "fields": [
+              {
+                "item": "ImplItemVerbatim"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "ImplItemConst",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "defaultness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "default",
+                  "ty": "Default"
+                }
+              }
+            }
+          },
+          {
+            "ident": "const_token",
+            "ty": {
+              "token": {
+                "repr": "const",
+                "ty": "Const"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "item": "Type"
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "item": "Expr"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ImplItemExistential",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "existential_token",
+            "ty": {
+              "token": {
+                "repr": "existential",
+                "ty": "Existential"
+              }
+            }
+          },
+          {
+            "ident": "type_token",
+            "ty": {
+              "token": {
+                "repr": "type",
+                "ty": "Type"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ImplItemMacro",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "mac",
+            "ty": {
+              "item": "Macro"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ImplItemMethod",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "defaultness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "default",
+                  "ty": "Default"
+                }
+              }
+            }
+          },
+          {
+            "ident": "sig",
+            "ty": {
+              "item": "MethodSig"
+            }
+          },
+          {
+            "ident": "block",
+            "ty": {
+              "item": "Block"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ImplItemType",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "defaultness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "default",
+                  "ty": "Default"
+                }
+              }
+            }
+          },
+          {
+            "ident": "type_token",
+            "ty": {
+              "token": {
+                "repr": "type",
+                "ty": "Type"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "item": "Type"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ImplItemVerbatim",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Index",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "index",
+            "ty": {
+              "std": "u32"
+            }
+          },
+          {
+            "ident": "span",
+            "ty": {
+              "item": "Span"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Item",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "ExternCrate",
+            "fields": [
+              {
+                "item": "ItemExternCrate"
+              }
+            ]
+          },
+          {
+            "ident": "Use",
+            "fields": [
+              {
+                "item": "ItemUse"
+              }
+            ]
+          },
+          {
+            "ident": "Static",
+            "fields": [
+              {
+                "item": "ItemStatic"
+              }
+            ]
+          },
+          {
+            "ident": "Const",
+            "fields": [
+              {
+                "item": "ItemConst"
+              }
+            ]
+          },
+          {
+            "ident": "Fn",
+            "fields": [
+              {
+                "item": "ItemFn"
+              }
+            ]
+          },
+          {
+            "ident": "Mod",
+            "fields": [
+              {
+                "item": "ItemMod"
+              }
+            ]
+          },
+          {
+            "ident": "ForeignMod",
+            "fields": [
+              {
+                "item": "ItemForeignMod"
+              }
+            ]
+          },
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "ItemType"
+              }
+            ]
+          },
+          {
+            "ident": "Existential",
+            "fields": [
+              {
+                "item": "ItemExistential"
+              }
+            ]
+          },
+          {
+            "ident": "Struct",
+            "fields": [
+              {
+                "item": "ItemStruct"
+              }
+            ]
+          },
+          {
+            "ident": "Enum",
+            "fields": [
+              {
+                "item": "ItemEnum"
+              }
+            ]
+          },
+          {
+            "ident": "Union",
+            "fields": [
+              {
+                "item": "ItemUnion"
+              }
+            ]
+          },
+          {
+            "ident": "Trait",
+            "fields": [
+              {
+                "item": "ItemTrait"
+              }
+            ]
+          },
+          {
+            "ident": "TraitAlias",
+            "fields": [
+              {
+                "item": "ItemTraitAlias"
+              }
+            ]
+          },
+          {
+            "ident": "Impl",
+            "fields": [
+              {
+                "item": "ItemImpl"
+              }
+            ]
+          },
+          {
+            "ident": "Macro",
+            "fields": [
+              {
+                "item": "ItemMacro"
+              }
+            ]
+          },
+          {
+            "ident": "Macro2",
+            "fields": [
+              {
+                "item": "ItemMacro2"
+              }
+            ]
+          },
+          {
+            "ident": "Verbatim",
+            "fields": [
+              {
+                "item": "ItemVerbatim"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemConst",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "const_token",
+            "ty": {
+              "token": {
+                "repr": "const",
+                "ty": "Const"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemEnum",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "enum_token",
+            "ty": {
+              "token": {
+                "repr": "enum",
+                "ty": "Enum"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "variants",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Variant"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemExistential",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "existential_token",
+            "ty": {
+              "token": {
+                "repr": "existential",
+                "ty": "Existential"
+              }
+            }
+          },
+          {
+            "ident": "type_token",
+            "ty": {
+              "token": {
+                "repr": "type",
+                "ty": "Type"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemExternCrate",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "extern_token",
+            "ty": {
+              "token": {
+                "repr": "extern",
+                "ty": "Extern"
+              }
+            }
+          },
+          {
+            "ident": "crate_token",
+            "ty": {
+              "token": {
+                "repr": "crate",
+                "ty": "Crate"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "rename",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": "as",
+                      "ty": "As"
+                    }
+                  },
+                  {
+                    "item": "Ident"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemFn",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "constness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "const",
+                  "ty": "Const"
+                }
+              }
+            }
+          },
+          {
+            "ident": "unsafety",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "unsafe",
+                  "ty": "Unsafe"
+                }
+              }
+            }
+          },
+          {
+            "ident": "asyncness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "async",
+                  "ty": "Async"
+                }
+              }
+            }
+          },
+          {
+            "ident": "abi",
+            "ty": {
+              "option": {
+                "item": "Abi"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "decl",
+            "ty": {
+              "box": {
+                "item": "FnDecl"
+              }
+            }
+          },
+          {
+            "ident": "block",
+            "ty": {
+              "box": {
+                "item": "Block"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemForeignMod",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "abi",
+            "ty": {
+              "item": "Abi"
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "items",
+            "ty": {
+              "vec": {
+                "item": "ForeignItem"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemImpl",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "defaultness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "default",
+                  "ty": "Default"
+                }
+              }
+            }
+          },
+          {
+            "ident": "unsafety",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "unsafe",
+                  "ty": "Unsafe"
+                }
+              }
+            }
+          },
+          {
+            "ident": "impl_token",
+            "ty": {
+              "token": {
+                "repr": "impl",
+                "ty": "Impl"
+              }
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "trait_",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "option": {
+                      "token": {
+                        "repr": "!",
+                        "ty": "Bang"
+                      }
+                    }
+                  },
+                  {
+                    "item": "Path"
+                  },
+                  {
+                    "token": {
+                      "repr": "for",
+                      "ty": "For"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "self_ty",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "items",
+            "ty": {
+              "vec": {
+                "item": "ImplItem"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemMacro",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "option": {
+                "item": "Ident"
+              }
+            }
+          },
+          {
+            "ident": "mac",
+            "ty": {
+              "item": "Macro"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemMacro2",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "macro_token",
+            "ty": {
+              "token": {
+                "repr": "macro",
+                "ty": "Macro"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "args",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "body",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemMod",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "mod_token",
+            "ty": {
+              "token": {
+                "repr": "mod",
+                "ty": "Mod"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "content",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token_group": "Brace"
+                  },
+                  {
+                    "vec": {
+                      "item": "Item"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "semi",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemStatic",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "static_token",
+            "ty": {
+              "token": {
+                "repr": "static",
+                "ty": "Static"
+              }
+            }
+          },
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemStruct",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "struct_token",
+            "ty": {
+              "token": {
+                "repr": "struct",
+                "ty": "Struct"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "fields",
+            "ty": {
+              "item": "Fields"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemTrait",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "unsafety",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "unsafe",
+                  "ty": "Unsafe"
+                }
+              }
+            }
+          },
+          {
+            "ident": "auto_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "auto",
+                  "ty": "Auto"
+                }
+              }
+            }
+          },
+          {
+            "ident": "trait_token",
+            "ty": {
+              "token": {
+                "repr": "trait",
+                "ty": "Trait"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "supertraits",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "items",
+            "ty": {
+              "vec": {
+                "item": "TraitItem"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemTraitAlias",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "trait_token",
+            "ty": {
+              "token": {
+                "repr": "trait",
+                "ty": "Trait"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemType",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "type_token",
+            "ty": {
+              "token": {
+                "repr": "type",
+                "ty": "Type"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemUnion",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "union_token",
+            "ty": {
+              "token": {
+                "repr": "union",
+                "ty": "Union"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "fields",
+            "ty": {
+              "item": "FieldsNamed"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemUse",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "vis",
+            "ty": {
+              "item": "Visibility"
+            }
+          },
+          {
+            "ident": "use_token",
+            "ty": {
+              "token": {
+                "repr": "use",
+                "ty": "Use"
+              }
+            }
+          },
+          {
+            "ident": "leading_colon",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "::",
+                  "ty": "Colon2"
+                }
+              }
+            }
+          },
+          {
+            "ident": "tree",
+            "ty": {
+              "item": "UseTree"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "ItemVerbatim",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Label",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "name",
+            "ty": {
+              "item": "Lifetime"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Lifetime",
+        "features": {
+          "any": []
+        },
+        "fields": [
+          {
+            "ident": "apostrophe",
+            "ty": {
+              "item": "Span"
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "LifetimeDef",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "lifetime",
+            "ty": {
+              "item": "Lifetime"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Lifetime"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Lit",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Str",
+            "fields": [
+              {
+                "item": "LitStr"
+              }
+            ]
+          },
+          {
+            "ident": "ByteStr",
+            "fields": [
+              {
+                "item": "LitByteStr"
+              }
+            ]
+          },
+          {
+            "ident": "Byte",
+            "fields": [
+              {
+                "item": "LitByte"
+              }
+            ]
+          },
+          {
+            "ident": "Char",
+            "fields": [
+              {
+                "item": "LitChar"
+              }
+            ]
+          },
+          {
+            "ident": "Int",
+            "fields": [
+              {
+                "item": "LitInt"
+              }
+            ]
+          },
+          {
+            "ident": "Float",
+            "fields": [
+              {
+                "item": "LitFloat"
+              }
+            ]
+          },
+          {
+            "ident": "Bool",
+            "fields": [
+              {
+                "item": "LitBool"
+              }
+            ]
+          },
+          {
+            "ident": "Verbatim",
+            "fields": [
+              {
+                "item": "LitVerbatim"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "LitBool",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "value",
+            "ty": {
+              "std": "bool"
+            }
+          },
+          {
+            "ident": "span",
+            "ty": {
+              "item": "Span"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "LitByte",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "token",
+            "ty": {
+              "ext": "Literal"
+            }
+          }
+        ],
+        "all_fields_pub": false
+      }
+    },
+    {
+      "struct": {
+        "ident": "LitByteStr",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "token",
+            "ty": {
+              "ext": "Literal"
+            }
+          }
+        ],
+        "all_fields_pub": false
+      }
+    },
+    {
+      "struct": {
+        "ident": "LitChar",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "token",
+            "ty": {
+              "ext": "Literal"
+            }
+          }
+        ],
+        "all_fields_pub": false
+      }
+    },
+    {
+      "struct": {
+        "ident": "LitFloat",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "token",
+            "ty": {
+              "ext": "Literal"
+            }
+          }
+        ],
+        "all_fields_pub": false
+      }
+    },
+    {
+      "struct": {
+        "ident": "LitInt",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "token",
+            "ty": {
+              "ext": "Literal"
+            }
+          }
+        ],
+        "all_fields_pub": false
+      }
+    },
+    {
+      "struct": {
+        "ident": "LitStr",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "token",
+            "ty": {
+              "ext": "Literal"
+            }
+          }
+        ],
+        "all_fields_pub": false
+      }
+    },
+    {
+      "struct": {
+        "ident": "LitVerbatim",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "token",
+            "ty": {
+              "ext": "Literal"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Local",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "let_token",
+            "ty": {
+              "token": {
+                "repr": "let",
+                "ty": "Let"
+              }
+            }
+          },
+          {
+            "ident": "pats",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Pat"
+                },
+                {
+                  "repr": "|",
+                  "ty": "Or"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": ":",
+                      "ty": "Colon"
+                    }
+                  },
+                  {
+                    "box": {
+                      "item": "Type"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "init",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": "=",
+                      "ty": "Eq"
+                    }
+                  },
+                  {
+                    "box": {
+                      "item": "Expr"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Macro",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          },
+          {
+            "ident": "bang_token",
+            "ty": {
+              "token": {
+                "repr": "!",
+                "ty": "Bang"
+              }
+            }
+          },
+          {
+            "ident": "delimiter",
+            "ty": {
+              "item": "MacroDelimiter"
+            }
+          },
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "MacroDelimiter",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Paren",
+            "fields": [
+              {
+                "token_group": "Paren"
+              }
+            ]
+          },
+          {
+            "ident": "Brace",
+            "fields": [
+              {
+                "token_group": "Brace"
+              }
+            ]
+          },
+          {
+            "ident": "Bracket",
+            "fields": [
+              {
+                "token_group": "Bracket"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "enum": {
+        "ident": "Member",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Named",
+            "fields": [
+              {
+                "item": "Ident"
+              }
+            ]
+          },
+          {
+            "ident": "Unnamed",
+            "fields": [
+              {
+                "item": "Index"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "enum": {
+        "ident": "Meta",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Word",
+            "fields": [
+              {
+                "item": "Ident"
+              }
+            ]
+          },
+          {
+            "ident": "List",
+            "fields": [
+              {
+                "item": "MetaList"
+              }
+            ]
+          },
+          {
+            "ident": "NameValue",
+            "fields": [
+              {
+                "item": "MetaNameValue"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "MetaList",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "nested",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "NestedMeta"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "MetaNameValue",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "lit",
+            "ty": {
+              "item": "Lit"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "MethodSig",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "constness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "const",
+                  "ty": "Const"
+                }
+              }
+            }
+          },
+          {
+            "ident": "unsafety",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "unsafe",
+                  "ty": "Unsafe"
+                }
+              }
+            }
+          },
+          {
+            "ident": "asyncness",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "async",
+                  "ty": "Async"
+                }
+              }
+            }
+          },
+          {
+            "ident": "abi",
+            "ty": {
+              "option": {
+                "item": "Abi"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "decl",
+            "ty": {
+              "item": "FnDecl"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "MethodTurbofish",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "colon2_token",
+            "ty": {
+              "token": {
+                "repr": "::",
+                "ty": "Colon2"
+              }
+            }
+          },
+          {
+            "ident": "lt_token",
+            "ty": {
+              "token": {
+                "repr": "<",
+                "ty": "Lt"
+              }
+            }
+          },
+          {
+            "ident": "args",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "GenericMethodArgument"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "gt_token",
+            "ty": {
+              "token": {
+                "repr": ">",
+                "ty": "Gt"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "NestedMeta",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Meta",
+            "fields": [
+              {
+                "item": "Meta"
+              }
+            ]
+          },
+          {
+            "ident": "Literal",
+            "fields": [
+              {
+                "item": "Lit"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "ParenthesizedGenericArguments",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "inputs",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Type"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "output",
+            "ty": {
+              "item": "ReturnType"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Pat",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Wild",
+            "fields": [
+              {
+                "item": "PatWild"
+              }
+            ]
+          },
+          {
+            "ident": "Ident",
+            "fields": [
+              {
+                "item": "PatIdent"
+              }
+            ]
+          },
+          {
+            "ident": "Struct",
+            "fields": [
+              {
+                "item": "PatStruct"
+              }
+            ]
+          },
+          {
+            "ident": "TupleStruct",
+            "fields": [
+              {
+                "item": "PatTupleStruct"
+              }
+            ]
+          },
+          {
+            "ident": "Path",
+            "fields": [
+              {
+                "item": "PatPath"
+              }
+            ]
+          },
+          {
+            "ident": "Tuple",
+            "fields": [
+              {
+                "item": "PatTuple"
+              }
+            ]
+          },
+          {
+            "ident": "Box",
+            "fields": [
+              {
+                "item": "PatBox"
+              }
+            ]
+          },
+          {
+            "ident": "Ref",
+            "fields": [
+              {
+                "item": "PatRef"
+              }
+            ]
+          },
+          {
+            "ident": "Lit",
+            "fields": [
+              {
+                "item": "PatLit"
+              }
+            ]
+          },
+          {
+            "ident": "Range",
+            "fields": [
+              {
+                "item": "PatRange"
+              }
+            ]
+          },
+          {
+            "ident": "Slice",
+            "fields": [
+              {
+                "item": "PatSlice"
+              }
+            ]
+          },
+          {
+            "ident": "Macro",
+            "fields": [
+              {
+                "item": "PatMacro"
+              }
+            ]
+          },
+          {
+            "ident": "Verbatim",
+            "fields": [
+              {
+                "item": "PatVerbatim"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatBox",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "box_token",
+            "ty": {
+              "token": {
+                "repr": "box",
+                "ty": "Box"
+              }
+            }
+          },
+          {
+            "ident": "pat",
+            "ty": {
+              "box": {
+                "item": "Pat"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatIdent",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "by_ref",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "ref",
+                  "ty": "Ref"
+                }
+              }
+            }
+          },
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "subpat",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": "@",
+                      "ty": "At"
+                    }
+                  },
+                  {
+                    "box": {
+                      "item": "Pat"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatLit",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "expr",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatMacro",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "mac",
+            "ty": {
+              "item": "Macro"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatPath",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "qself",
+            "ty": {
+              "option": {
+                "item": "QSelf"
+              }
+            }
+          },
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatRange",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "lo",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          },
+          {
+            "ident": "limits",
+            "ty": {
+              "item": "RangeLimits"
+            }
+          },
+          {
+            "ident": "hi",
+            "ty": {
+              "box": {
+                "item": "Expr"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatRef",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "and_token",
+            "ty": {
+              "token": {
+                "repr": "&",
+                "ty": "And"
+              }
+            }
+          },
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "pat",
+            "ty": {
+              "box": {
+                "item": "Pat"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatSlice",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "bracket_token",
+            "ty": {
+              "token_group": "Bracket"
+            }
+          },
+          {
+            "ident": "front",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Pat"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "middle",
+            "ty": {
+              "option": {
+                "box": {
+                  "item": "Pat"
+                }
+              }
+            }
+          },
+          {
+            "ident": "dot2_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "..",
+                  "ty": "Dot2"
+                }
+              }
+            }
+          },
+          {
+            "ident": "comma_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              }
+            }
+          },
+          {
+            "ident": "back",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Pat"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatStruct",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          },
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "fields",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "FieldPat"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "dot2_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "..",
+                  "ty": "Dot2"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatTuple",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "front",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Pat"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "dot2_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "..",
+                  "ty": "Dot2"
+                }
+              }
+            }
+          },
+          {
+            "ident": "comma_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              }
+            }
+          },
+          {
+            "ident": "back",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Pat"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatTupleStruct",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          },
+          {
+            "ident": "pat",
+            "ty": {
+              "item": "PatTuple"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatVerbatim",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PatWild",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "underscore_token",
+            "ty": {
+              "token": {
+                "repr": "_",
+                "ty": "Underscore"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "Path",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "leading_colon",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "::",
+                  "ty": "Colon2"
+                }
+              }
+            }
+          },
+          {
+            "ident": "segments",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "PathSegment"
+                },
+                {
+                  "repr": "::",
+                  "ty": "Colon2"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "PathArguments",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "None",
+            "fields": []
+          },
+          {
+            "ident": "AngleBracketed",
+            "fields": [
+              {
+                "item": "AngleBracketedGenericArguments"
+              }
+            ]
+          },
+          {
+            "ident": "Parenthesized",
+            "fields": [
+              {
+                "item": "ParenthesizedGenericArguments"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "PathSegment",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "arguments",
+            "ty": {
+              "item": "PathArguments"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PredicateEq",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "lhs_ty",
+            "ty": {
+              "item": "Type"
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "token": {
+                "repr": "=",
+                "ty": "Eq"
+              }
+            }
+          },
+          {
+            "ident": "rhs_ty",
+            "ty": {
+              "item": "Type"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PredicateLifetime",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "lifetime",
+            "ty": {
+              "item": "Lifetime"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Lifetime"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "PredicateType",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "lifetimes",
+            "ty": {
+              "option": {
+                "item": "BoundLifetimes"
+              }
+            }
+          },
+          {
+            "ident": "bounded_ty",
+            "ty": {
+              "item": "Type"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "QSelf",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "lt_token",
+            "ty": {
+              "token": {
+                "repr": "<",
+                "ty": "Lt"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          },
+          {
+            "ident": "position",
+            "ty": {
+              "std": "usize"
+            }
+          },
+          {
+            "ident": "as_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "as",
+                  "ty": "As"
+                }
+              }
+            }
+          },
+          {
+            "ident": "gt_token",
+            "ty": {
+              "token": {
+                "repr": ">",
+                "ty": "Gt"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "RangeLimits",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "HalfOpen",
+            "fields": [
+              {
+                "token": {
+                  "repr": "..",
+                  "ty": "Dot2"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Closed",
+            "fields": [
+              {
+                "token": {
+                  "repr": "..=",
+                  "ty": "DotDotEq"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "enum": {
+        "ident": "ReturnType",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Default",
+            "fields": []
+          },
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "token": {
+                  "repr": "->",
+                  "ty": "RArrow"
+                }
+              },
+              {
+                "box": {
+                  "item": "Type"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "Span",
+        "features": {
+          "any": []
+        },
+        "fields": [],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Stmt",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Local",
+            "fields": [
+              {
+                "item": "Local"
+              }
+            ]
+          },
+          {
+            "ident": "Item",
+            "fields": [
+              {
+                "item": "Item"
+              }
+            ]
+          },
+          {
+            "ident": "Expr",
+            "fields": [
+              {
+                "item": "Expr"
+              }
+            ]
+          },
+          {
+            "ident": "Semi",
+            "fields": [
+              {
+                "item": "Expr"
+              },
+              {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "TraitBound",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "paren_token",
+            "ty": {
+              "option": {
+                "token_group": "Paren"
+              }
+            }
+          },
+          {
+            "ident": "modifier",
+            "ty": {
+              "item": "TraitBoundModifier"
+            }
+          },
+          {
+            "ident": "lifetimes",
+            "ty": {
+              "option": {
+                "item": "BoundLifetimes"
+              }
+            }
+          },
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "TraitBoundModifier",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "None",
+            "fields": []
+          },
+          {
+            "ident": "Maybe",
+            "fields": [
+              {
+                "token": {
+                  "repr": "?",
+                  "ty": "Question"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "enum": {
+        "ident": "TraitItem",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Const",
+            "fields": [
+              {
+                "item": "TraitItemConst"
+              }
+            ]
+          },
+          {
+            "ident": "Method",
+            "fields": [
+              {
+                "item": "TraitItemMethod"
+              }
+            ]
+          },
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "TraitItemType"
+              }
+            ]
+          },
+          {
+            "ident": "Macro",
+            "fields": [
+              {
+                "item": "TraitItemMacro"
+              }
+            ]
+          },
+          {
+            "ident": "Verbatim",
+            "fields": [
+              {
+                "item": "TraitItemVerbatim"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "TraitItemConst",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "const_token",
+            "ty": {
+              "token": {
+                "repr": "const",
+                "ty": "Const"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "token": {
+                "repr": ":",
+                "ty": "Colon"
+              }
+            }
+          },
+          {
+            "ident": "ty",
+            "ty": {
+              "item": "Type"
+            }
+          },
+          {
+            "ident": "default",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": "=",
+                      "ty": "Eq"
+                    }
+                  },
+                  {
+                    "item": "Expr"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TraitItemMacro",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "mac",
+            "ty": {
+              "item": "Macro"
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TraitItemMethod",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "sig",
+            "ty": {
+              "item": "MethodSig"
+            }
+          },
+          {
+            "ident": "default",
+            "ty": {
+              "option": {
+                "item": "Block"
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ";",
+                  "ty": "Semi"
+                }
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TraitItemType",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "type_token",
+            "ty": {
+              "token": {
+                "repr": "type",
+                "ty": "Type"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "generics",
+            "ty": {
+              "item": "Generics"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "default",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": "=",
+                      "ty": "Eq"
+                    }
+                  },
+                  {
+                    "item": "Type"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TraitItemVerbatim",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Type",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Slice",
+            "fields": [
+              {
+                "item": "TypeSlice"
+              }
+            ]
+          },
+          {
+            "ident": "Array",
+            "fields": [
+              {
+                "item": "TypeArray"
+              }
+            ]
+          },
+          {
+            "ident": "Ptr",
+            "fields": [
+              {
+                "item": "TypePtr"
+              }
+            ]
+          },
+          {
+            "ident": "Reference",
+            "fields": [
+              {
+                "item": "TypeReference"
+              }
+            ]
+          },
+          {
+            "ident": "BareFn",
+            "fields": [
+              {
+                "item": "TypeBareFn"
+              }
+            ]
+          },
+          {
+            "ident": "Never",
+            "fields": [
+              {
+                "item": "TypeNever"
+              }
+            ]
+          },
+          {
+            "ident": "Tuple",
+            "fields": [
+              {
+                "item": "TypeTuple"
+              }
+            ]
+          },
+          {
+            "ident": "Path",
+            "fields": [
+              {
+                "item": "TypePath"
+              }
+            ]
+          },
+          {
+            "ident": "TraitObject",
+            "fields": [
+              {
+                "item": "TypeTraitObject"
+              }
+            ]
+          },
+          {
+            "ident": "ImplTrait",
+            "fields": [
+              {
+                "item": "TypeImplTrait"
+              }
+            ]
+          },
+          {
+            "ident": "Paren",
+            "fields": [
+              {
+                "item": "TypeParen"
+              }
+            ]
+          },
+          {
+            "ident": "Group",
+            "fields": [
+              {
+                "item": "TypeGroup"
+              }
+            ]
+          },
+          {
+            "ident": "Infer",
+            "fields": [
+              {
+                "item": "TypeInfer"
+              }
+            ]
+          },
+          {
+            "ident": "Macro",
+            "fields": [
+              {
+                "item": "TypeMacro"
+              }
+            ]
+          },
+          {
+            "ident": "Verbatim",
+            "fields": [
+              {
+                "item": "TypeVerbatim"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeArray",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "bracket_token",
+            "ty": {
+              "token_group": "Bracket"
+            }
+          },
+          {
+            "ident": "elem",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          },
+          {
+            "ident": "semi_token",
+            "ty": {
+              "token": {
+                "repr": ";",
+                "ty": "Semi"
+              }
+            }
+          },
+          {
+            "ident": "len",
+            "ty": {
+              "item": "Expr"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeBareFn",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "lifetimes",
+            "ty": {
+              "option": {
+                "item": "BoundLifetimes"
+              }
+            }
+          },
+          {
+            "ident": "unsafety",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "unsafe",
+                  "ty": "Unsafe"
+                }
+              }
+            }
+          },
+          {
+            "ident": "abi",
+            "ty": {
+              "option": {
+                "item": "Abi"
+              }
+            }
+          },
+          {
+            "ident": "fn_token",
+            "ty": {
+              "token": {
+                "repr": "fn",
+                "ty": "Fn"
+              }
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "inputs",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "BareFnArg"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "variadic",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "...",
+                  "ty": "Dot3"
+                }
+              }
+            }
+          },
+          {
+            "ident": "output",
+            "ty": {
+              "item": "ReturnType"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeGroup",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "group_token",
+            "ty": {
+              "token_group": "Group"
+            }
+          },
+          {
+            "ident": "elem",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeImplTrait",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "impl_token",
+            "ty": {
+              "token": {
+                "repr": "impl",
+                "ty": "Impl"
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeInfer",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "underscore_token",
+            "ty": {
+              "token": {
+                "repr": "_",
+                "ty": "Underscore"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeMacro",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "mac",
+            "ty": {
+              "item": "Macro"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeNever",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "bang_token",
+            "ty": {
+              "token": {
+                "repr": "!",
+                "ty": "Bang"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeParam",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": ":",
+                  "ty": "Colon"
+                }
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          },
+          {
+            "ident": "eq_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "=",
+                  "ty": "Eq"
+                }
+              }
+            }
+          },
+          {
+            "ident": "default",
+            "ty": {
+              "option": {
+                "item": "Type"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "TypeParamBound",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Trait",
+            "fields": [
+              {
+                "item": "TraitBound"
+              }
+            ]
+          },
+          {
+            "ident": "Lifetime",
+            "fields": [
+              {
+                "item": "Lifetime"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeParen",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "elem",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypePath",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "qself",
+            "ty": {
+              "option": {
+                "item": "QSelf"
+              }
+            }
+          },
+          {
+            "ident": "path",
+            "ty": {
+              "item": "Path"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypePtr",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "star_token",
+            "ty": {
+              "token": {
+                "repr": "*",
+                "ty": "Star"
+              }
+            }
+          },
+          {
+            "ident": "const_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "const",
+                  "ty": "Const"
+                }
+              }
+            }
+          },
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "elem",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeReference",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "and_token",
+            "ty": {
+              "token": {
+                "repr": "&",
+                "ty": "And"
+              }
+            }
+          },
+          {
+            "ident": "lifetime",
+            "ty": {
+              "option": {
+                "item": "Lifetime"
+              }
+            }
+          },
+          {
+            "ident": "mutability",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "mut",
+                  "ty": "Mut"
+                }
+              }
+            }
+          },
+          {
+            "ident": "elem",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeSlice",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "bracket_token",
+            "ty": {
+              "token_group": "Bracket"
+            }
+          },
+          {
+            "ident": "elem",
+            "ty": {
+              "box": {
+                "item": "Type"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeTraitObject",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "dyn_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "dyn",
+                  "ty": "Dyn"
+                }
+              }
+            }
+          },
+          {
+            "ident": "bounds",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "TypeParamBound"
+                },
+                {
+                  "repr": "+",
+                  "ty": "Add"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeTuple",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "elems",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "Type"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "TypeVerbatim",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "tts",
+            "ty": {
+              "ext": "TokenStream"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "UnOp",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Deref",
+            "fields": [
+              {
+                "token": {
+                  "repr": "*",
+                  "ty": "Star"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Not",
+            "fields": [
+              {
+                "token": {
+                  "repr": "!",
+                  "ty": "Bang"
+                }
+              }
+            ]
+          },
+          {
+            "ident": "Neg",
+            "fields": [
+              {
+                "token": {
+                  "repr": "-",
+                  "ty": "Sub"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "UseGlob",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "star_token",
+            "ty": {
+              "token": {
+                "repr": "*",
+                "ty": "Star"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "UseGroup",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "brace_token",
+            "ty": {
+              "token_group": "Brace"
+            }
+          },
+          {
+            "ident": "items",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "UseTree"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "UseName",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "UsePath",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "colon2_token",
+            "ty": {
+              "token": {
+                "repr": "::",
+                "ty": "Colon2"
+              }
+            }
+          },
+          {
+            "ident": "tree",
+            "ty": {
+              "box": {
+                "item": "UseTree"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "UseRename",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "as_token",
+            "ty": {
+              "token": {
+                "repr": "as",
+                "ty": "As"
+              }
+            }
+          },
+          {
+            "ident": "rename",
+            "ty": {
+              "item": "Ident"
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "UseTree",
+        "features": {
+          "any": [
+            "full"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Path",
+            "fields": [
+              {
+                "item": "UsePath"
+              }
+            ]
+          },
+          {
+            "ident": "Name",
+            "fields": [
+              {
+                "item": "UseName"
+              }
+            ]
+          },
+          {
+            "ident": "Rename",
+            "fields": [
+              {
+                "item": "UseRename"
+              }
+            ]
+          },
+          {
+            "ident": "Glob",
+            "fields": [
+              {
+                "item": "UseGlob"
+              }
+            ]
+          },
+          {
+            "ident": "Group",
+            "fields": [
+              {
+                "item": "UseGroup"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "Variant",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "attrs",
+            "ty": {
+              "vec": {
+                "item": "Attribute"
+              }
+            }
+          },
+          {
+            "ident": "ident",
+            "ty": {
+              "item": "Ident"
+            }
+          },
+          {
+            "ident": "fields",
+            "ty": {
+              "item": "Fields"
+            }
+          },
+          {
+            "ident": "discriminant",
+            "ty": {
+              "option": {
+                "tuple": [
+                  {
+                    "token": {
+                      "repr": "=",
+                      "ty": "Eq"
+                    }
+                  },
+                  {
+                    "item": "Expr"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "VisCrate",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "crate_token",
+            "ty": {
+              "token": {
+                "repr": "crate",
+                "ty": "Crate"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "VisPublic",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "pub_token",
+            "ty": {
+              "token": {
+                "repr": "pub",
+                "ty": "Pub"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "struct": {
+        "ident": "VisRestricted",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "pub_token",
+            "ty": {
+              "token": {
+                "repr": "pub",
+                "ty": "Pub"
+              }
+            }
+          },
+          {
+            "ident": "paren_token",
+            "ty": {
+              "token_group": "Paren"
+            }
+          },
+          {
+            "ident": "in_token",
+            "ty": {
+              "option": {
+                "token": {
+                  "repr": "in",
+                  "ty": "In"
+                }
+              }
+            }
+          },
+          {
+            "ident": "path",
+            "ty": {
+              "box": {
+                "item": "Path"
+              }
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "Visibility",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Public",
+            "fields": [
+              {
+                "item": "VisPublic"
+              }
+            ]
+          },
+          {
+            "ident": "Crate",
+            "fields": [
+              {
+                "item": "VisCrate"
+              }
+            ]
+          },
+          {
+            "ident": "Restricted",
+            "fields": [
+              {
+                "item": "VisRestricted"
+              }
+            ]
+          },
+          {
+            "ident": "Inherited",
+            "fields": []
+          }
+        ]
+      }
+    },
+    {
+      "struct": {
+        "ident": "WhereClause",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "fields": [
+          {
+            "ident": "where_token",
+            "ty": {
+              "token": {
+                "repr": "where",
+                "ty": "Where"
+              }
+            }
+          },
+          {
+            "ident": "predicates",
+            "ty": {
+              "punctuated": [
+                {
+                  "item": "WherePredicate"
+                },
+                {
+                  "repr": ",",
+                  "ty": "Comma"
+                }
+              ]
+            }
+          }
+        ],
+        "all_fields_pub": true
+      }
+    },
+    {
+      "enum": {
+        "ident": "WherePredicate",
+        "features": {
+          "any": [
+            "full",
+            "derive"
+          ]
+        },
+        "variants": [
+          {
+            "ident": "Type",
+            "fields": [
+              {
+                "item": "PredicateType"
+              }
+            ]
+          },
+          {
+            "ident": "Lifetime",
+            "fields": [
+              {
+                "item": "PredicateLifetime"
+              }
+            ]
+          },
+          {
+            "ident": "Eq",
+            "fields": [
+              {
+                "item": "PredicateEq"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The JSON file can be used by third party libs to build tools that
consume `syn` types.

The JSON is generated to `syn.json`. [Link](https://github.com/carllerche/syn/blob/introspect-json/syn.json).

Follow up to #579.