### PR TITLE
Reclasify Ident and Span as being from proc_macro2

### DIFF
--- a/codegen/src/types.rs
+++ b/codegen/src/types.rs
@@ -1,19 +1,20 @@
 use std::collections::BTreeMap;
 use std::ops;
 
+#[derive(Debug, Clone)]
 pub struct Definitions {
     pub types: Vec<Node>,
     pub tokens: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "node", rename_all = "lowercase")]
 pub enum Node {
     Struct(Struct),
     Enum(Enum),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Struct {
     ident: String,
     features: Features,
@@ -21,27 +22,27 @@ pub struct Struct {
     all_fields_pub: bool,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Enum {
     ident: String,
     features: Features,
     variants: Vec<Variant>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Variant {
     ident: String,
     fields: Vec<Type>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Field {
     ident: String,
     #[serde(rename = "type")]
     ty: Type,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
     /// Type defined by `syn`
@@ -69,7 +70,7 @@ pub enum Type {
     Tuple(Vec<Type>),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Punctuated {
     element: Box<Type>,
     punct: String,
@@ -78,6 +79,12 @@ pub struct Punctuated {
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct Features {
     any: Vec<String>,
+}
+
+impl Definitions {
+    pub fn insert(&mut self, node: Node) {
+        self.types.push(node);
+    }
 }
 
 impl Node {

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -354,9 +354,6 @@ pub trait Fold {
     fn fold_generics(&mut self, i: Generics) -> Generics {
         fold_generics(self, i)
     }
-    fn fold_ident(&mut self, i: Ident) -> Ident {
-        fold_ident(self, i)
-    }
     #[cfg(feature = "full")]
     fn fold_impl_item(&mut self, i: ImplItem) -> ImplItem {
         fold_impl_item(self, i)
@@ -651,9 +648,6 @@ pub trait Fold {
     fn fold_return_type(&mut self, i: ReturnType) -> ReturnType {
         fold_return_type(self, i)
     }
-    fn fold_span(&mut self, i: Span) -> Span {
-        fold_span(self, i)
-    }
     #[cfg(feature = "full")]
     fn fold_stmt(&mut self, i: Stmt) -> Stmt {
         fold_stmt(self, i)
@@ -817,6 +811,12 @@ pub trait Fold {
     #[cfg(any(feature = "full", feature = "derive"))]
     fn fold_where_predicate(&mut self, i: WherePredicate) -> WherePredicate {
         fold_where_predicate(self, i)
+    }
+    fn fold_span(&mut self, i: Span) -> Span {
+        fold_span(self, i)
+    }
+    fn fold_ident(&mut self, i: Ident) -> Ident {
+        fold_ident(self, i)
     }
 }
 #[cfg(any(feature = "full", feature = "derive"))]
@@ -1753,12 +1753,6 @@ pub fn fold_generics<V: Fold + ?Sized>(_visitor: &mut V, _i: Generics) -> Generi
         where_clause: (_i.where_clause).map(|it| _visitor.fold_where_clause(it)),
     }
 }
-pub fn fold_ident<V: Fold + ?Sized>(_visitor: &mut V, _i: Ident) -> Ident {
-    let mut _i = _i;
-    let span = _visitor.fold_span(_i.span());
-    _i.set_span(span);
-    _i
-}
 #[cfg(feature = "full")]
 pub fn fold_impl_item<V: Fold + ?Sized>(_visitor: &mut V, _i: ImplItem) -> ImplItem {
     match _i {
@@ -2519,9 +2513,6 @@ pub fn fold_return_type<V: Fold + ?Sized>(_visitor: &mut V, _i: ReturnType) -> R
         ),
     }
 }
-pub fn fold_span<V: Fold + ?Sized>(_visitor: &mut V, _i: Span) -> Span {
-    _i
-}
 #[cfg(feature = "full")]
 pub fn fold_stmt<V: Fold + ?Sized>(_visitor: &mut V, _i: Stmt) -> Stmt {
     match _i {
@@ -2934,4 +2925,13 @@ pub fn fold_where_predicate<V: Fold + ?Sized>(
             WherePredicate::Eq(_visitor.fold_predicate_eq(_binding_0))
         }
     }
+}
+pub fn fold_span<V: Fold + ?Sized>(_visitor: &mut V, _i: Span) -> Span {
+    _i
+}
+pub fn fold_ident<V: Fold + ?Sized>(_visitor: &mut V, _i: Ident) -> Ident {
+    let mut _i = _i;
+    let span = _visitor.fold_span(_i.span());
+    _i.set_span(span);
+    _i
 }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -355,9 +355,6 @@ pub trait Visit<'ast> {
     fn visit_generics(&mut self, i: &'ast Generics) {
         visit_generics(self, i)
     }
-    fn visit_ident(&mut self, i: &'ast Ident) {
-        visit_ident(self, i)
-    }
     #[cfg(feature = "full")]
     fn visit_impl_item(&mut self, i: &'ast ImplItem) {
         visit_impl_item(self, i)
@@ -649,9 +646,6 @@ pub trait Visit<'ast> {
     fn visit_return_type(&mut self, i: &'ast ReturnType) {
         visit_return_type(self, i)
     }
-    fn visit_span(&mut self, i: &'ast Span) {
-        visit_span(self, i)
-    }
     #[cfg(feature = "full")]
     fn visit_stmt(&mut self, i: &'ast Stmt) {
         visit_stmt(self, i)
@@ -815,6 +809,12 @@ pub trait Visit<'ast> {
     #[cfg(any(feature = "full", feature = "derive"))]
     fn visit_where_predicate(&mut self, i: &'ast WherePredicate) {
         visit_where_predicate(self, i)
+    }
+    fn visit_span(&mut self, i: &'ast Span) {
+        visit_span(self, i)
+    }
+    fn visit_ident(&mut self, i: &'ast Ident) {
+        visit_ident(self, i)
     }
 }
 #[cfg(any(feature = "full", feature = "derive"))]
@@ -1939,7 +1939,6 @@ pub fn visit_generics<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast
         _visitor.visit_where_clause(it)
     };
 }
-pub fn visit_ident<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast Ident) {}
 #[cfg(feature = "full")]
 pub fn visit_impl_item<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast ImplItem) {
     match *_i {
@@ -2896,7 +2895,6 @@ pub fn visit_return_type<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'
         }
     }
 }
-pub fn visit_span<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast Span) {}
 #[cfg(feature = "full")]
 pub fn visit_stmt<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast Stmt) {
     match *_i {
@@ -3381,3 +3379,5 @@ pub fn visit_where_predicate<'ast, V: Visit<'ast> + ?Sized>(
         }
     }
 }
+pub fn visit_span<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast Span) {}
+pub fn visit_ident<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast Ident) {}

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -358,9 +358,6 @@ pub trait VisitMut {
     fn visit_generics_mut(&mut self, i: &mut Generics) {
         visit_generics_mut(self, i)
     }
-    fn visit_ident_mut(&mut self, i: &mut Ident) {
-        visit_ident_mut(self, i)
-    }
     #[cfg(feature = "full")]
     fn visit_impl_item_mut(&mut self, i: &mut ImplItem) {
         visit_impl_item_mut(self, i)
@@ -652,9 +649,6 @@ pub trait VisitMut {
     fn visit_return_type_mut(&mut self, i: &mut ReturnType) {
         visit_return_type_mut(self, i)
     }
-    fn visit_span_mut(&mut self, i: &mut Span) {
-        visit_span_mut(self, i)
-    }
     #[cfg(feature = "full")]
     fn visit_stmt_mut(&mut self, i: &mut Stmt) {
         visit_stmt_mut(self, i)
@@ -818,6 +812,12 @@ pub trait VisitMut {
     #[cfg(any(feature = "full", feature = "derive"))]
     fn visit_where_predicate_mut(&mut self, i: &mut WherePredicate) {
         visit_where_predicate_mut(self, i)
+    }
+    fn visit_span_mut(&mut self, i: &mut Span) {
+        visit_span_mut(self, i)
+    }
+    fn visit_ident_mut(&mut self, i: &mut Ident) {
+        visit_ident_mut(self, i)
     }
 }
 #[cfg(any(feature = "full", feature = "derive"))]
@@ -1909,7 +1909,6 @@ pub fn visit_generics_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Gener
         _visitor.visit_where_clause_mut(it)
     };
 }
-pub fn visit_ident_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Ident) {}
 #[cfg(feature = "full")]
 pub fn visit_impl_item_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut ImplItem) {
     match *_i {
@@ -2830,7 +2829,6 @@ pub fn visit_return_type_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Re
         }
     }
 }
-pub fn visit_span_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Span) {}
 #[cfg(feature = "full")]
 pub fn visit_stmt_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Stmt) {
     match *_i {
@@ -3288,3 +3286,5 @@ pub fn visit_where_predicate_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mu
         }
     }
 }
+pub fn visit_span_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Span) {}
+pub fn visit_ident_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Ident) {}

--- a/syn.json
+++ b/syn.json
@@ -361,7 +361,7 @@
           "ident": "Named",
           "fields": [
             {
-              "syn": "Ident"
+              "proc_macro2": "Ident"
             }
           ]
         },
@@ -624,7 +624,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -737,7 +737,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -784,7 +784,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -959,7 +959,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -2334,7 +2334,7 @@
         {
           "ident": "method",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -3011,7 +3011,7 @@
           "ident": "ident",
           "type": {
             "option": {
-              "syn": "Ident"
+              "proc_macro2": "Ident"
             }
           }
         },
@@ -3425,7 +3425,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -3519,7 +3519,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -3577,7 +3577,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -3771,15 +3771,6 @@
       "all_fields_pub": true
     },
     {
-      "node": "struct",
-      "ident": "Ident",
-      "features": {
-        "any": []
-      },
-      "fields": [],
-      "all_fields_pub": true
-    },
-    {
       "node": "enum",
       "ident": "ImplItem",
       "features": {
@@ -3878,7 +3869,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -3946,7 +3937,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -4103,7 +4094,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -4170,7 +4161,7 @@
         {
           "ident": "span",
           "type": {
-            "syn": "Span"
+            "proc_macro2": "Span"
           }
         }
       ],
@@ -4363,7 +4354,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -4435,7 +4426,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -4502,7 +4493,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -4577,7 +4568,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -4589,7 +4580,7 @@
                   "token": "As"
                 },
                 {
-                  "syn": "Ident"
+                  "proc_macro2": "Ident"
                 }
               ]
             }
@@ -4662,7 +4653,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -4835,7 +4826,7 @@
           "ident": "ident",
           "type": {
             "option": {
-              "syn": "Ident"
+              "proc_macro2": "Ident"
             }
           }
         },
@@ -4888,7 +4879,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -4950,7 +4941,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -5021,7 +5012,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -5093,7 +5084,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -5167,7 +5158,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -5244,7 +5235,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -5311,7 +5302,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -5375,7 +5366,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -5497,13 +5488,13 @@
         {
           "ident": "apostrophe",
           "type": {
-            "syn": "Span"
+            "proc_macro2": "Span"
           }
         },
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         }
       ],
@@ -5650,7 +5641,7 @@
         {
           "ident": "span",
           "type": {
-            "syn": "Span"
+            "proc_macro2": "Span"
           }
         }
       ],
@@ -5953,7 +5944,7 @@
           "ident": "Named",
           "fields": [
             {
-              "syn": "Ident"
+              "proc_macro2": "Ident"
             }
           ]
         },
@@ -5981,7 +5972,7 @@
           "ident": "Word",
           "fields": [
             {
-              "syn": "Ident"
+              "proc_macro2": "Ident"
             }
           ]
         },
@@ -6016,7 +6007,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -6052,7 +6043,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -6114,7 +6105,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -6400,7 +6391,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -6857,7 +6848,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -7084,15 +7075,6 @@
       ]
     },
     {
-      "node": "struct",
-      "ident": "Span",
-      "features": {
-        "any": []
-      },
-      "fields": [],
-      "all_fields_pub": true
-    },
-    {
       "node": "enum",
       "ident": "Stmt",
       "features": {
@@ -7280,7 +7262,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -7421,7 +7403,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -7871,7 +7853,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -8283,7 +8265,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         }
       ],
@@ -8301,7 +8283,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -8333,7 +8315,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {
@@ -8345,7 +8327,7 @@
         {
           "ident": "rename",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         }
       ],
@@ -8423,7 +8405,7 @@
         {
           "ident": "ident",
           "type": {
-            "syn": "Ident"
+            "proc_macro2": "Ident"
           }
         },
         {


### PR DESCRIPTION
The JSON file now specifies `Ident` as part of `proc_macro2` and `Ident` / `Span` are no longer included in definitions.

This alters the generated visit / visit_mut / fold files only by reordering some items. I assume this is OK. If not, I can dig in a bit more.