### PR TITLE
Function to peek any ident

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,10 @@ fn main() {
         println!("cargo:rustc-cfg=syn_can_use_thread_id");
     }
 
+    if compiler.minor >= 20 {
+        println!("cargo:rustc-cfg=syn_can_use_associated_constants");
+    }
+
     // Macro modularization allows re-exporting the `quote!` macro in 1.30+.
     if compiler.minor >= 30 {
         println!("cargo:rustc-cfg=syn_can_call_macro_by_path");

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -4,9 +4,15 @@
 
 use proc_macro2::Ident;
 
+use parse::{ParseStream, Result};
+
+#[cfg(syn_can_use_associated_constants)]
 use buffer::Cursor;
-use parse::{ParseStream, Peek, Result};
+#[cfg(syn_can_use_associated_constants)]
+use parse::Peek;
+#[cfg(syn_can_use_associated_constants)]
 use sealed::lookahead;
+#[cfg(syn_can_use_associated_constants)]
 use token::CustomToken;
 
 /// Additional methods for `Ident` not provided by proc-macro2 or libproc_macro.
@@ -53,6 +59,7 @@ pub trait IdentExt: Sized + private::Sealed {
     ///
     /// This is different from `input.peek(Ident)` which only returns true in
     /// the case of an ident which is not a Rust keyword.
+    #[cfg(syn_can_use_associated_constants)]
     #[allow(non_upper_case_globals)]
     const peek_any: private::PeekFn = private::PeekFn;
 
@@ -104,10 +111,12 @@ impl IdentExt for Ident {
     }
 }
 
+#[cfg(syn_can_use_associated_constants)]
 impl Peek for private::PeekFn {
     type Token = private::IdentAny;
 }
 
+#[cfg(syn_can_use_associated_constants)]
 impl CustomToken for private::IdentAny {
     fn peek(cursor: Cursor) -> bool {
         cursor.ident().is_some()
@@ -118,6 +127,7 @@ impl CustomToken for private::IdentAny {
     }
 }
 
+#[cfg(syn_can_use_associated_constants)]
 impl lookahead::Sealed for private::PeekFn {}
 
 mod private {
@@ -127,7 +137,9 @@ mod private {
 
     impl Sealed for Ident {}
 
+    #[cfg(syn_can_use_associated_constants)]
     #[derive(Copy, Clone)]
     pub struct PeekFn;
+    #[cfg(syn_can_use_associated_constants)]
     pub struct IdentAny;
 }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -4,7 +4,10 @@
 
 use proc_macro2::Ident;
 
-use parse::{ParseStream, Result};
+use buffer::Cursor;
+use parse::{ParseStream, Peek, Result};
+use sealed::lookahead;
+use token::CustomToken;
 
 /// Additional methods for `Ident` not provided by proc-macro2 or libproc_macro.
 ///
@@ -15,7 +18,7 @@ use parse::{ParseStream, Result};
 pub trait IdentExt: Sized + private::Sealed {
     /// Parses any identifier including keywords.
     ///
-    /// This is useful when parsing a DSL which allows Rust keywords as
+    /// This is useful when parsing macro input which allows Rust keywords as
     /// identifiers.
     ///
     /// # Example
@@ -25,6 +28,10 @@ pub trait IdentExt: Sized + private::Sealed {
     /// use syn::ext::IdentExt;
     /// use syn::parse::ParseStream;
     ///
+    /// mod kw {
+    ///     syn::custom_keyword!(name);
+    /// }
+    ///
     /// // Parses input that looks like `name = NAME` where `NAME` can be
     /// // any identifier.
     /// //
@@ -33,16 +40,21 @@ pub trait IdentExt: Sized + private::Sealed {
     /// //     name = anything
     /// //     name = impl
     /// fn parse_dsl(input: ParseStream) -> Result<Ident> {
-    ///     let name_token: Ident = input.parse()?;
-    ///     if name_token != "name" {
-    ///         return Err(Error::new(name_token.span(), "expected `name`"));
-    ///     }
+    ///     input.parse::<kw::name>()?;
     ///     input.parse::<Token![=]>()?;
     ///     let name = input.call(Ident::parse_any)?;
     ///     Ok(name)
     /// }
     /// ```
     fn parse_any(input: ParseStream) -> Result<Self>;
+
+    /// Peeks any identifier including keywords. Usage:
+    /// `input.peek(Ident::peek_any)`
+    ///
+    /// This is different from `input.peek(Ident)` which only returns true in
+    /// the case of an ident which is not a Rust keyword.
+    #[allow(non_upper_case_globals)]
+    const peek_any: private::PeekFn = private::PeekFn;
 
     /// Strips the raw marker `r#`, if any, from the beginning of an ident.
     ///
@@ -92,10 +104,30 @@ impl IdentExt for Ident {
     }
 }
 
+impl Peek for private::PeekFn {
+    type Token = private::IdentAny;
+}
+
+impl CustomToken for private::IdentAny {
+    fn peek(cursor: Cursor) -> bool {
+        cursor.ident().is_some()
+    }
+
+    fn display() -> &'static str {
+        "identifier"
+    }
+}
+
+impl lookahead::Sealed for private::PeekFn {}
+
 mod private {
     use proc_macro2::Ident;
 
     pub trait Sealed {}
 
     impl Sealed for Ident {}
+
+    #[derive(Copy, Clone)]
+    pub struct PeekFn;
+    pub struct IdentAny;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,6 +540,7 @@ pub mod export;
 
 mod custom_keyword;
 mod custom_punctuation;
+mod sealed;
 
 #[cfg(feature = "parsing")]
 mod lookahead;

--- a/src/lookahead.rs
+++ b/src/lookahead.rs
@@ -4,6 +4,7 @@ use proc_macro2::{Delimiter, Span};
 
 use buffer::Cursor;
 use error::{self, Error};
+use sealed::lookahead::Sealed;
 use span::IntoSpans;
 use token::Token;
 
@@ -94,7 +95,8 @@ impl<'a> Lookahead1<'a> {
     ///
     /// - `input.peek(Token![struct])`
     /// - `input.peek(Token![==])`
-    /// - `input.peek(Ident)`
+    /// - `input.peek(Ident)`&emsp;*(does not accept keywords)*
+    /// - `input.peek(Ident::peek_any)`
     /// - `input.peek(Lifetime)`
     /// - `input.peek(token::Brace)`
     pub fn peek<T: Peek>(&self, token: T) -> bool {
@@ -141,7 +143,7 @@ impl<'a> Lookahead1<'a> {
 /// This trait is sealed and cannot be implemented for types outside of Syn.
 ///
 /// [`ParseStream::peek`]: struct.ParseBuffer.html#method.peek
-pub trait Peek: private::Sealed {
+pub trait Peek: Sealed {
     // Not public API.
     #[doc(hidden)]
     type Token: Token;
@@ -163,8 +165,4 @@ pub fn is_delimiter(cursor: Cursor, delimiter: Delimiter) -> bool {
     cursor.group(delimiter).is_some()
 }
 
-mod private {
-    use super::{Token, TokenMarker};
-    pub trait Sealed: Copy {}
-    impl<F: Copy + FnOnce(TokenMarker) -> T, T: Token> Sealed for F {}
-}
+impl<F: Copy + FnOnce(TokenMarker) -> T, T: Token> Sealed for F {}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -469,7 +469,8 @@ impl<'a> ParseBuffer<'a> {
     ///
     /// - `input.peek(Token![struct])`
     /// - `input.peek(Token![==])`
-    /// - `input.peek(Ident)`
+    /// - `input.peek(Ident)`&emsp;*(does not accept keywords)*
+    /// - `input.peek(Ident::peek_any)`
     /// - `input.peek(Lifetime)`
     /// - `input.peek(token::Brace)`
     ///

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "parsing")]
+pub mod lookahead {
+    pub trait Sealed: Copy {}
+}


### PR DESCRIPTION
```rust
use syn::ext::IdentExt;

impl Parse for MySyntaxTree {
    fn parse(input: ParseStream) -> Result<Self> {
        if input.peek(Ident::parse_any) {...}

        unimplemented!()
    }
}
```

Fixes #522.