### PR TITLE
Parse impls for more expr types

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -232,7 +232,7 @@ pub mod parsing {
                 }
 
                 if input.peek(Lit) {
-                    let lit = input.call(expr::parsing::expr_lit)?;
+                    let lit = input.parse()?;
                     return Ok(GenericArgument::Const(Expr::Lit(lit)));
                 }
 


### PR DESCRIPTION
Added `Parse` impls for:  `loop`, `while` and `for` loops, `if` expressions and literals.