### PR TITLE
Allow parsing ItemMod in inner attribute

### DIFF
--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -2024,7 +2024,7 @@ pub fn fold_item_mod<V: Fold + ?Sized>(_visitor: &mut V, _i: ItemMod) -> ItemMod
         attrs: FoldHelper::lift(_i.attrs, |it| _visitor.fold_attribute(it)),
         vis: _visitor.fold_visibility(_i.vis),
         mod_token: Token![mod](tokens_helper(_visitor, &_i.mod_token.span)),
-        ident: _visitor.fold_ident(_i.ident),
+        ident: _i.ident.map(|ident| _visitor.fold_ident(ident)),
         content: (_i.content).map(|it| {
             (
                 Brace(tokens_helper(_visitor, &(it).0.span)),

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -2285,7 +2285,7 @@ pub fn visit_item_mod<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast
     }
     _visitor.visit_visibility(&_i.vis);
     tokens_helper(_visitor, &_i.mod_token.span);
-    _visitor.visit_ident(&_i.ident);
+    _i.ident.as_ref().map(|ident| _visitor.visit_ident(ident));
     if let Some(ref it) = _i.content {
         tokens_helper(_visitor, &(it).0.span);
         for it in &(it).1 {

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -2285,7 +2285,7 @@ pub fn visit_item_mod<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast
     }
     _visitor.visit_visibility(&_i.vis);
     tokens_helper(_visitor, &_i.mod_token.span);
-    _i.ident.as_ref().map(|ident| _visitor.visit_ident(ident));
+    if let Some(ident) = _i.ident.as_ref() { _visitor.visit_ident(ident) }
     if let Some(ref it) = _i.content {
         tokens_helper(_visitor, &(it).0.span);
         for it in &(it).1 {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -2240,7 +2240,7 @@ pub fn visit_item_mod_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut ItemM
     }
     _visitor.visit_visibility_mut(&mut _i.vis);
     tokens_helper(_visitor, &mut _i.mod_token.span);
-    _visitor.visit_ident_mut(&mut _i.ident);
+    _i.ident.as_mut().map(|ident| _visitor.visit_ident_mut(ident));
     if let Some(ref mut it) = _i.content {
         tokens_helper(_visitor, &mut (it).0.span);
         for it in &mut (it).1 {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -2240,7 +2240,7 @@ pub fn visit_item_mod_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut ItemM
     }
     _visitor.visit_visibility_mut(&mut _i.vis);
     tokens_helper(_visitor, &mut _i.mod_token.span);
-    _i.ident.as_mut().map(|ident| _visitor.visit_ident_mut(ident));
+    if let Some(ident) = _i.ident.as_mut() { _visitor.visit_ident_mut(ident) }
     if let Some(ref mut it) = _i.content {
         tokens_helper(_visitor, &mut (it).0.span);
         for it in &mut (it).1 {

--- a/src/item.rs
+++ b/src/item.rs
@@ -99,7 +99,7 @@ ast_enum_of_structs! {
             pub attrs: Vec<Attribute>,
             pub vis: Visibility,
             pub mod_token: Token![mod],
-            pub ident: Ident,
+            pub ident: Option<Ident>,
             pub content: Option<(token::Brace, Vec<Item>)>,
             pub semi: Option<Token![;]>,
         }),
@@ -1211,7 +1211,7 @@ pub mod parsing {
             let outer_attrs = input.call(Attribute::parse_outer)?;
             let vis: Visibility = input.parse()?;
             let mod_token: Token![mod] = input.parse()?;
-            let ident: Ident = input.parse()?;
+            let ident: Option<Ident> = input.parse().ok();
 
             let lookahead = input.lookahead1();
             if lookahead.peek(Token![;]) {


### PR DESCRIPTION
Syn assumes that every `ItemMod` has an ident (i.e. `pub mod $ident { ... }`, but this is not the case when adding an inner attribute to a file mod:

```rust
#![feature(custom_inner_attributes, proc_macro_hygiene)]
#![MyCustomAttribute]

// ...
```

This PR remedies this by making `ItemMod.ident` an `Option`.