### PR TITLE
Pretend to have `span` field on punctuation with single span

### DIFF
--- a/src/ident.rs
+++ b/src/ident.rs
@@ -81,6 +81,6 @@ ident_from_token!(extern);
 
 impl From<Token![_]> for Ident {
     fn from(token: Token![_]) -> Ident {
-        Ident::new("_", token.spans[0])
+        Ident::new("_", token.span)
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -503,7 +503,7 @@ define_punctuation_structs! {
 #[cfg(feature = "printing")]
 impl ToTokens for Underscore {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.append(Ident::new("_", self.spans[0]));
+        tokens.append(Ident::new("_", self.span));
     }
 }
 


### PR DESCRIPTION
The punctuation tokens are structured as:

```rust
pub struct $name {
    pub spans: [Span; $len]
}
```

It is good that this is consistent across punctuation with single and multiple spans. Accessing spans as `shl.spans[0]`, `shl.spans[1]` is fine for something like `Token![<<]`. But for tokens with a single span like `Token![;]` it would be nice to allow referring to `semi.span` as an alternative to `semi.spans[0]`.

This commit adds Deref and DerefMut impls to make that work:

```rust
use proc_macro2::Span;
use syn::Token;

fn main() {
    let mut semi = Token![;](Span::call_site());
    println!("{:?}", semi.spans[0]);

    // New:
    semi.span = Span::call_site();
    println!("{:?}", semi.span);
}
```

I suspect many people (because that includes me) write code like this already without paying attention. Now instead of compile errors it will just do the right thing.