### PR TITLE
Parse paths in Meta

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -529,6 +529,7 @@ where
 pub mod parsing {
     use super::*;
 
+    use ext::PathExt;
     use parse::{Parse, ParseStream, Result};
     #[cfg(feature = "full")]
     use private;

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -460,7 +460,7 @@ ast_enum_of_structs! {
 }
 
 impl Meta {
-    /// Returns the identifier that begins this structured meta item.
+    /// Returns the path that begins this structured meta item.
     ///
     /// For example this would return:
     ///
@@ -469,15 +469,11 @@ impl Meta {
     /// * `Copy` in `Copy`
     /// * `serde::Serialize` in `serde::Serialize`
     /// * `path` in `#[path = "sys/windows.rs"]`.
-    ///
-    /// *This type is available if Syn is built with the `"clone-impls"`
-    /// feature.*
-    #[cfg(feature = "clone-impls")]
-    pub fn name(&self) -> Path {
+    pub fn name(&self) -> &Path {
         match *self {
-            Meta::Path(ref path) => path.clone(),
-            Meta::List(ref meta) => meta.path.clone(),
-            Meta::NameValue(ref meta) => meta.path.clone(),
+            Meta::Path(ref path) => &path,
+            Meta::List(ref meta) => &meta.path,
+            Meta::NameValue(ref meta) => &meta.path,
         }
     }
 }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -40,6 +40,8 @@ pub trait IdentExt: Sized + private::Sealed {
     /// }
     /// ```
     fn parse_any(input: ParseStream) -> Result<Self>;
+    /// Peeks for any identifier including keywords.
+    fn peek_any(input: ParseStream) -> bool;
 }
 
 impl IdentExt for Ident {
@@ -48,6 +50,11 @@ impl IdentExt for Ident {
             Some((ident, rest)) => Ok((ident, rest)),
             None => Err(cursor.error("expected ident")),
         })
+    }
+
+    fn peek_any(input: ParseStream) -> bool {
+        let ahead = input.fork();
+        Self::parse_any(&ahead).is_ok()
     }
 }
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -5,9 +5,6 @@
 use proc_macro2::Ident;
 
 use parse::{ParseStream, Result};
-use punctuated::Punctuated;
-#[cfg(any(feature = "full", feature = "derive"))]
-use path::{Path, PathSegment};
 
 /// Additional parsing methods for `Ident`.
 ///
@@ -61,62 +58,10 @@ impl IdentExt for Ident {
     }
 }
 
-#[cfg(any(feature = "full", feature = "derive"))]
-/// Additional parsing methods for `Path`.
-///
-/// This trait is sealed and cannot be implemented for types outside of Syn.
-///
-/// *This trait is available if Syn is built with the `"parsing"` feature.*
-pub trait PathExt: Sized + private::Sealed {
-    /// Parse a `Path` in mod style, while accepting keywords.
-    ///
-    /// This function is only available within `syn` to parse meta items.
-    ///
-    /// *This function is available if Syn is built with the `"parsing"`
-    /// feature.*
-    fn parse_meta(input: ParseStream) -> Result<Self>;
-}
-
-#[cfg(any(feature = "full", feature = "derive"))]
-impl PathExt for Path {
-    fn parse_meta(input: ParseStream) -> Result<Self> {
-        Ok(Path {
-            leading_colon: input.parse()?,
-            segments: {
-                let mut segments = Punctuated::new();
-                loop {
-                    if !Ident::peek_any(input) {
-                        break;
-                    }
-                    let ident = Ident::parse_any(input)?;
-                    segments.push_value(PathSegment::from(ident));
-                    if !input.peek(Token![::]) {
-                        break;
-                    }
-                    let punct = input.parse()?;
-                    segments.push_punct(punct);
-                }
-                if segments.is_empty() {
-                    return Err(input.error("expected path"));
-                } else if segments.trailing_punct() {
-                    return Err(input.error("expected path segment"));
-                }
-                segments
-            },
-        })
-    }
-}
-
 mod private {
     use proc_macro2::Ident;
-
-    #[cfg(any(feature = "full", feature = "derive"))]
-    use path::Path;
 
     pub trait Sealed {}
 
     impl Sealed for Ident {}
-
-    #[cfg(any(feature = "full", feature = "derive"))]
-    impl Sealed for Path {}
 }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -5,8 +5,9 @@
 use proc_macro2::Ident;
 
 use parse::{ParseStream, Result};
-use path::{Path, PathSegment};
 use punctuated::Punctuated;
+#[cfg(any(feature = "full", feature = "derive"))]
+use path::{Path, PathSegment};
 
 /// Additional parsing methods for `Ident`.
 ///
@@ -60,6 +61,7 @@ impl IdentExt for Ident {
     }
 }
 
+#[cfg(any(feature = "full", feature = "derive"))]
 /// Additional parsing methods for `Path`.
 ///
 /// This trait is sealed and cannot be implemented for types outside of Syn.
@@ -75,6 +77,7 @@ pub trait PathExt: Sized + private::Sealed {
     fn parse_meta(input: ParseStream) -> Result<Self>;
 }
 
+#[cfg(any(feature = "full", feature = "derive"))]
 impl PathExt for Path {
     fn parse_meta(input: ParseStream) -> Result<Self> {
         Ok(Path {
@@ -106,10 +109,14 @@ impl PathExt for Path {
 
 mod private {
     use proc_macro2::Ident;
+
+    #[cfg(any(feature = "full", feature = "derive"))]
     use path::Path;
 
     pub trait Sealed {}
 
     impl Sealed for Ident {}
+
+    #[cfg(any(feature = "full", feature = "derive"))]
     impl Sealed for Path {}
 }

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -2237,6 +2237,7 @@ pub fn fold_member<V: Fold + ?Sized>(_visitor: &mut V, _i: Member) -> Member {
 pub fn fold_meta<V: Fold + ?Sized>(_visitor: &mut V, _i: Meta) -> Meta {
     match _i {
         Meta::Word(_binding_0) => Meta::Word(_visitor.fold_ident(_binding_0)),
+        Meta::Path(_binding_0) => Meta::Path(_visitor.fold_path(_binding_0)),
         Meta::List(_binding_0) => Meta::List(_visitor.fold_meta_list(_binding_0)),
         Meta::NameValue(_binding_0) => Meta::NameValue(_visitor.fold_meta_name_value(_binding_0)),
     }

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -2236,7 +2236,6 @@ pub fn fold_member<V: Fold + ?Sized>(_visitor: &mut V, _i: Member) -> Member {
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn fold_meta<V: Fold + ?Sized>(_visitor: &mut V, _i: Meta) -> Meta {
     match _i {
-        Meta::Word(_binding_0) => Meta::Word(_visitor.fold_ident(_binding_0)),
         Meta::Path(_binding_0) => Meta::Path(_visitor.fold_path(_binding_0)),
         Meta::List(_binding_0) => Meta::List(_visitor.fold_meta_list(_binding_0)),
         Meta::NameValue(_binding_0) => Meta::NameValue(_visitor.fold_meta_name_value(_binding_0)),
@@ -2245,7 +2244,7 @@ pub fn fold_meta<V: Fold + ?Sized>(_visitor: &mut V, _i: Meta) -> Meta {
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn fold_meta_list<V: Fold + ?Sized>(_visitor: &mut V, _i: MetaList) -> MetaList {
     MetaList {
-        ident: _visitor.fold_ident(_i.ident),
+        path: _visitor.fold_path(_i.path),
         paren_token: Paren(tokens_helper(_visitor, &_i.paren_token.span)),
         nested: FoldHelper::lift(_i.nested, |it| _visitor.fold_nested_meta(it)),
     }
@@ -2256,7 +2255,7 @@ pub fn fold_meta_name_value<V: Fold + ?Sized>(
     _i: MetaNameValue,
 ) -> MetaNameValue {
     MetaNameValue {
-        ident: _visitor.fold_ident(_i.ident),
+        path: _visitor.fold_path(_i.path),
         eq_token: Token ! [ = ](tokens_helper(_visitor, &_i.eq_token.spans)),
         lit: _visitor.fold_lit(_i.lit),
     }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -2548,9 +2548,6 @@ pub fn visit_member<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast M
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_meta<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast Meta) {
     match *_i {
-        Meta::Word(ref _binding_0) => {
-            _visitor.visit_ident(_binding_0);
-        }
         Meta::Path(ref _binding_0) => {
             _visitor.visit_path(_binding_0);
         }
@@ -2564,7 +2561,7 @@ pub fn visit_meta<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast Met
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_meta_list<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast MetaList) {
-    _visitor.visit_ident(&_i.ident);
+    _visitor.visit_path(&_i.path);
     tokens_helper(_visitor, &_i.paren_token.span);
     for el in Punctuated::pairs(&_i.nested) {
         let it = el.value();
@@ -2576,7 +2573,7 @@ pub fn visit_meta_name_value<'ast, V: Visit<'ast> + ?Sized>(
     _visitor: &mut V,
     _i: &'ast MetaNameValue,
 ) {
-    _visitor.visit_ident(&_i.ident);
+    _visitor.visit_path(&_i.path);
     tokens_helper(_visitor, &_i.eq_token.spans);
     _visitor.visit_lit(&_i.lit);
 }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -2551,6 +2551,9 @@ pub fn visit_meta<'ast, V: Visit<'ast> + ?Sized>(_visitor: &mut V, _i: &'ast Met
         Meta::Word(ref _binding_0) => {
             _visitor.visit_ident(_binding_0);
         }
+        Meta::Path(ref _binding_0) => {
+            _visitor.visit_path(_binding_0);
+        }
         Meta::List(ref _binding_0) => {
             _visitor.visit_meta_list(_binding_0);
         }

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -2497,6 +2497,9 @@ pub fn visit_meta_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Meta) {
         Meta::Word(ref mut _binding_0) => {
             _visitor.visit_ident_mut(_binding_0);
         }
+        Meta::Path(ref mut _binding_0) => {
+            _visitor.visit_path_mut(_binding_0);
+        }
         Meta::List(ref mut _binding_0) => {
             _visitor.visit_meta_list_mut(_binding_0);
         }

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -2494,9 +2494,6 @@ pub fn visit_member_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Member)
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_meta_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Meta) {
     match *_i {
-        Meta::Word(ref mut _binding_0) => {
-            _visitor.visit_ident_mut(_binding_0);
-        }
         Meta::Path(ref mut _binding_0) => {
             _visitor.visit_path_mut(_binding_0);
         }
@@ -2510,7 +2507,7 @@ pub fn visit_meta_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Meta) {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_meta_list_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut MetaList) {
-    _visitor.visit_ident_mut(&mut _i.ident);
+    _visitor.visit_path_mut(&mut _i.path);
     tokens_helper(_visitor, &mut _i.paren_token.span);
     for mut el in Punctuated::pairs_mut(&mut _i.nested) {
         let it = el.value_mut();
@@ -2519,7 +2516,7 @@ pub fn visit_meta_list_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut Meta
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_meta_name_value_mut<V: VisitMut + ?Sized>(_visitor: &mut V, _i: &mut MetaNameValue) {
-    _visitor.visit_ident_mut(&mut _i.ident);
+    _visitor.visit_path_mut(&mut _i.path);
     tokens_helper(_visitor, &mut _i.eq_token.spans);
     _visitor.visit_lit_mut(&mut _i.lit);
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -418,39 +418,6 @@ pub mod parsing {
             })
         }
 
-        /// Parse a `Path` in mod style, while accepting keywords.
-        ///
-        /// This function is only available within `syn` to parse meta items.
-        ///
-        /// *This function is available if Syn is built with the `"parsing"`
-        /// feature.*
-        pub(crate) fn parse_meta(input: ParseStream) -> Result<Self> {
-            Ok(Path {
-                leading_colon: input.parse()?,
-                segments: {
-                    let mut segments = Punctuated::new();
-                    loop {
-                        if !Ident::peek_any(input) {
-                            break;
-                        }
-                        let ident = Ident::parse_any(input)?;
-                        segments.push_value(PathSegment::from(ident));
-                        if !input.peek(Token![::]) {
-                            break;
-                        }
-                        let punct = input.parse()?;
-                        segments.push_punct(punct);
-                    }
-                    if segments.is_empty() {
-                        return Err(input.error("expected path"));
-                    } else if segments.trailing_punct() {
-                        return Err(input.error("expected path segment"));
-                    }
-                    segments
-                },
-            })
-        }
-
         /// Determines whether this is a path of length 1 equal to the given
         /// ident.
         ///

--- a/src/path.rs
+++ b/src/path.rs
@@ -418,6 +418,39 @@ pub mod parsing {
             })
         }
 
+        /// Parse a `Path` in mod style, while accepting keywords.
+        ///
+        /// This function is only available within `syn` to parse meta items.
+        ///
+        /// *This function is available if Syn is built with the `"parsing"`
+        /// feature.*
+        pub(crate) fn parse_meta(input: ParseStream) -> Result<Self> {
+            Ok(Path {
+                leading_colon: input.parse()?,
+                segments: {
+                    let mut segments = Punctuated::new();
+                    loop {
+                        if !Ident::peek_any(input) {
+                            break;
+                        }
+                        let ident = Ident::parse_any(input)?;
+                        segments.push_value(PathSegment::from(ident));
+                        if !input.peek(Token![::]) {
+                            break;
+                        }
+                        let punct = input.parse()?;
+                        segments.push_punct(punct);
+                    }
+                    if segments.is_empty() {
+                        return Err(input.error("expected path"));
+                    } else if segments.trailing_punct() {
+                        return Err(input.error("expected path segment"));
+                    }
+                    segments
+                },
+            })
+        }
+
         /// Determines whether this is a path of length 1 equal to the given
         /// ident.
         ///

--- a/syn.json
+++ b/syn.json
@@ -3913,6 +3913,11 @@
             "proc_macro2": "Ident"
           }
         ],
+        "Path": [
+          {
+            "syn": "Path"
+          }
+        ],
         "List": [
           {
             "syn": "MetaList"

--- a/syn.json
+++ b/syn.json
@@ -3908,11 +3908,6 @@
         ]
       },
       "variants": {
-        "Word": [
-          {
-            "proc_macro2": "Ident"
-          }
-        ],
         "Path": [
           {
             "syn": "Path"
@@ -3939,8 +3934,8 @@
         ]
       },
       "fields": {
-        "ident": {
-          "proc_macro2": "Ident"
+        "path": {
+          "syn": "Path"
         },
         "paren_token": {
           "group": "Paren"
@@ -3964,8 +3959,8 @@
         ]
       },
       "fields": {
-        "ident": {
-          "proc_macro2": "Ident"
+        "path": {
+          "syn": "Path"
         },
         "eq_token": {
           "token": "Eq"

--- a/tests/snapshots/test_attribute__bool_lit-2.snap
+++ b/tests/snapshots/test_attribute__bool_lit-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:39:58.894785578Z"
+created: "2019-03-17T19:23:24.099484Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Literal(

--- a/tests/snapshots/test_attribute__bool_lit.snap
+++ b/tests/snapshots/test_attribute__bool_lit.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:39:56.764147500Z"
+created: "2019-03-17T19:07:57.505231700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Literal(

--- a/tests/snapshots/test_attribute__meta_item_bool_value-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_bool_value-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:39:58.894781289Z"
+created: "2019-03-17T19:23:24.098501900Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Bool(
             LitBool {

--- a/tests/snapshots/test_attribute__meta_item_bool_value-3.snap
+++ b/tests/snapshots/test_attribute__meta_item_bool_value-3.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:40:00.962390546Z"
+created: "2019-03-17T19:29:17.433554400Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Bool(
             LitBool {

--- a/tests/snapshots/test_attribute__meta_item_bool_value-4.snap
+++ b/tests/snapshots/test_attribute__meta_item_bool_value-4.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:40:02.824077655Z"
+created: "2019-03-17T19:31:05.630278700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Bool(
             LitBool {

--- a/tests/snapshots/test_attribute__meta_item_bool_value.snap
+++ b/tests/snapshots/test_attribute__meta_item_bool_value.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:39:56.764147498Z"
+created: "2019-03-17T19:07:57.505231700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Bool(
             LitBool {

--- a/tests/snapshots/test_attribute__meta_item_list_bool_value-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_bool_value-2.snap
@@ -1,22 +1,38 @@
 ---
-created: "2019-03-11T05:39:58.894795070Z"
+created: "2019-03-17T19:23:24.099484Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
                 NameValue(
                     MetaNameValue {
-                        ident: Ident(
-                            bar
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        bar
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         eq_token: Eq,
                         lit: Bool(
                             LitBool {

--- a/tests/snapshots/test_attribute__meta_item_list_bool_value.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_bool_value.snap
@@ -1,22 +1,38 @@
 ---
-created: "2019-03-11T05:39:56.764179861Z"
+created: "2019-03-17T19:07:57.505231700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
                 NameValue(
                     MetaNameValue {
-                        ident: Ident(
-                            bar
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        bar
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         eq_token: Eq,
                         lit: Bool(
                             LitBool {

--- a/tests/snapshots/test_attribute__meta_item_list_bool_value_multiple_segments-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_bool_value_multiple_segments-2.snap
@@ -1,0 +1,55 @@
+---
+created: "2019-03-17T19:29:17.432556500Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                NameValue(
+                    MetaNameValue {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        bar
+                                    ),
+                                    arguments: None
+                                },
+                                Colon2,
+                                PathSegment {
+                                    ident: Ident(
+                                        baz
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        eq_token: Eq,
+                        lit: Bool(
+                            LitBool {
+                                value: true,
+                                span: Span
+                            }
+                        )
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_bool_value_multiple_segments.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_bool_value_multiple_segments.snap
@@ -1,0 +1,55 @@
+---
+created: "2019-03-17T19:23:24.098501900Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                NameValue(
+                    MetaNameValue {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        bar
+                                    ),
+                                    arguments: None
+                                },
+                                Colon2,
+                                PathSegment {
+                                    ident: Ident(
+                                        baz
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        eq_token: Eq,
+                        lit: Bool(
+                            LitBool {
+                                value: true,
+                                span: Span
+                            }
+                        )
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_lit-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_lit-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:39:58.894786310Z"
+created: "2019-03-17T19:23:24.099484Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Literal(

--- a/tests/snapshots/test_attribute__meta_item_list_lit.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_lit.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:39:56.764180712Z"
+created: "2019-03-17T19:07:57.505231700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Literal(

--- a/tests/snapshots/test_attribute__meta_item_list_name_value-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_name_value-2.snap
@@ -1,22 +1,38 @@
 ---
-created: "2019-03-11T05:39:58.909429817Z"
+created: "2019-03-17T19:23:24.099484Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
                 NameValue(
                     MetaNameValue {
-                        ident: Ident(
-                            bar
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        bar
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         eq_token: Eq,
                         lit: Int(
                             LitInt {

--- a/tests/snapshots/test_attribute__meta_item_list_name_value.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_name_value.snap
@@ -1,22 +1,38 @@
 ---
-created: "2019-03-11T05:39:56.775177870Z"
+created: "2019-03-17T19:07:57.505231700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
                 NameValue(
                     MetaNameValue {
-                        ident: Ident(
-                            bar
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        bar
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         eq_token: Eq,
                         lit: Int(
                             LitInt {

--- a/tests/snapshots/test_attribute__meta_item_list_name_value_multiple_segments-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_name_value_multiple_segments-2.snap
@@ -1,0 +1,56 @@
+---
+created: "2019-03-17T19:29:17.432556500Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                NameValue(
+                    MetaNameValue {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        bar
+                                    ),
+                                    arguments: None
+                                },
+                                Colon2,
+                                PathSegment {
+                                    ident: Ident(
+                                        baz
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        eq_token: Eq,
+                        lit: Int(
+                            LitInt {
+                                token: Literal {
+                                    lit: 5
+                                }
+                            }
+                        )
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_name_value_multiple_segments.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_name_value_multiple_segments.snap
@@ -1,0 +1,56 @@
+---
+created: "2019-03-17T19:23:24.098501900Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                NameValue(
+                    MetaNameValue {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        bar
+                                    ),
+                                    arguments: None
+                                },
+                                Colon2,
+                                PathSegment {
+                                    ident: Ident(
+                                        baz
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        eq_token: Eq,
+                        lit: Int(
+                            LitInt {
+                                token: Literal {
+                                    lit: 5
+                                }
+                            }
+                        )
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_path-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_path-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-15T08:17:20.455754900Z"
+created: "2019-03-17T19:31:05.630278700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(

--- a/tests/snapshots/test_attribute__meta_item_list_path-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_path-2.snap
@@ -1,0 +1,38 @@
+---
+created: "2019-03-15T08:17:20.455754900Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        ident: Ident(
+            foo
+        ),
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    bar
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    Baz
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_path.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_path.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-15T08:15:35.594692300Z"
+created: "2019-03-17T19:07:57.505231700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(

--- a/tests/snapshots/test_attribute__meta_item_list_path.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_path.snap
@@ -1,0 +1,38 @@
+---
+created: "2019-03-15T08:15:35.594692300Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        ident: Ident(
+            foo
+        ),
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    bar
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    Baz
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_path_leading_colon-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_path_leading_colon-2.snap
@@ -1,0 +1,57 @@
+---
+created: "2019-03-17T19:29:17.434551900Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: Some(
+                Colon2
+            ),
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: Some(
+                            Colon2
+                        ),
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    baz
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    Qux
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_path_leading_colon.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_path_leading_colon.snap
@@ -1,0 +1,57 @@
+---
+created: "2019-03-17T19:23:24.170294200Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: Some(
+                Colon2
+            ),
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: Some(
+                            Colon2
+                        ),
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    baz
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    Qux
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_path_multiple_segments-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_path_multiple_segments-2.snap
@@ -1,0 +1,53 @@
+---
+created: "2019-03-17T19:29:17.435553400Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    baz
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    Qux
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_path_multiple_segments.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_path_multiple_segments.snap
@@ -1,0 +1,53 @@
+---
+created: "2019-03-17T19:23:24.170294200Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    baz
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    Qux
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_list_word.snap
+++ b/tests/snapshots/test_attribute__meta_item_list_word.snap
@@ -1,21 +1,37 @@
 ---
-created: "2019-03-11T05:39:56.777566785Z"
+created: "2019-03-17T19:07:57.505231700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
-                Word(
-                    Ident(
-                        bar
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    bar
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             )
         ]

--- a/tests/snapshots/test_attribute__meta_item_multiple-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_multiple-2.snap
@@ -1,30 +1,54 @@
 ---
-created: "2019-03-11T05:39:58.913038051Z"
+created: "2019-03-17T19:23:24.174283500Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
-                Word(
-                    Ident(
-                        word
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             ),
             Comma,
             Meta(
                 NameValue(
                     MetaNameValue {
-                        ident: Ident(
-                            name
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        name
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         eq_token: Eq,
                         lit: Int(
                             LitInt {
@@ -40,17 +64,33 @@ List(
             Meta(
                 List(
                     MetaList {
-                        ident: Ident(
-                            list
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        list
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         paren_token: Paren,
                         nested: [
                             Meta(
                                 NameValue(
                                     MetaNameValue {
-                                        ident: Ident(
-                                            name2
-                                        ),
+                                        path: Path {
+                                            leading_colon: None,
+                                            segments: [
+                                                PathSegment {
+                                                    ident: Ident(
+                                                        name2
+                                                    ),
+                                                    arguments: None
+                                                }
+                                            ]
+                                        },
                                         eq_token: Eq,
                                         lit: Int(
                                             LitInt {
@@ -68,10 +108,18 @@ List(
             ),
             Comma,
             Meta(
-                Word(
-                    Ident(
-                        word2
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word2
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             )
         ]

--- a/tests/snapshots/test_attribute__meta_item_multiple.snap
+++ b/tests/snapshots/test_attribute__meta_item_multiple.snap
@@ -1,30 +1,54 @@
 ---
-created: "2019-03-11T05:39:56.781580510Z"
+created: "2019-03-17T19:07:57.505231700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
-                Word(
-                    Ident(
-                        word
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             ),
             Comma,
             Meta(
                 NameValue(
                     MetaNameValue {
-                        ident: Ident(
-                            name
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        name
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         eq_token: Eq,
                         lit: Int(
                             LitInt {
@@ -40,17 +64,33 @@ List(
             Meta(
                 List(
                     MetaList {
-                        ident: Ident(
-                            list
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        list
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         paren_token: Paren,
                         nested: [
                             Meta(
                                 NameValue(
                                     MetaNameValue {
-                                        ident: Ident(
-                                            name2
-                                        ),
+                                        path: Path {
+                                            leading_colon: None,
+                                            segments: [
+                                                PathSegment {
+                                                    ident: Ident(
+                                                        name2
+                                                    ),
+                                                    arguments: None
+                                                }
+                                            ]
+                                        },
                                         eq_token: Eq,
                                         lit: Int(
                                             LitInt {
@@ -68,10 +108,18 @@ List(
             ),
             Comma,
             Meta(
-                Word(
-                    Ident(
-                        word2
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word2
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             )
         ]

--- a/tests/snapshots/test_attribute__meta_item_multiple_with_path-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_multiple_with_path-2.snap
@@ -1,0 +1,159 @@
+---
+created: "2019-03-17T21:23:01.656303800Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                NameValue(
+                    MetaNameValue {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        name
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        eq_token: Eq,
+                        lit: Int(
+                            LitInt {
+                                token: Literal {
+                                    lit: 5
+                                }
+                            }
+                        )
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                List(
+                    MetaList {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        list
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        paren_token: Paren,
+                        nested: [
+                            Meta(
+                                NameValue(
+                                    MetaNameValue {
+                                        path: Path {
+                                            leading_colon: None,
+                                            segments: [
+                                                PathSegment {
+                                                    ident: Ident(
+                                                        name2
+                                                    ),
+                                                    arguments: None
+                                                }
+                                            ]
+                                        },
+                                        eq_token: Eq,
+                                        lit: Int(
+                                            LitInt {
+                                                token: Literal {
+                                                    lit: 6
+                                                }
+                                            }
+                                        )
+                                    }
+                                )
+                            )
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word2
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: Some(
+                            Colon2
+                        ),
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    path
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    true
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_multiple_with_path.snap
+++ b/tests/snapshots/test_attribute__meta_item_multiple_with_path.snap
@@ -1,0 +1,159 @@
+---
+created: "2019-03-17T21:22:52.899940600Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                NameValue(
+                    MetaNameValue {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        name
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        eq_token: Eq,
+                        lit: Int(
+                            LitInt {
+                                token: Literal {
+                                    lit: 5
+                                }
+                            }
+                        )
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                List(
+                    MetaList {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        list
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        paren_token: Paren,
+                        nested: [
+                            Meta(
+                                NameValue(
+                                    MetaNameValue {
+                                        path: Path {
+                                            leading_colon: None,
+                                            segments: [
+                                                PathSegment {
+                                                    ident: Ident(
+                                                        name2
+                                                    ),
+                                                    arguments: None
+                                                }
+                                            ]
+                                        },
+                                        eq_token: Eq,
+                                        lit: Int(
+                                            LitInt {
+                                                token: Literal {
+                                                    lit: 6
+                                                }
+                                            }
+                                        )
+                                    }
+                                )
+                            )
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word2
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: Some(
+                            Colon2
+                        ),
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    path
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    true
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_name_value-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_name_value-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:39:58.912645460Z"
+created: "2019-03-17T19:23:24.179270400Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Int(
             LitInt {

--- a/tests/snapshots/test_attribute__meta_item_name_value.snap
+++ b/tests/snapshots/test_attribute__meta_item_name_value.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:39:56.782341532Z"
+created: "2019-03-17T19:07:57.587013100Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Int(
             LitInt {

--- a/tests/snapshots/test_attribute__meta_item_name_value_leading_colon-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_name_value_leading_colon-2.snap
@@ -1,0 +1,38 @@
+---
+created: "2019-03-17T19:29:17.436547Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+NameValue(
+    MetaNameValue {
+        path: Path {
+            leading_colon: Some(
+                Colon2
+            ),
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        eq_token: Eq,
+        lit: Int(
+            LitInt {
+                token: Literal {
+                    lit: 5
+                }
+            }
+        )
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_name_value_leading_colon.snap
+++ b/tests/snapshots/test_attribute__meta_item_name_value_leading_colon.snap
@@ -1,0 +1,38 @@
+---
+created: "2019-03-17T19:23:24.181264200Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+NameValue(
+    MetaNameValue {
+        path: Path {
+            leading_colon: Some(
+                Colon2
+            ),
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        eq_token: Eq,
+        lit: Int(
+            LitInt {
+                token: Literal {
+                    lit: 5
+                }
+            }
+        )
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_name_value_multiple_segments-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_name_value_multiple_segments-2.snap
@@ -1,0 +1,36 @@
+---
+created: "2019-03-17T19:29:17.436547Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+NameValue(
+    MetaNameValue {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        eq_token: Eq,
+        lit: Int(
+            LitInt {
+                token: Literal {
+                    lit: 5
+                }
+            }
+        )
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_name_value_multiple_segments.snap
+++ b/tests/snapshots/test_attribute__meta_item_name_value_multiple_segments.snap
@@ -1,0 +1,36 @@
+---
+created: "2019-03-17T19:23:24.182262200Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+NameValue(
+    MetaNameValue {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        eq_token: Eq,
+        lit: Int(
+            LitInt {
+                token: Literal {
+                    lit: 5
+                }
+            }
+        )
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_path-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_path-2.snap
@@ -1,0 +1,19 @@
+---
+created: "2019-03-17T19:29:17.516334500Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+Path(
+    Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            }
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_path.snap
+++ b/tests/snapshots/test_attribute__meta_item_path.snap
@@ -1,0 +1,19 @@
+---
+created: "2019-03-17T19:23:24.185254Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+Path(
+    Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            }
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_path_leading_colon-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_path_leading_colon-2.snap
@@ -1,0 +1,28 @@
+---
+created: "2019-03-17T19:29:17.514338300Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+Path(
+    Path {
+        leading_colon: Some(
+            Colon2
+        ),
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            },
+            Colon2,
+            PathSegment {
+                ident: Ident(
+                    bar
+                ),
+                arguments: None
+            }
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_path_leading_colon.snap
+++ b/tests/snapshots/test_attribute__meta_item_path_leading_colon.snap
@@ -1,0 +1,28 @@
+---
+created: "2019-03-17T19:23:24.188245400Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+Path(
+    Path {
+        leading_colon: Some(
+            Colon2
+        ),
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            },
+            Colon2,
+            PathSegment {
+                ident: Ident(
+                    bar
+                ),
+                arguments: None
+            }
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_path_multiple_segments-2.snap
+++ b/tests/snapshots/test_attribute__meta_item_path_multiple_segments-2.snap
@@ -1,0 +1,26 @@
+---
+created: "2019-03-17T19:29:17.528301700Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+Path(
+    Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            },
+            Colon2,
+            PathSegment {
+                ident: Ident(
+                    bar
+                ),
+                arguments: None
+            }
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_path_multiple_segments.snap
+++ b/tests/snapshots/test_attribute__meta_item_path_multiple_segments.snap
@@ -1,0 +1,26 @@
+---
+created: "2019-03-17T19:23:24.274016500Z"
+creator: insta@0.7.1
+source: tests/test_attribute.rs
+expression: syntax_tree
+---
+Path(
+    Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            },
+            Colon2,
+            PathSegment {
+                ident: Ident(
+                    bar
+                ),
+                arguments: None
+            }
+        ]
+    }
+)

--- a/tests/snapshots/test_attribute__meta_item_word.snap
+++ b/tests/snapshots/test_attribute__meta_item_word.snap
@@ -1,11 +1,19 @@
 ---
-created: "2019-03-11T05:39:56.788344806Z"
+created: "2019-03-17T19:07:57.590003700Z"
 creator: insta@0.7.1
 source: tests/test_attribute.rs
 expression: syntax_tree
 ---
-Word(
-    Ident(
-        foo
-    )
+Path(
+    Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            }
+        ]
+    }
 )

--- a/tests/snapshots/test_derive_input__enum-2.snap
+++ b/tests/snapshots/test_derive_input__enum-2.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-03-11T05:40:06.910167896Z"
+created: "2019-03-17T20:01:48.967344100Z"
 creator: insta@0.7.1
 source: tests/test_derive_input.rs
 expression: syntax_tree
@@ -7,9 +7,17 @@ expression: syntax_tree
 [
     NameValue(
         MetaNameValue {
-            ident: Ident(
-                doc
-            ),
+            path: Path {
+                leading_colon: None,
+                segments: [
+                    PathSegment {
+                        ident: Ident(
+                            doc
+                        ),
+                        arguments: None
+                    }
+                ]
+            },
             eq_token: Eq,
             lit: Str(
                 LitStr {
@@ -20,9 +28,17 @@ expression: syntax_tree
             )
         }
     ),
-    Word(
-        Ident(
-            must_use
-        )
+    Path(
+        Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        must_use
+                    ),
+                    arguments: None
+                }
+            ]
+        }
     )
 ]

--- a/tests/snapshots/test_derive_input__struct-2.snap
+++ b/tests/snapshots/test_derive_input__struct-2.snap
@@ -1,29 +1,53 @@
 ---
-created: "2019-03-11T05:40:06.919215869Z"
+created: "2019-03-17T20:01:48.968342400Z"
 creator: insta@0.7.1
 source: tests/test_derive_input.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            derive
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        derive
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
-                Word(
-                    Ident(
-                        Debug
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    Debug
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             ),
             Comma,
             Meta(
-                Word(
-                    Ident(
-                        Clone
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    Clone
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             )
         ]

--- a/tests/snapshots/test_meta__parse_meta_item_list_lit-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_list_lit-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:40:21.675781063Z"
+created: "2019-03-17T20:28:26.050832100Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Literal(

--- a/tests/snapshots/test_meta__parse_meta_item_list_lit.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_list_lit.snap
@@ -1,13 +1,21 @@
 ---
-created: "2019-03-11T05:40:19.682551683Z"
+created: "2019-03-17T20:26:22.508944900Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 MetaList {
-    ident: Ident(
-        foo
-    ),
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            }
+        ]
+    },
     paren_token: Paren,
     nested: [
         Literal(

--- a/tests/snapshots/test_meta__parse_meta_item_list_with_path-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_list_with_path-2.snap
@@ -1,0 +1,40 @@
+---
+created: "2019-03-17T20:28:26.049833Z"
+creator: insta@0.7.1
+source: tests/test_meta.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Literal(
+                Int(
+                    LitInt {
+                        token: Literal {
+                            lit: 5
+                        }
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_meta__parse_meta_item_list_with_path.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_list_with_path.snap
@@ -1,0 +1,38 @@
+---
+created: "2019-03-17T20:26:22.507948100Z"
+creator: insta@0.7.1
+source: tests/test_meta.rs
+expression: syntax_tree
+---
+MetaList {
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            },
+            Colon2,
+            PathSegment {
+                ident: Ident(
+                    bar
+                ),
+                arguments: None
+            }
+        ]
+    },
+    paren_token: Paren,
+    nested: [
+        Literal(
+            Int(
+                LitInt {
+                    token: Literal {
+                        lit: 5
+                    }
+                }
+            )
+        )
+    ]
+}

--- a/tests/snapshots/test_meta__parse_meta_item_multiple-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_multiple-2.snap
@@ -1,30 +1,54 @@
 ---
-created: "2019-03-11T05:40:21.675850965Z"
+created: "2019-03-17T20:28:26.050832100Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 List(
     MetaList {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         paren_token: Paren,
         nested: [
             Meta(
-                Word(
-                    Ident(
-                        word
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             ),
             Comma,
             Meta(
                 NameValue(
                     MetaNameValue {
-                        ident: Ident(
-                            name
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        name
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         eq_token: Eq,
                         lit: Int(
                             LitInt {
@@ -40,17 +64,33 @@ List(
             Meta(
                 List(
                     MetaList {
-                        ident: Ident(
-                            list
-                        ),
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        list
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
                         paren_token: Paren,
                         nested: [
                             Meta(
                                 NameValue(
                                     MetaNameValue {
-                                        ident: Ident(
-                                            name2
-                                        ),
+                                        path: Path {
+                                            leading_colon: None,
+                                            segments: [
+                                                PathSegment {
+                                                    ident: Ident(
+                                                        name2
+                                                    ),
+                                                    arguments: None
+                                                }
+                                            ]
+                                        },
                                         eq_token: Eq,
                                         lit: Int(
                                             LitInt {
@@ -68,10 +108,18 @@ List(
             ),
             Comma,
             Meta(
-                Word(
-                    Ident(
-                        word2
-                    )
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word2
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
                 )
             )
         ]

--- a/tests/snapshots/test_meta__parse_meta_item_multiple.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_multiple.snap
@@ -1,29 +1,53 @@
 ---
-created: "2019-03-11T05:40:19.682559314Z"
+created: "2019-03-17T20:26:22.508944900Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 MetaList {
-    ident: Ident(
-        foo
-    ),
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            }
+        ]
+    },
     paren_token: Paren,
     nested: [
         Meta(
-            Word(
-                Ident(
-                    word
-                )
+            Path(
+                Path {
+                    leading_colon: None,
+                    segments: [
+                        PathSegment {
+                            ident: Ident(
+                                word
+                            ),
+                            arguments: None
+                        }
+                    ]
+                }
             )
         ),
         Comma,
         Meta(
             NameValue(
                 MetaNameValue {
-                    ident: Ident(
-                        name
-                    ),
+                    path: Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    name
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    },
                     eq_token: Eq,
                     lit: Int(
                         LitInt {
@@ -39,17 +63,33 @@ MetaList {
         Meta(
             List(
                 MetaList {
-                    ident: Ident(
-                        list
-                    ),
+                    path: Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    list
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    },
                     paren_token: Paren,
                     nested: [
                         Meta(
                             NameValue(
                                 MetaNameValue {
-                                    ident: Ident(
-                                        name2
-                                    ),
+                                    path: Path {
+                                        leading_colon: None,
+                                        segments: [
+                                            PathSegment {
+                                                ident: Ident(
+                                                    name2
+                                                ),
+                                                arguments: None
+                                            }
+                                        ]
+                                    },
                                     eq_token: Eq,
                                     lit: Int(
                                         LitInt {
@@ -67,10 +107,18 @@ MetaList {
         ),
         Comma,
         Meta(
-            Word(
-                Ident(
-                    word2
-                )
+            Path(
+                Path {
+                    leading_colon: None,
+                    segments: [
+                        PathSegment {
+                            ident: Ident(
+                                word2
+                            ),
+                            arguments: None
+                        }
+                    ]
+                }
             )
         )
     ]

--- a/tests/snapshots/test_meta__parse_meta_item_multiple_with_path-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_multiple_with_path-2.snap
@@ -1,0 +1,157 @@
+---
+created: "2019-03-17T21:23:40.461664300Z"
+creator: insta@0.7.1
+source: tests/test_meta.rs
+expression: syntax_tree
+---
+List(
+    MetaList {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        paren_token: Paren,
+        nested: [
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                NameValue(
+                    MetaNameValue {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        name
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        eq_token: Eq,
+                        lit: Int(
+                            LitInt {
+                                token: Literal {
+                                    lit: 5
+                                }
+                            }
+                        )
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                List(
+                    MetaList {
+                        path: Path {
+                            leading_colon: None,
+                            segments: [
+                                PathSegment {
+                                    ident: Ident(
+                                        list
+                                    ),
+                                    arguments: None
+                                }
+                            ]
+                        },
+                        paren_token: Paren,
+                        nested: [
+                            Meta(
+                                NameValue(
+                                    MetaNameValue {
+                                        path: Path {
+                                            leading_colon: None,
+                                            segments: [
+                                                PathSegment {
+                                                    ident: Ident(
+                                                        name2
+                                                    ),
+                                                    arguments: None
+                                                }
+                                            ]
+                                        },
+                                        eq_token: Eq,
+                                        lit: Int(
+                                            LitInt {
+                                                token: Literal {
+                                                    lit: 6
+                                                }
+                                            }
+                                        )
+                                    }
+                                )
+                            )
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    word2
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            ),
+            Comma,
+            Meta(
+                Path(
+                    Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    path
+                                ),
+                                arguments: None
+                            },
+                            Colon2,
+                            PathSegment {
+                                ident: Ident(
+                                    true
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    }
+                )
+            )
+        ]
+    }
+)

--- a/tests/snapshots/test_meta__parse_meta_item_multiple_with_path.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_multiple_with_path.snap
@@ -1,0 +1,155 @@
+---
+created: "2019-03-17T21:23:15.802756500Z"
+creator: insta@0.7.1
+source: tests/test_meta.rs
+expression: syntax_tree
+---
+MetaList {
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            },
+            Colon2,
+            PathSegment {
+                ident: Ident(
+                    bar
+                ),
+                arguments: None
+            }
+        ]
+    },
+    paren_token: Paren,
+    nested: [
+        Meta(
+            Path(
+                Path {
+                    leading_colon: None,
+                    segments: [
+                        PathSegment {
+                            ident: Ident(
+                                word
+                            ),
+                            arguments: None
+                        }
+                    ]
+                }
+            )
+        ),
+        Comma,
+        Meta(
+            NameValue(
+                MetaNameValue {
+                    path: Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    name
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    },
+                    eq_token: Eq,
+                    lit: Int(
+                        LitInt {
+                            token: Literal {
+                                lit: 5
+                            }
+                        }
+                    )
+                }
+            )
+        ),
+        Comma,
+        Meta(
+            List(
+                MetaList {
+                    path: Path {
+                        leading_colon: None,
+                        segments: [
+                            PathSegment {
+                                ident: Ident(
+                                    list
+                                ),
+                                arguments: None
+                            }
+                        ]
+                    },
+                    paren_token: Paren,
+                    nested: [
+                        Meta(
+                            NameValue(
+                                MetaNameValue {
+                                    path: Path {
+                                        leading_colon: None,
+                                        segments: [
+                                            PathSegment {
+                                                ident: Ident(
+                                                    name2
+                                                ),
+                                                arguments: None
+                                            }
+                                        ]
+                                    },
+                                    eq_token: Eq,
+                                    lit: Int(
+                                        LitInt {
+                                            token: Literal {
+                                                lit: 6
+                                            }
+                                        }
+                                    )
+                                }
+                            )
+                        )
+                    ]
+                }
+            )
+        ),
+        Comma,
+        Meta(
+            Path(
+                Path {
+                    leading_colon: None,
+                    segments: [
+                        PathSegment {
+                            ident: Ident(
+                                word2
+                            ),
+                            arguments: None
+                        }
+                    ]
+                }
+            )
+        ),
+        Comma,
+        Meta(
+            Path(
+                Path {
+                    leading_colon: None,
+                    segments: [
+                        PathSegment {
+                            ident: Ident(
+                                path
+                            ),
+                            arguments: None
+                        },
+                        Colon2,
+                        PathSegment {
+                            ident: Ident(
+                                true
+                            ),
+                            arguments: None
+                        }
+                    ]
+                }
+            )
+        )
+    ]
+}

--- a/tests/snapshots/test_meta__parse_meta_item_word.snap
+++ b/tests/snapshots/test_meta__parse_meta_item_word.snap
@@ -1,11 +1,19 @@
 ---
-created: "2019-03-11T05:40:19.682489939Z"
+created: "2019-03-17T20:26:22.508944900Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
-Word(
-    Ident(
-        hello
-    )
+Path(
+    Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    hello
+                ),
+                arguments: None
+            }
+        ]
+    }
 )

--- a/tests/snapshots/test_meta__parse_meta_name_value-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:40:21.675781065Z"
+created: "2019-03-17T20:28:26.050832100Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            foo
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Int(
             LitInt {

--- a/tests/snapshots/test_meta__parse_meta_name_value.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value.snap
@@ -1,13 +1,21 @@
 ---
-created: "2019-03-11T05:40:19.682552842Z"
+created: "2019-03-17T20:26:22.508944900Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 MetaNameValue {
-    ident: Ident(
-        foo
-    ),
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            }
+        ]
+    },
     eq_token: Eq,
     lit: Int(
         LitInt {

--- a/tests/snapshots/test_meta__parse_meta_name_value_with_bool-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value_with_bool-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:40:21.676510552Z"
+created: "2019-03-17T21:23:40.461664300Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            true
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        true
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Int(
             LitInt {

--- a/tests/snapshots/test_meta__parse_meta_name_value_with_bool.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value_with_bool.snap
@@ -1,13 +1,21 @@
 ---
-created: "2019-03-11T05:40:19.694865579Z"
+created: "2019-03-17T21:23:15.803754400Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 MetaNameValue {
-    ident: Ident(
-        true
-    ),
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    true
+                ),
+                arguments: None
+            }
+        ]
+    },
     eq_token: Eq,
     lit: Int(
         LitInt {

--- a/tests/snapshots/test_meta__parse_meta_name_value_with_keyword-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value_with_keyword-2.snap
@@ -1,14 +1,22 @@
 ---
-created: "2019-03-11T05:40:21.687855159Z"
+created: "2019-03-17T21:23:40.461664300Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 NameValue(
     MetaNameValue {
-        ident: Ident(
-            static
-        ),
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        static
+                    ),
+                    arguments: None
+                }
+            ]
+        },
         eq_token: Eq,
         lit: Int(
             LitInt {

--- a/tests/snapshots/test_meta__parse_meta_name_value_with_keyword.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value_with_keyword.snap
@@ -1,13 +1,21 @@
 ---
-created: "2019-03-11T05:40:19.694905983Z"
+created: "2019-03-17T21:23:15.803754400Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
 ---
 MetaNameValue {
-    ident: Ident(
-        static
-    ),
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    static
+                ),
+                arguments: None
+            }
+        ]
+    },
     eq_token: Eq,
     lit: Int(
         LitInt {

--- a/tests/snapshots/test_meta__parse_meta_name_value_with_keyword_and_path-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value_with_keyword_and_path-2.snap
@@ -1,0 +1,36 @@
+---
+created: "2019-03-17T21:23:40.462661Z"
+creator: insta@0.7.1
+source: tests/test_meta.rs
+expression: syntax_tree
+---
+NameValue(
+    MetaNameValue {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        extern
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        static
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        eq_token: Eq,
+        lit: Int(
+            LitInt {
+                token: Literal {
+                    lit: 5
+                }
+            }
+        )
+    }
+)

--- a/tests/snapshots/test_meta__parse_meta_name_value_with_keyword_and_path.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value_with_keyword_and_path.snap
@@ -1,0 +1,34 @@
+---
+created: "2019-03-17T21:23:15.803754400Z"
+creator: insta@0.7.1
+source: tests/test_meta.rs
+expression: syntax_tree
+---
+MetaNameValue {
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    extern
+                ),
+                arguments: None
+            },
+            Colon2,
+            PathSegment {
+                ident: Ident(
+                    static
+                ),
+                arguments: None
+            }
+        ]
+    },
+    eq_token: Eq,
+    lit: Int(
+        LitInt {
+            token: Literal {
+                lit: 5
+            }
+        }
+    )
+}

--- a/tests/snapshots/test_meta__parse_meta_name_value_with_path-2.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value_with_path-2.snap
@@ -1,0 +1,36 @@
+---
+created: "2019-03-17T20:28:26.049833Z"
+creator: insta@0.7.1
+source: tests/test_meta.rs
+expression: syntax_tree
+---
+NameValue(
+    MetaNameValue {
+        path: Path {
+            leading_colon: None,
+            segments: [
+                PathSegment {
+                    ident: Ident(
+                        foo
+                    ),
+                    arguments: None
+                },
+                Colon2,
+                PathSegment {
+                    ident: Ident(
+                        bar
+                    ),
+                    arguments: None
+                }
+            ]
+        },
+        eq_token: Eq,
+        lit: Int(
+            LitInt {
+                token: Literal {
+                    lit: 5
+                }
+            }
+        )
+    }
+)

--- a/tests/snapshots/test_meta__parse_meta_name_value_with_path.snap
+++ b/tests/snapshots/test_meta__parse_meta_name_value_with_path.snap
@@ -1,0 +1,34 @@
+---
+created: "2019-03-17T20:26:22.507948100Z"
+creator: insta@0.7.1
+source: tests/test_meta.rs
+expression: syntax_tree
+---
+MetaNameValue {
+    path: Path {
+        leading_colon: None,
+        segments: [
+            PathSegment {
+                ident: Ident(
+                    foo
+                ),
+                arguments: None
+            },
+            Colon2,
+            PathSegment {
+                ident: Ident(
+                    bar
+                ),
+                arguments: None
+            }
+        ]
+    },
+    eq_token: Eq,
+    lit: Int(
+        LitInt {
+            token: Literal {
+                lit: 5
+            }
+        }
+    )
+}

--- a/tests/snapshots/test_meta__parse_nested_meta-2.snap
+++ b/tests/snapshots/test_meta__parse_nested_meta-2.snap
@@ -1,5 +1,5 @@
 ---
-created: "2019-03-11T05:40:21.688020363Z"
+created: "2019-03-17T20:26:22.508944900Z"
 creator: insta@0.7.1
 source: tests/test_meta.rs
 expression: syntax_tree
@@ -7,17 +7,33 @@ expression: syntax_tree
 Meta(
     List(
         MetaList {
-            ident: Ident(
-                list
-            ),
+            path: Path {
+                leading_colon: None,
+                segments: [
+                    PathSegment {
+                        ident: Ident(
+                            list
+                        ),
+                        arguments: None
+                    }
+                ]
+            },
             paren_token: Paren,
             nested: [
                 Meta(
                     NameValue(
                         MetaNameValue {
-                            ident: Ident(
-                                name2
-                            ),
+                            path: Path {
+                                leading_colon: None,
+                                segments: [
+                                    PathSegment {
+                                        ident: Ident(
+                                            name2
+                                        ),
+                                        arguments: None
+                                    }
+                                ]
+                            },
                             eq_token: Eq,
                             lit: Int(
                                 LitInt {

--- a/tests/test_attribute.rs
+++ b/tests/test_attribute.rs
@@ -9,8 +9,18 @@ use syn::parse::Parser;
 use syn::Attribute;
 
 #[test]
-fn test_meta_item_word() {
+fn test_meta_item_path() {
     test("#[foo]")
+}
+
+#[test]
+fn test_meta_item_path_multiple_segments() {
+    test("#[foo::bar]")
+}
+
+#[test]
+fn test_meta_item_path_leading_colon() {
+    test("#[::foo::bar]")
 }
 
 #[test]
@@ -25,13 +35,18 @@ fn test_meta_item_bool_value() {
 }
 
 #[test]
-fn test_meta_item_list_lit() {
-    test("#[foo(5)]")
+fn test_meta_item_name_value_multiple_segments() {
+    test("#[foo::bar = 5]")
 }
 
 #[test]
-fn test_meta_item_list_word() {
-    test("#[foo(bar)]")
+fn test_meta_item_name_value_leading_colon() {
+    test("#[::foo::bar = 5]")
+}
+
+#[test]
+fn test_meta_item_list_lit() {
+    test("#[foo(5)]")
 }
 
 #[test]
@@ -40,8 +55,23 @@ fn test_meta_item_list_path() {
 }
 
 #[test]
+fn test_meta_item_list_path_multiple_segments() {
+    test("#[foo::bar(baz::Qux)]")
+}
+
+#[test]
+fn test_meta_item_list_path_leading_colon() {
+    test("#[::foo::bar(::baz::Qux)]")
+}
+
+#[test]
 fn test_meta_item_list_name_value() {
     test("#[foo(bar = 5)]")
+}
+
+#[test]
+fn test_meta_item_list_name_value_multiple_segments() {
+    test("#[foo(bar::baz = 5)]")
 }
 
 #[test]
@@ -50,8 +80,18 @@ fn test_meta_item_list_bool_value() {
 }
 
 #[test]
+fn test_meta_item_list_bool_value_multiple_segments() {
+    test("#[foo(bar::baz = true)]")
+}
+
+#[test]
 fn test_meta_item_multiple() {
     test("#[foo(word, name = 5, list(name2 = 6), word2)]")
+}
+
+#[test]
+fn test_meta_item_multiple_with_path() {
+    test("#[foo::bar(word, name = 5, list(name2 = 6), word2, ::path::true)]")
 }
 
 #[test]

--- a/tests/test_attribute.rs
+++ b/tests/test_attribute.rs
@@ -35,6 +35,11 @@ fn test_meta_item_list_word() {
 }
 
 #[test]
+fn test_meta_item_list_path() {
+    test("#[foo(bar::Baz)]")
+}
+
+#[test]
 fn test_meta_item_list_name_value() {
     test("#[foo(bar = 5)]")
 }

--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -107,7 +107,7 @@ fn test_attr_with_mod_style_path_with_self() {
 
     let actual = snapshot!(code as DeriveInput);
 
-    assert!(actual.attrs[0].interpret_meta().is_none());
+    assert!(actual.attrs[0].interpret_meta().is_some());
 }
 
 #[test]

--- a/tests/test_meta.rs
+++ b/tests/test_meta.rs
@@ -22,8 +22,18 @@ fn test_parse_meta_name_value() {
 }
 
 #[test]
+fn test_parse_meta_name_value_with_path() {
+    test::<MetaNameValue>("foo::bar = 5");
+}
+
+#[test]
 fn test_parse_meta_name_value_with_keyword() {
     test::<MetaNameValue>("static = 5");
+}
+
+#[test]
+fn test_parse_meta_name_value_with_keyword_and_path() {
+    test::<MetaNameValue>("extern::static = 5");
 }
 
 #[test]
@@ -37,8 +47,18 @@ fn test_parse_meta_item_list_lit() {
 }
 
 #[test]
+fn test_parse_meta_item_list_with_path() {
+    test::<MetaList>("foo::bar(5)");
+}
+
+#[test]
 fn test_parse_meta_item_multiple() {
     test::<MetaList>("foo(word, name = 5, list(name2 = 6), word2)");
+}
+
+#[test]
+fn test_parse_meta_item_multiple_with_path() {
+    test::<MetaList>("foo::bar(word, name = 5, list(name2 = 6), word2, path::true)");
 }
 
 #[test]


### PR DESCRIPTION
Closes #597.

Now we can have:

```rust
#[foo(bar::Baz)] // bar::Baz is a `Meta::Path(Path)`
```

~~Bumped the version to `0.16.0` as this is a breaking change.~~
Got the tests going with `cargo insta`.
Couldn't find a `CHANGELOG.md`, not sure if you would like one.

---

Just realized, bumping `syn` to `0.16` in the whole ecosystem is an upcoming chore.