### PR TITLE
Split fold / visit / visit_mut codegen

### DIFF
--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -1,5 +1,4 @@
 use crate::{file, full, gen};
-use inflections::Inflect;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, TokenStreamExt};
 use syn::*;
@@ -13,12 +12,8 @@ struct State {
     fold_impl: TokenStream,
 }
 
-fn under_name(name: &str) -> Ident {
-    Ident::new(&name.to_snake_case(), Span::call_site())
-}
-
 fn simple_visit(item: &str, name: &TokenStream) -> TokenStream {
-    let ident = under_name(item);
+    let ident = gen::under_name(item);
     let method = Ident::new(&format!("fold_{}", ident), Span::call_site());
     quote! {
         _visitor.#method(#name)
@@ -118,7 +113,7 @@ fn visit_features(features: &types::Features) -> TokenStream {
 
 fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
     let features = visit_features(&s.features);
-    let under_name = under_name(&s.ident);
+    let under_name = gen::under_name(&s.ident);
     let ty = Ident::new(&s.ident, Span::call_site());
     let fold_fn = Ident::new(&format!("fold_{}", under_name), Span::call_site());
 

--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -1,4 +1,4 @@
-use crate::file;
+use crate::{file, full};
 use quote::quote;
 use syn_codegen as types;
 
@@ -328,22 +328,7 @@ pub fn generate(defs: &types::Definitions) {
         codegen::generate(&mut state, &s, defs);
     }
 
-    let full_macro = quote! {
-        #[cfg(feature = "full")]
-        macro_rules! full {
-            ($e:expr) => {
-                $e
-            };
-        }
-
-        #[cfg(all(feature = "derive", not(feature = "full")))]
-        macro_rules! full {
-            ($e:expr) => {
-                unreachable!()
-            };
-        }
-    };
-
+    let full_macro = full::get_macro();
     let fold_trait = state.fold_trait;
     let fold_impl = state.fold_impl;
     file::write(

--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -1,280 +1,259 @@
 use crate::{file, full, gen};
-use quote::quote;
+use inflections::Inflect;
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, TokenStreamExt};
+use syn::*;
 use syn_codegen as types;
 
 const FOLD_SRC: &str = "../src/gen/fold.rs";
 
-mod codegen {
-    use crate::gen;
-    use inflections::Inflect;
-    use proc_macro2::{Span, TokenStream};
-    use quote::{quote, TokenStreamExt};
-    use syn::*;
-    use syn_codegen as types;
+#[derive(Default)]
+struct State {
+    fold_trait: TokenStream,
+    fold_impl: TokenStream,
+}
 
-    #[derive(Default)]
-    pub struct State {
-        pub fold_trait: TokenStream,
-        pub fold_impl: TokenStream,
+fn under_name(name: &str) -> Ident {
+    Ident::new(&name.to_snake_case(), Span::call_site())
+}
+
+fn simple_visit(item: &str, name: &TokenStream) -> TokenStream {
+    let ident = under_name(item);
+
+    let method = Ident::new(&format!("fold_{}", ident), Span::call_site());
+    quote! {
+        _visitor.#method(#name)
+    }
+}
+
+fn box_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &TokenStream,
+) -> Option<TokenStream> {
+    let res = visit(elem, features, defs, &quote!(*#name))?;
+    Some(quote! {
+        Box::new(#res)
+    })
+}
+
+fn vec_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &TokenStream,
+) -> Option<TokenStream> {
+    let operand = quote!(it);
+    let val = visit(elem, features, defs, &operand)?;
+    Some(quote! {
+        FoldHelper::lift(#name, |it| { #val })
+    })
+}
+
+fn punctuated_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &TokenStream,
+) -> Option<TokenStream> {
+    let operand = quote!(it);
+    let val = visit(elem, features, defs, &operand)?;
+    Some(quote! {
+        FoldHelper::lift(#name, |it| { #val })
+    })
+}
+
+fn option_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &TokenStream,
+) -> Option<TokenStream> {
+    let it = quote!(it);
+    let val = visit(elem, features, defs, &it)?;
+    Some(quote! {
+        (#name).map(|it| { #val })
+    })
+}
+
+fn tuple_visit(
+    elems: &[types::Type],
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &TokenStream,
+) -> Option<TokenStream> {
+    if elems.is_empty() {
+        return None;
     }
 
-    fn under_name(name: &str) -> Ident {
-        Ident::new(&name.to_snake_case(), Span::call_site())
+    let mut code = TokenStream::new();
+    for (i, elem) in elems.iter().enumerate() {
+        let i = Index::from(i);
+        let it = quote!((#name).#i);
+        let val = visit(elem, features, defs, &it).unwrap_or(it);
+        code.append_all(val);
+        code.append_all(quote!(,));
     }
+    Some(quote! {
+        (#code)
+    })
+}
 
-    fn simple_visit(item: &str, name: &TokenStream) -> TokenStream {
-        let ident = under_name(item);
+fn token_punct_visit(repr: &str, name: &TokenStream) -> TokenStream {
+    let ty: TokenStream = syn::parse_str(&format!("Token![{}]", repr)).unwrap();
+    quote! {
+        #ty(tokens_helper(_visitor, &#name.spans))
+    }
+}
 
-        let method = Ident::new(&format!("fold_{}", ident), Span::call_site());
-        quote! {
-            _visitor.#method(#name)
+fn token_keyword_visit(repr: &str, name: &TokenStream) -> TokenStream {
+    let ty: TokenStream = syn::parse_str(&format!("Token![{}]", repr)).unwrap();
+    quote! {
+        #ty(tokens_helper(_visitor, &#name.span))
+    }
+}
+
+fn token_group_visit(ty: &str, name: &TokenStream) -> TokenStream {
+    let ty = Ident::new(ty, Span::call_site());
+    quote! {
+        #ty(tokens_helper(_visitor, &#name.span))
+    }
+}
+
+fn visit(
+    ty: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &TokenStream,
+) -> Option<TokenStream> {
+    match ty {
+        types::Type::Box(t) => box_visit(&*t, features, defs, name),
+        types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
+        types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
+        types::Type::Option(t) => option_visit(&*t, features, defs, name),
+        types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
+        types::Type::Token(t) => {
+            let repr = &defs.tokens[t];
+            let is_keyword = repr.chars().next().unwrap().is_alphabetic();
+            if is_keyword {
+                Some(token_keyword_visit(repr, name))
+            } else {
+                Some(token_punct_visit(repr, name))
+            }
         }
-    }
+        types::Type::Group(t) => Some(token_group_visit(&t[..], name)),
+        types::Type::Syn(t) => {
+            fn requires_full(features: &types::Features) -> bool {
+                features.any.contains("full") && features.any.len() == 1
+            }
 
-    fn box_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &TokenStream,
-    ) -> Option<TokenStream> {
-        let res = visit(elem, features, defs, &quote!(*#name))?;
-        Some(quote! {
-            Box::new(#res)
-        })
-    }
+            let res = simple_visit(t, name);
 
-    fn vec_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &TokenStream,
-    ) -> Option<TokenStream> {
-        let operand = quote!(it);
-        let val = visit(elem, features, defs, &operand)?;
-        Some(quote! {
-            FoldHelper::lift(#name, |it| { #val })
-        })
-    }
+            let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
 
-    fn punctuated_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &TokenStream,
-    ) -> Option<TokenStream> {
-        let operand = quote!(it);
-        let val = visit(elem, features, defs, &operand)?;
-        Some(quote! {
-            FoldHelper::lift(#name, |it| { #val })
-        })
-    }
-
-    fn option_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &TokenStream,
-    ) -> Option<TokenStream> {
-        let it = quote!(it);
-        let val = visit(elem, features, defs, &it)?;
-        Some(quote! {
-            (#name).map(|it| { #val })
-        })
-    }
-
-    fn tuple_visit(
-        elems: &[types::Type],
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &TokenStream,
-    ) -> Option<TokenStream> {
-        if elems.is_empty() {
-            return None;
-        }
-
-        let mut code = TokenStream::new();
-        for (i, elem) in elems.iter().enumerate() {
-            let i = Index::from(i);
-            let it = quote!((#name).#i);
-            let val = visit(elem, features, defs, &it).unwrap_or(it);
-            code.append_all(val);
-            code.append_all(quote!(,));
-        }
-        Some(quote! {
-            (#code)
-        })
-    }
-
-    fn token_punct_visit(repr: &str, name: &TokenStream) -> TokenStream {
-        let ty: TokenStream = syn::parse_str(&format!("Token![{}]", repr)).unwrap();
-        quote! {
-            #ty(tokens_helper(_visitor, &#name.spans))
-        }
-    }
-
-    fn token_keyword_visit(repr: &str, name: &TokenStream) -> TokenStream {
-        let ty: TokenStream = syn::parse_str(&format!("Token![{}]", repr)).unwrap();
-        quote! {
-            #ty(tokens_helper(_visitor, &#name.span))
-        }
-    }
-
-    fn token_group_visit(ty: &str, name: &TokenStream) -> TokenStream {
-        let ty = Ident::new(ty, Span::call_site());
-        quote! {
-            #ty(tokens_helper(_visitor, &#name.span))
-        }
-    }
-
-    fn visit(
-        ty: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &TokenStream,
-    ) -> Option<TokenStream> {
-        match ty {
-            types::Type::Box(t) => box_visit(&*t, features, defs, name),
-            types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
-            types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
-            types::Type::Option(t) => option_visit(&*t, features, defs, name),
-            types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
-            types::Type::Token(t) => {
-                let repr = &defs.tokens[t];
-                let is_keyword = repr.chars().next().unwrap().is_alphabetic();
-                if is_keyword {
-                    Some(token_keyword_visit(repr, name))
+            Some(
+                if requires_full(&target.features) && !requires_full(features) {
+                    quote! {
+                        full!(#res)
+                    }
                 } else {
-                    Some(token_punct_visit(repr, name))
-                }
-            }
-            types::Type::Group(t) => Some(token_group_visit(&t[..], name)),
-            types::Type::Syn(t) => {
-                fn requires_full(features: &types::Features) -> bool {
-                    features.any.contains("full") && features.any.len() == 1
-                }
-
-                let res = simple_visit(t, name);
-
-                let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
-
-                Some(
-                    if requires_full(&target.features) && !requires_full(features) {
-                        quote! {
-                            full!(#res)
-                        }
-                    } else {
-                        res
-                    },
-                )
-            }
-            types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => {
-                Some(simple_visit(t, name))
-            }
-            types::Type::Ext(_) | types::Type::Std(_) => None,
+                    res
+                },
+            )
         }
+        types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => Some(simple_visit(t, name)),
+        types::Type::Ext(_) | types::Type::Std(_) => None,
     }
+}
 
-    fn visit_features(features: &types::Features) -> TokenStream {
-        let features = &features.any;
-        match features.len() {
-            0 => quote!(),
-            1 => quote!(#[cfg(feature = #(#features)*)]),
-            _ => quote!(#[cfg(any(#(feature = #features),*))]),
-        }
+fn visit_features(features: &types::Features) -> TokenStream {
+    let features = &features.any;
+    match features.len() {
+        0 => quote!(),
+        1 => quote!(#[cfg(feature = #(#features)*)]),
+        _ => quote!(#[cfg(any(#(feature = #features),*))]),
     }
+}
 
-    pub fn generate(state: &mut State, s: &types::Node, defs: &types::Definitions) {
-        let features = visit_features(&s.features);
-        let under_name = under_name(&s.ident);
-        let ty = Ident::new(&s.ident, Span::call_site());
-        let fold_fn = Ident::new(&format!("fold_{}", under_name), Span::call_site());
+fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
+    let features = visit_features(&s.features);
+    let under_name = under_name(&s.ident);
+    let ty = Ident::new(&s.ident, Span::call_site());
+    let fold_fn = Ident::new(&format!("fold_{}", under_name), Span::call_site());
 
-        let mut fold_impl = TokenStream::new();
+    let mut fold_impl = TokenStream::new();
 
-        match &s.data {
-            types::Data::Enum(variants) => {
-                let mut fold_variants = TokenStream::new();
+    match &s.data {
+        types::Data::Enum(variants) => {
+            let mut fold_variants = TokenStream::new();
 
-                for (variant, fields) in variants {
-                    let variant_ident = Ident::new(variant, Span::call_site());
+            for (variant, fields) in variants {
+                let variant_ident = Ident::new(variant, Span::call_site());
 
-                    if fields.is_empty() {
-                        fold_variants.append_all(quote! {
-                            #ty::#variant_ident => {
-                                #ty::#variant_ident
-                            }
-                        });
-                    } else {
-                        let mut bind_fold_fields = TokenStream::new();
-                        let mut fold_fields = TokenStream::new();
-
-                        for (idx, ty) in fields.iter().enumerate() {
-                            let name = format!("_binding_{}", idx);
-                            let binding = Ident::new(&name, Span::call_site());
-
-                            bind_fold_fields.append_all(quote! {
-                                #binding,
-                            });
-
-                            let owned_binding = quote!(#binding);
-
-                            fold_fields.append_all(
-                                visit(ty, &s.features, defs, &owned_binding)
-                                    .unwrap_or(owned_binding),
-                            );
-
-                            fold_fields.append_all(quote!(,));
+                if fields.is_empty() {
+                    fold_variants.append_all(quote! {
+                        #ty::#variant_ident => {
+                            #ty::#variant_ident
                         }
+                    });
+                } else {
+                    let mut bind_fold_fields = TokenStream::new();
+                    let mut fold_fields = TokenStream::new();
 
-                        fold_variants.append_all(quote! {
-                            #ty::#variant_ident(#bind_fold_fields) => {
-                                #ty::#variant_ident(
-                                    #fold_fields
-                                )
-                            }
+                    for (idx, ty) in fields.iter().enumerate() {
+                        let name = format!("_binding_{}", idx);
+                        let binding = Ident::new(&name, Span::call_site());
+
+                        bind_fold_fields.append_all(quote! {
+                            #binding,
                         });
-                    }
-                }
 
-                fold_impl.append_all(quote! {
-                    match _i {
-                        #fold_variants
+                        let owned_binding = quote!(#binding);
+
+                        fold_fields.append_all(
+                            visit(ty, &s.features, defs, &owned_binding).unwrap_or(owned_binding),
+                        );
+
+                        fold_fields.append_all(quote!(,));
                     }
+
+                    fold_variants.append_all(quote! {
+                        #ty::#variant_ident(#bind_fold_fields) => {
+                            #ty::#variant_ident(
+                                #fold_fields
+                            )
+                        }
+                    });
+                }
+            }
+
+            fold_impl.append_all(quote! {
+                match _i {
+                    #fold_variants
+                }
+            });
+        }
+        types::Data::Struct(fields) => {
+            let mut fold_fields = TokenStream::new();
+
+            for (field, ty) in fields {
+                let id = Ident::new(&field, Span::call_site());
+                let ref_toks = quote!(_i.#id);
+                let fold = visit(&ty, &s.features, defs, &ref_toks).unwrap_or(ref_toks);
+
+                fold_fields.append_all(quote! {
+                    #id: #fold,
                 });
             }
-            types::Data::Struct(fields) => {
-                let mut fold_fields = TokenStream::new();
 
-                for (field, ty) in fields {
-                    let id = Ident::new(&field, Span::call_site());
-                    let ref_toks = quote!(_i.#id);
-                    let fold = visit(&ty, &s.features, defs, &ref_toks).unwrap_or(ref_toks);
-
-                    fold_fields.append_all(quote! {
-                        #id: #fold,
-                    });
-                }
-
-                if !fields.is_empty() {
-                    fold_impl.append_all(quote! {
-                        #ty {
-                            #fold_fields
-                        }
-                    })
-                } else {
-                    if ty == "Ident" {
-                        fold_impl.append_all(quote! {
-                            let mut _i = _i;
-                            let span = _visitor.fold_span(_i.span());
-                            _i.set_span(span);
-                        });
+            if !fields.is_empty() {
+                fold_impl.append_all(quote! {
+                    #ty {
+                        #fold_fields
                     }
-                    fold_impl.append_all(quote! {
-                        _i
-                    });
-                }
-            }
-            types::Data::Private => {
+                })
+            } else {
                 if ty == "Ident" {
                     fold_impl.append_all(quote! {
                         let mut _i = _i;
@@ -287,34 +266,46 @@ mod codegen {
                 });
             }
         }
-
-        let include_fold_impl = match &s.data {
-            types::Data::Private => gen::TERMINAL_TYPES.contains(&s.ident.as_str()),
-            types::Data::Struct(_) | types::Data::Enum(_) => true,
-        };
-
-        state.fold_trait.append_all(quote! {
-            #features
-            fn #fold_fn(&mut self, i: #ty) -> #ty {
-                #fold_fn(self, i)
+        types::Data::Private => {
+            if ty == "Ident" {
+                fold_impl.append_all(quote! {
+                    let mut _i = _i;
+                    let span = _visitor.fold_span(_i.span());
+                    _i.set_span(span);
+                });
             }
-        });
-
-        if include_fold_impl {
-            state.fold_impl.append_all(quote! {
-                #features
-                pub fn #fold_fn<V: Fold + ?Sized>(
-                    _visitor: &mut V, _i: #ty
-                ) -> #ty {
-                    #fold_impl
-                }
+            fold_impl.append_all(quote! {
+                _i
             });
         }
+    }
+
+    let include_fold_impl = match &s.data {
+        types::Data::Private => gen::TERMINAL_TYPES.contains(&s.ident.as_str()),
+        types::Data::Struct(_) | types::Data::Enum(_) => true,
+    };
+
+    state.fold_trait.append_all(quote! {
+        #features
+        fn #fold_fn(&mut self, i: #ty) -> #ty {
+            #fold_fn(self, i)
+        }
+    });
+
+    if include_fold_impl {
+        state.fold_impl.append_all(quote! {
+            #features
+            pub fn #fold_fn<V: Fold + ?Sized>(
+                _visitor: &mut V, _i: #ty
+            ) -> #ty {
+                #fold_impl
+            }
+        });
     }
 }
 
 pub fn generate(defs: &types::Definitions) {
-    let state = gen::traverse(defs, codegen::generate);
+    let state = gen::traverse(defs, node);
     let full_macro = full::get_macro();
     let fold_trait = state.fold_trait;
     let fold_impl = state.fold_impl;

--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -96,17 +96,7 @@ fn visit(
     }
 }
 
-fn visit_features(features: &Features) -> TokenStream {
-    let features = &features.any;
-    match features.len() {
-        0 => quote!(),
-        1 => quote!(#[cfg(feature = #(#features)*)]),
-        _ => quote!(#[cfg(any(#(feature = #features),*))]),
-    }
-}
-
 fn node(traits: &mut TokenStream, impls: &mut TokenStream, s: &Node, defs: &Definitions) {
-    let features = visit_features(&s.features);
     let under_name = gen::under_name(&s.ident);
     let ty = Ident::new(&s.ident, Span::call_site());
     let fold_fn = Ident::new(&format!("fold_{}", under_name), Span::call_site());
@@ -221,14 +211,12 @@ fn node(traits: &mut TokenStream, impls: &mut TokenStream, s: &Node, defs: &Defi
     }
 
     traits.extend(quote! {
-        #features
         fn #fold_fn(&mut self, i: #ty) -> #ty {
             #fold_fn(self, i)
         }
     });
 
     impls.extend(quote! {
-        #features
         pub fn #fold_fn<V: Fold + ?Sized>(
             _visitor: &mut V, _i: #ty
         ) -> #ty {

--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -1,0 +1,402 @@
+use crate::file;
+use quote::quote;
+use syn_codegen as types;
+
+const FOLD_SRC: &str = "../src/gen/fold.rs";
+
+mod codegen {
+    use inflections::Inflect;
+    use proc_macro2::{Span, TokenStream};
+    use quote::{quote, TokenStreamExt};
+    use syn::*;
+    use syn_codegen as types;
+
+    #[derive(Default)]
+    pub struct State {
+        pub fold_trait: TokenStream,
+        pub fold_impl: TokenStream,
+    }
+
+    fn under_name(name: &str) -> Ident {
+        Ident::new(&name.to_snake_case(), Span::call_site())
+    }
+
+    fn simple_visit(item: &str, name: &TokenStream) -> TokenStream {
+        let ident = under_name(item);
+
+        let method = Ident::new(&format!("fold_{}", ident), Span::call_site());
+        quote! {
+            _visitor.#method(#name)
+        }
+    }
+
+    fn box_visit(
+        elem: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &TokenStream,
+    ) -> Option<TokenStream> {
+        let res = visit(elem, features, defs, &quote!(*#name))?;
+        Some(quote! {
+            Box::new(#res)
+        })
+    }
+
+    fn vec_visit(
+        elem: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &TokenStream,
+    ) -> Option<TokenStream> {
+        let operand = quote!(it);
+        let val = visit(elem, features, defs, &operand)?;
+        Some(quote! {
+            FoldHelper::lift(#name, |it| { #val })
+        })
+    }
+
+    fn punctuated_visit(
+        elem: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &TokenStream,
+    ) -> Option<TokenStream> {
+        let operand = quote!(it);
+        let val = visit(elem, features, defs, &operand)?;
+        Some(quote! {
+            FoldHelper::lift(#name, |it| { #val })
+        })
+    }
+
+    fn option_visit(
+        elem: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &TokenStream,
+    ) -> Option<TokenStream> {
+        let it = quote!(it);
+        let val = visit(elem, features, defs, &it)?;
+        Some(quote! {
+            (#name).map(|it| { #val })
+        })
+    }
+
+    fn tuple_visit(
+        elems: &[types::Type],
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &TokenStream,
+    ) -> Option<TokenStream> {
+        if elems.is_empty() {
+            return None;
+        }
+
+        let mut code = TokenStream::new();
+        for (i, elem) in elems.iter().enumerate() {
+            let i = Index::from(i);
+            let it = quote!((#name).#i);
+            let val = visit(elem, features, defs, &it).unwrap_or(it);
+            code.append_all(val);
+            code.append_all(quote!(,));
+        }
+        Some(quote! {
+            (#code)
+        })
+    }
+
+    fn token_punct_visit(repr: &str, name: &TokenStream) -> TokenStream {
+        let ty: TokenStream = syn::parse_str(&format!("Token![{}]", repr)).unwrap();
+        quote! {
+            #ty(tokens_helper(_visitor, &#name.spans))
+        }
+    }
+
+    fn token_keyword_visit(repr: &str, name: &TokenStream) -> TokenStream {
+        let ty: TokenStream = syn::parse_str(&format!("Token![{}]", repr)).unwrap();
+        quote! {
+            #ty(tokens_helper(_visitor, &#name.span))
+        }
+    }
+
+    fn token_group_visit(ty: &str, name: &TokenStream) -> TokenStream {
+        let ty = Ident::new(ty, Span::call_site());
+        quote! {
+            #ty(tokens_helper(_visitor, &#name.span))
+        }
+    }
+
+    fn visit(
+        ty: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &TokenStream,
+    ) -> Option<TokenStream> {
+        match ty {
+            types::Type::Box(t) => box_visit(&*t, features, defs, name),
+            types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
+            types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
+            types::Type::Option(t) => option_visit(&*t, features, defs, name),
+            types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
+            types::Type::Token(t) => {
+                let repr = &defs.tokens[t];
+                let is_keyword = repr.chars().next().unwrap().is_alphabetic();
+                if is_keyword {
+                    Some(token_keyword_visit(repr, name))
+                } else {
+                    Some(token_punct_visit(repr, name))
+                }
+            }
+            types::Type::Group(t) => Some(token_group_visit(&t[..], name)),
+            types::Type::Syn(t) => {
+                fn requires_full(features: &types::Features) -> bool {
+                    features.any.contains("full") && features.any.len() == 1
+                }
+
+                let res = simple_visit(t, name);
+
+                let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
+
+                Some(
+                    if requires_full(&target.features) && !requires_full(features) {
+                        quote! {
+                            full!(#res)
+                        }
+                    } else {
+                        res
+                    },
+                )
+            }
+            types::Type::Ext(t) if super::TERMINAL_TYPES.contains(&&t[..]) => {
+                Some(simple_visit(t, name))
+            }
+            types::Type::Ext(_) | types::Type::Std(_) => None,
+        }
+    }
+
+    fn visit_features(features: &types::Features) -> TokenStream {
+        let features = &features.any;
+        match features.len() {
+            0 => quote!(),
+            1 => quote!(#[cfg(feature = #(#features)*)]),
+            _ => quote!(#[cfg(any(#(feature = #features),*))]),
+        }
+    }
+
+    pub fn generate(state: &mut State, s: &types::Node, defs: &types::Definitions) {
+        let features = visit_features(&s.features);
+        let under_name = under_name(&s.ident);
+        let ty = Ident::new(&s.ident, Span::call_site());
+        let fold_fn = Ident::new(&format!("fold_{}", under_name), Span::call_site());
+
+        let mut fold_impl = TokenStream::new();
+
+        match &s.data {
+            types::Data::Enum(variants) => {
+                let mut fold_variants = TokenStream::new();
+
+                for (variant, fields) in variants {
+                    let variant_ident = Ident::new(variant, Span::call_site());
+
+                    if fields.is_empty() {
+                        fold_variants.append_all(quote! {
+                            #ty::#variant_ident => {
+                                #ty::#variant_ident
+                            }
+                        });
+                    } else {
+                        let mut bind_fold_fields = TokenStream::new();
+                        let mut fold_fields = TokenStream::new();
+
+                        for (idx, ty) in fields.iter().enumerate() {
+                            let name = format!("_binding_{}", idx);
+                            let binding = Ident::new(&name, Span::call_site());
+
+                            bind_fold_fields.append_all(quote! {
+                                #binding,
+                            });
+
+                            let owned_binding = quote!(#binding);
+
+                            fold_fields.append_all(
+                                visit(ty, &s.features, defs, &owned_binding)
+                                    .unwrap_or(owned_binding),
+                            );
+
+                            fold_fields.append_all(quote!(,));
+                        }
+
+                        fold_variants.append_all(quote! {
+                            #ty::#variant_ident(#bind_fold_fields) => {
+                                #ty::#variant_ident(
+                                    #fold_fields
+                                )
+                            }
+                        });
+                    }
+                }
+
+                fold_impl.append_all(quote! {
+                    match _i {
+                        #fold_variants
+                    }
+                });
+            }
+            types::Data::Struct(fields) => {
+                let mut fold_fields = TokenStream::new();
+
+                for (field, ty) in fields {
+                    let id = Ident::new(&field, Span::call_site());
+                    let ref_toks = quote!(_i.#id);
+                    let fold = visit(&ty, &s.features, defs, &ref_toks).unwrap_or(ref_toks);
+
+                    fold_fields.append_all(quote! {
+                        #id: #fold,
+                    });
+                }
+
+                if !fields.is_empty() {
+                    fold_impl.append_all(quote! {
+                        #ty {
+                            #fold_fields
+                        }
+                    })
+                } else {
+                    if ty == "Ident" {
+                        fold_impl.append_all(quote! {
+                            let mut _i = _i;
+                            let span = _visitor.fold_span(_i.span());
+                            _i.set_span(span);
+                        });
+                    }
+                    fold_impl.append_all(quote! {
+                        _i
+                    });
+                }
+            }
+            types::Data::Private => {
+                if ty == "Ident" {
+                    fold_impl.append_all(quote! {
+                        let mut _i = _i;
+                        let span = _visitor.fold_span(_i.span());
+                        _i.set_span(span);
+                    });
+                }
+                fold_impl.append_all(quote! {
+                    _i
+                });
+            }
+        }
+
+        let include_fold_impl = match &s.data {
+            types::Data::Private => super::TERMINAL_TYPES.contains(&s.ident.as_str()),
+            types::Data::Struct(_) | types::Data::Enum(_) => true,
+        };
+
+        state.fold_trait.append_all(quote! {
+            #features
+            fn #fold_fn(&mut self, i: #ty) -> #ty {
+                #fold_fn(self, i)
+            }
+        });
+
+        if include_fold_impl {
+            state.fold_impl.append_all(quote! {
+                #features
+                pub fn #fold_fn<V: Fold + ?Sized>(
+                    _visitor: &mut V, _i: #ty
+                ) -> #ty {
+                    #fold_impl
+                }
+            });
+        }
+    }
+}
+
+const TERMINAL_TYPES: &[&str] = &["Span", "Ident"];
+
+pub fn generate(defs: &types::Definitions) {
+    let mut state = codegen::State::default();
+    for s in &defs.types {
+        codegen::generate(&mut state, s, defs);
+    }
+    for tt in TERMINAL_TYPES {
+        let s = types::Node {
+            ident: tt.to_string(),
+            features: types::Features::default(),
+            data: types::Data::Private,
+        };
+        codegen::generate(&mut state, &s, defs);
+    }
+
+    let full_macro = quote! {
+        #[cfg(feature = "full")]
+        macro_rules! full {
+            ($e:expr) => {
+                $e
+            };
+        }
+
+        #[cfg(all(feature = "derive", not(feature = "full")))]
+        macro_rules! full {
+            ($e:expr) => {
+                unreachable!()
+            };
+        }
+    };
+
+    let fold_trait = state.fold_trait;
+    let fold_impl = state.fold_impl;
+    file::write(
+        FOLD_SRC,
+        quote! {
+            // Unreachable code is generated sometimes without the full feature.
+            #![allow(unreachable_code)]
+
+            use *;
+            #[cfg(any(feature = "full", feature = "derive"))]
+            use token::{Brace, Bracket, Paren, Group};
+            use proc_macro2::Span;
+            #[cfg(any(feature = "full", feature = "derive"))]
+            use gen::helper::fold::*;
+
+            #full_macro
+
+            /// Syntax tree traversal to transform the nodes of an owned syntax tree.
+            ///
+            /// See the [module documentation] for details.
+            ///
+            /// [module documentation]: index.html
+            ///
+            /// *This trait is available if Syn is built with the `"fold"` feature.*
+            pub trait Fold {
+                #fold_trait
+            }
+
+            #[cfg(any(feature = "full", feature = "derive"))]
+            macro_rules! fold_span_only {
+                ($f:ident : $t:ident) => {
+                    pub fn $f<V: Fold + ?Sized>(_visitor: &mut V, mut _i: $t) -> $t {
+                        let span = _visitor.fold_span(_i.span());
+                        _i.set_span(span);
+                        _i
+                    }
+                }
+            }
+
+            #[cfg(any(feature = "full", feature = "derive"))]
+            fold_span_only!(fold_lit_byte: LitByte);
+            #[cfg(any(feature = "full", feature = "derive"))]
+            fold_span_only!(fold_lit_byte_str: LitByteStr);
+            #[cfg(any(feature = "full", feature = "derive"))]
+            fold_span_only!(fold_lit_char: LitChar);
+            #[cfg(any(feature = "full", feature = "derive"))]
+            fold_span_only!(fold_lit_float: LitFloat);
+            #[cfg(any(feature = "full", feature = "derive"))]
+            fold_span_only!(fold_lit_int: LitInt);
+            #[cfg(any(feature = "full", feature = "derive"))]
+            fold_span_only!(fold_lit_str: LitStr);
+
+            #fold_impl
+        },
+    );
+}

--- a/codegen/src/full.rs
+++ b/codegen/src/full.rs
@@ -1,0 +1,20 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub fn get_macro() -> TokenStream {
+    quote! {
+        #[cfg(feature = "full")]
+        macro_rules! full {
+            ($e:expr) => {
+                $e
+            };
+        }
+
+        #[cfg(all(feature = "derive", not(feature = "full")))]
+        macro_rules! full {
+            ($e:expr) => {
+                unreachable!()
+            };
+        }
+    }
+}

--- a/codegen/src/gen.rs
+++ b/codegen/src/gen.rs
@@ -1,0 +1,23 @@
+use syn_codegen as types;
+
+pub const TERMINAL_TYPES: &[&str] = &["Span", "Ident"];
+
+pub fn traverse<S, F>(defs: &types::Definitions, generate: F) -> S
+where
+    S: Default,
+    F: Fn(&mut S, &types::Node, &types::Definitions),
+{
+    let mut state = S::default();
+    for s in &defs.types {
+        generate(&mut state, s, defs);
+    }
+    for tt in TERMINAL_TYPES {
+        let s = types::Node {
+            ident: tt.to_string(),
+            features: types::Features::default(),
+            data: types::Data::Private,
+        };
+        generate(&mut state, &s, defs);
+    }
+    state
+}

--- a/codegen/src/gen.rs
+++ b/codegen/src/gen.rs
@@ -1,6 +1,6 @@
 use inflections::Inflect;
-use proc_macro2::{Ident, Span};
-use syn_codegen as types;
+use proc_macro2::{Ident, Span, TokenStream};
+use syn_codegen::{Data, Features, Definitions, Node};
 
 pub const TERMINAL_TYPES: &[&str] = &["Span", "Ident"];
 
@@ -8,22 +8,22 @@ pub fn under_name(name: &str) -> Ident {
     Ident::new(&name.to_snake_case(), Span::call_site())
 }
 
-pub fn traverse<S, F>(defs: &types::Definitions, node: F) -> S
-where
-    S: Default,
-    F: Fn(&mut S, &types::Node, &types::Definitions),
-{
-    let mut state = S::default();
+pub fn traverse(
+    defs: &Definitions,
+    node: fn(&mut TokenStream, &mut TokenStream, &Node, &Definitions),
+) -> (TokenStream, TokenStream) {
+    let mut traits = TokenStream::new();
+    let mut impls = TokenStream::new();
     for s in &defs.types {
-        node(&mut state, s, defs);
+        node(&mut traits, &mut impls, s, defs);
     }
     for tt in TERMINAL_TYPES {
-        let s = types::Node {
+        let s = Node {
             ident: tt.to_string(),
-            features: types::Features::default(),
-            data: types::Data::Private,
+            features: Features::default(),
+            data: Data::Private,
         };
-        node(&mut state, &s, defs);
+        node(&mut traits, &mut impls, &s, defs);
     }
-    state
+    (traits, impls)
 }

--- a/codegen/src/gen.rs
+++ b/codegen/src/gen.rs
@@ -2,14 +2,14 @@ use syn_codegen as types;
 
 pub const TERMINAL_TYPES: &[&str] = &["Span", "Ident"];
 
-pub fn traverse<S, F>(defs: &types::Definitions, generate: F) -> S
+pub fn traverse<S, F>(defs: &types::Definitions, node: F) -> S
 where
     S: Default,
     F: Fn(&mut S, &types::Node, &types::Definitions),
 {
     let mut state = S::default();
     for s in &defs.types {
-        generate(&mut state, s, defs);
+        node(&mut state, s, defs);
     }
     for tt in TERMINAL_TYPES {
         let s = types::Node {
@@ -17,7 +17,7 @@ where
             features: types::Features::default(),
             data: types::Data::Private,
         };
-        generate(&mut state, &s, defs);
+        node(&mut state, &s, defs);
     }
     state
 }

--- a/codegen/src/gen.rs
+++ b/codegen/src/gen.rs
@@ -1,6 +1,12 @@
+use inflections::Inflect;
+use proc_macro2::{Ident, Span};
 use syn_codegen as types;
 
 pub const TERMINAL_TYPES: &[&str] = &["Span", "Ident"];
+
+pub fn under_name(name: &str) -> Ident {
+    Ident::new(&name.to_snake_case(), Span::call_site())
+}
 
 pub fn traverse<S, F>(defs: &types::Definitions, node: F) -> S
 where

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -15,6 +15,7 @@
 mod file;
 mod fold;
 mod full;
+mod gen;
 mod json;
 mod parse;
 mod version;

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -14,14 +14,16 @@
 
 mod file;
 mod fold;
-mod gen;
 mod json;
 mod parse;
 mod version;
+mod visit;
+mod visit_mut;
 
 fn main() {
     let defs = parse::parse();
     json::generate(&defs);
-    gen::generate(&defs);
     fold::generate(&defs);
+    visit::generate(&defs);
+    visit_mut::generate(&defs);
 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -14,6 +14,7 @@
 
 mod file;
 mod fold;
+mod full;
 mod json;
 mod parse;
 mod version;

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::needless_pass_by_value)]
 
 mod file;
+mod fold;
 mod gen;
 mod json;
 mod parse;
@@ -22,4 +23,5 @@ fn main() {
     let defs = parse::parse();
     json::generate(&defs);
     gen::generate(&defs);
+    fold::generate(&defs);
 }

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -17,6 +17,7 @@ mod fold;
 mod full;
 mod gen;
 mod json;
+mod operand;
 mod parse;
 mod version;
 mod visit;

--- a/codegen/src/operand.rs
+++ b/codegen/src/operand.rs
@@ -1,0 +1,38 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub enum Operand {
+    Borrowed(TokenStream),
+    Owned(TokenStream),
+}
+
+pub use self::Operand::*;
+
+impl Operand {
+    pub fn tokens(&self) -> &TokenStream {
+        match self {
+            Borrowed(n) | Owned(n) => n,
+        }
+    }
+
+    pub fn ref_tokens(&self) -> TokenStream {
+        match self {
+            Borrowed(n) => n.clone(),
+            Owned(n) => quote!(&#n),
+        }
+    }
+
+    pub fn ref_mut_tokens(&self) -> TokenStream {
+        match self {
+            Borrowed(n) => n.clone(),
+            Owned(n) => quote!(&mut #n),
+        }
+    }
+
+    pub fn owned_tokens(&self) -> TokenStream {
+        match self {
+            Borrowed(n) => quote!(*#n),
+            Owned(n) => n.clone(),
+        }
+    }
+}

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -1,321 +1,313 @@
 use crate::{file, full, gen};
-use quote::quote;
+use inflections::Inflect;
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, TokenStreamExt};
+use syn::*;
 use syn_codegen as types;
 
 const VISIT_SRC: &str = "../src/gen/visit.rs";
 
-mod codegen {
-    use crate::gen;
-    use inflections::Inflect;
-    use proc_macro2::{Span, TokenStream};
-    use quote::{quote, TokenStreamExt};
-    use syn::*;
-    use syn_codegen as types;
+#[derive(Default)]
+struct State {
+    visit_trait: TokenStream,
+    visit_impl: TokenStream,
+}
 
-    #[derive(Default)]
-    pub struct State {
-        pub visit_trait: TokenStream,
-        pub visit_impl: TokenStream,
-    }
+fn under_name(name: &str) -> Ident {
+    Ident::new(&name.to_snake_case(), Span::call_site())
+}
 
-    fn under_name(name: &str) -> Ident {
-        Ident::new(&name.to_snake_case(), Span::call_site())
-    }
+enum Operand {
+    Borrowed(TokenStream),
+    Owned(TokenStream),
+}
 
-    enum Operand {
-        Borrowed(TokenStream),
-        Owned(TokenStream),
-    }
+use self::Operand::*;
 
-    use self::Operand::*;
-
-    impl Operand {
-        fn tokens(&self) -> &TokenStream {
-            match *self {
-                Borrowed(ref n) | Owned(ref n) => n,
-            }
-        }
-
-        fn ref_tokens(&self) -> TokenStream {
-            match *self {
-                Borrowed(ref n) => n.clone(),
-                Owned(ref n) => quote!(&#n),
-            }
-        }
-
-        fn owned_tokens(&self) -> TokenStream {
-            match *self {
-                Borrowed(ref n) => quote!(*#n),
-                Owned(ref n) => n.clone(),
-            }
+impl Operand {
+    fn tokens(&self) -> &TokenStream {
+        match *self {
+            Borrowed(ref n) | Owned(ref n) => n,
         }
     }
 
-    fn simple_visit(item: &str, name: &Operand) -> TokenStream {
-        let ident = under_name(item);
-        let method = Ident::new(&format!("visit_{}", ident), Span::call_site());
-        let name = name.ref_tokens();
-        quote! {
-            _visitor.#method(#name)
+    fn ref_tokens(&self) -> TokenStream {
+        match *self {
+            Borrowed(ref n) => n.clone(),
+            Owned(ref n) => quote!(&#n),
         }
     }
 
-    fn box_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        let name = name.owned_tokens();
-        let res = visit(elem, features, defs, &Owned(quote!(*#name)))?;
-        Some(res)
-    }
-
-    fn vec_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        let operand = Borrowed(quote!(it));
-        let val = visit(elem, features, defs, &operand)?;
-        let name = name.ref_tokens();
-        Some(quote! {
-            for it in #name {
-                #val
-            }
-        })
-    }
-
-    fn punctuated_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        let operand = Borrowed(quote!(it));
-        let val = visit(elem, features, defs, &operand)?;
-        let name = name.ref_tokens();
-        Some(quote! {
-            for el in Punctuated::pairs(#name) {
-                let it = el.value();
-                #val
-            }
-        })
-    }
-
-    fn option_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        let it = Borrowed(quote!(it));
-        let val = visit(elem, features, defs, &it)?;
-        let name = name.owned_tokens();
-        Some(quote! {
-            if let Some(ref it) = #name {
-                #val
-            }
-        })
-    }
-
-    fn tuple_visit(
-        elems: &[types::Type],
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        if elems.is_empty() {
-            return None;
+    fn owned_tokens(&self) -> TokenStream {
+        match *self {
+            Borrowed(ref n) => quote!(*#n),
+            Owned(ref n) => n.clone(),
         }
-
-        let mut code = TokenStream::new();
-        for (i, elem) in elems.iter().enumerate() {
-            let name = name.tokens();
-            let i = Index::from(i);
-            let it = Owned(quote!((#name).#i));
-            let val = visit(elem, features, defs, &it).unwrap_or_else(|| noop_visit(&it));
-            code.append_all(val);
-            code.append_all(quote!(;));
-        }
-        Some(code)
-    }
-
-    fn token_punct_visit(name: &Operand) -> TokenStream {
-        let name = name.tokens();
-        quote! {
-            tokens_helper(_visitor, &#name.spans)
-        }
-    }
-
-    fn token_keyword_visit(name: &Operand) -> TokenStream {
-        let name = name.tokens();
-        quote! {
-            tokens_helper(_visitor, &#name.span)
-        }
-    }
-
-    fn token_group_visit(name: &Operand) -> TokenStream {
-        let name = name.tokens();
-        quote! {
-            tokens_helper(_visitor, &#name.span)
-        }
-    }
-
-    fn noop_visit(name: &Operand) -> TokenStream {
-        let name = name.tokens();
-        quote! {
-            skip!(#name)
-        }
-    }
-
-    fn visit(
-        ty: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        match ty {
-            types::Type::Box(t) => box_visit(&*t, features, defs, name),
-            types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
-            types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
-            types::Type::Option(t) => option_visit(&*t, features, defs, name),
-            types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
-            types::Type::Token(t) => {
-                let repr = &defs.tokens[t];
-                let is_keyword = repr.chars().next().unwrap().is_alphabetic();
-                if is_keyword {
-                    Some(token_keyword_visit(name))
-                } else {
-                    Some(token_punct_visit(name))
-                }
-            }
-            types::Type::Group(_) => Some(token_group_visit(name)),
-            types::Type::Syn(t) => {
-                fn requires_full(features: &types::Features) -> bool {
-                    features.any.contains("full") && features.any.len() == 1
-                }
-
-                let res = simple_visit(t, name);
-
-                let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
-
-                Some(
-                    if requires_full(&target.features) && !requires_full(features) {
-                        quote! {
-                            full!(#res)
-                        }
-                    } else {
-                        res
-                    },
-                )
-            }
-            types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => {
-                Some(simple_visit(t, name))
-            }
-            types::Type::Ext(_) | types::Type::Std(_) => None,
-        }
-    }
-
-    fn visit_features(features: &types::Features) -> TokenStream {
-        let features = &features.any;
-        match features.len() {
-            0 => quote!(),
-            1 => quote!(#[cfg(feature = #(#features)*)]),
-            _ => quote!(#[cfg(any(#(feature = #features),*))]),
-        }
-    }
-
-    pub fn generate(state: &mut State, s: &types::Node, defs: &types::Definitions) {
-        let features = visit_features(&s.features);
-        let under_name = under_name(&s.ident);
-        let ty = Ident::new(&s.ident, Span::call_site());
-        let visit_fn = Ident::new(&format!("visit_{}", under_name), Span::call_site());
-
-        let mut visit_impl = TokenStream::new();
-
-        match &s.data {
-            types::Data::Enum(variants) => {
-                let mut visit_variants = TokenStream::new();
-
-                for (variant, fields) in variants {
-                    let variant_ident = Ident::new(variant, Span::call_site());
-
-                    if fields.is_empty() {
-                        visit_variants.append_all(quote! {
-                            #ty::#variant_ident => {}
-                        });
-                    } else {
-                        let mut bind_visit_fields = TokenStream::new();
-                        let mut visit_fields = TokenStream::new();
-
-                        for (idx, ty) in fields.iter().enumerate() {
-                            let name = format!("_binding_{}", idx);
-                            let binding = Ident::new(&name, Span::call_site());
-
-                            bind_visit_fields.append_all(quote! {
-                                ref #binding,
-                            });
-
-                            let borrowed_binding = Borrowed(quote!(#binding));
-
-                            visit_fields.append_all(
-                                visit(ty, &s.features, defs, &borrowed_binding)
-                                    .unwrap_or_else(|| noop_visit(&borrowed_binding)),
-                            );
-
-                            visit_fields.append_all(quote!(;));
-                        }
-
-                        visit_variants.append_all(quote! {
-                            #ty::#variant_ident(#bind_visit_fields) => {
-                                #visit_fields
-                            }
-                        });
-                    }
-                }
-
-                visit_impl.append_all(quote! {
-                    match *_i {
-                        #visit_variants
-                    }
-                });
-            }
-            types::Data::Struct(fields) => {
-                for (field, ty) in fields {
-                    let id = Ident::new(&field, Span::call_site());
-                    let ref_toks = Owned(quote!(_i.#id));
-                    let visit_field = visit(&ty, &s.features, defs, &ref_toks)
-                        .unwrap_or_else(|| noop_visit(&ref_toks));
-                    visit_impl.append_all(quote! {
-                        #visit_field;
-                    });
-                }
-            }
-            types::Data::Private => {}
-        }
-
-        state.visit_trait.append_all(quote! {
-            #features
-            fn #visit_fn(&mut self, i: &'ast #ty) {
-                #visit_fn(self, i)
-            }
-        });
-
-        state.visit_impl.append_all(quote! {
-            #features
-            pub fn #visit_fn<'ast, V: Visit<'ast> + ?Sized>(
-                _visitor: &mut V, _i: &'ast #ty
-            ) {
-                #visit_impl
-            }
-        });
     }
 }
 
+fn simple_visit(item: &str, name: &Operand) -> TokenStream {
+    let ident = under_name(item);
+    let method = Ident::new(&format!("visit_{}", ident), Span::call_site());
+    let name = name.ref_tokens();
+    quote! {
+        _visitor.#method(#name)
+    }
+}
+
+fn box_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    let name = name.owned_tokens();
+    let res = visit(elem, features, defs, &Owned(quote!(*#name)))?;
+    Some(res)
+}
+
+fn vec_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    let operand = Borrowed(quote!(it));
+    let val = visit(elem, features, defs, &operand)?;
+    let name = name.ref_tokens();
+    Some(quote! {
+        for it in #name {
+            #val
+        }
+    })
+}
+
+fn punctuated_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    let operand = Borrowed(quote!(it));
+    let val = visit(elem, features, defs, &operand)?;
+    let name = name.ref_tokens();
+    Some(quote! {
+        for el in Punctuated::pairs(#name) {
+            let it = el.value();
+            #val
+        }
+    })
+}
+
+fn option_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    let it = Borrowed(quote!(it));
+    let val = visit(elem, features, defs, &it)?;
+    let name = name.owned_tokens();
+    Some(quote! {
+        if let Some(ref it) = #name {
+            #val
+        }
+    })
+}
+
+fn tuple_visit(
+    elems: &[types::Type],
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    if elems.is_empty() {
+        return None;
+    }
+
+    let mut code = TokenStream::new();
+    for (i, elem) in elems.iter().enumerate() {
+        let name = name.tokens();
+        let i = Index::from(i);
+        let it = Owned(quote!((#name).#i));
+        let val = visit(elem, features, defs, &it).unwrap_or_else(|| noop_visit(&it));
+        code.append_all(val);
+        code.append_all(quote!(;));
+    }
+    Some(code)
+}
+
+fn token_punct_visit(name: &Operand) -> TokenStream {
+    let name = name.tokens();
+    quote! {
+        tokens_helper(_visitor, &#name.spans)
+    }
+}
+
+fn token_keyword_visit(name: &Operand) -> TokenStream {
+    let name = name.tokens();
+    quote! {
+        tokens_helper(_visitor, &#name.span)
+    }
+}
+
+fn token_group_visit(name: &Operand) -> TokenStream {
+    let name = name.tokens();
+    quote! {
+        tokens_helper(_visitor, &#name.span)
+    }
+}
+
+fn noop_visit(name: &Operand) -> TokenStream {
+    let name = name.tokens();
+    quote! {
+        skip!(#name)
+    }
+}
+
+fn visit(
+    ty: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    match ty {
+        types::Type::Box(t) => box_visit(&*t, features, defs, name),
+        types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
+        types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
+        types::Type::Option(t) => option_visit(&*t, features, defs, name),
+        types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
+        types::Type::Token(t) => {
+            let repr = &defs.tokens[t];
+            let is_keyword = repr.chars().next().unwrap().is_alphabetic();
+            if is_keyword {
+                Some(token_keyword_visit(name))
+            } else {
+                Some(token_punct_visit(name))
+            }
+        }
+        types::Type::Group(_) => Some(token_group_visit(name)),
+        types::Type::Syn(t) => {
+            fn requires_full(features: &types::Features) -> bool {
+                features.any.contains("full") && features.any.len() == 1
+            }
+
+            let res = simple_visit(t, name);
+
+            let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
+
+            Some(
+                if requires_full(&target.features) && !requires_full(features) {
+                    quote! {
+                        full!(#res)
+                    }
+                } else {
+                    res
+                },
+            )
+        }
+        types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => Some(simple_visit(t, name)),
+        types::Type::Ext(_) | types::Type::Std(_) => None,
+    }
+}
+
+fn visit_features(features: &types::Features) -> TokenStream {
+    let features = &features.any;
+    match features.len() {
+        0 => quote!(),
+        1 => quote!(#[cfg(feature = #(#features)*)]),
+        _ => quote!(#[cfg(any(#(feature = #features),*))]),
+    }
+}
+
+fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
+    let features = visit_features(&s.features);
+    let under_name = under_name(&s.ident);
+    let ty = Ident::new(&s.ident, Span::call_site());
+    let visit_fn = Ident::new(&format!("visit_{}", under_name), Span::call_site());
+
+    let mut visit_impl = TokenStream::new();
+
+    match &s.data {
+        types::Data::Enum(variants) => {
+            let mut visit_variants = TokenStream::new();
+
+            for (variant, fields) in variants {
+                let variant_ident = Ident::new(variant, Span::call_site());
+
+                if fields.is_empty() {
+                    visit_variants.append_all(quote! {
+                        #ty::#variant_ident => {}
+                    });
+                } else {
+                    let mut bind_visit_fields = TokenStream::new();
+                    let mut visit_fields = TokenStream::new();
+
+                    for (idx, ty) in fields.iter().enumerate() {
+                        let name = format!("_binding_{}", idx);
+                        let binding = Ident::new(&name, Span::call_site());
+
+                        bind_visit_fields.append_all(quote! {
+                            ref #binding,
+                        });
+
+                        let borrowed_binding = Borrowed(quote!(#binding));
+
+                        visit_fields.append_all(
+                            visit(ty, &s.features, defs, &borrowed_binding)
+                                .unwrap_or_else(|| noop_visit(&borrowed_binding)),
+                        );
+
+                        visit_fields.append_all(quote!(;));
+                    }
+
+                    visit_variants.append_all(quote! {
+                        #ty::#variant_ident(#bind_visit_fields) => {
+                            #visit_fields
+                        }
+                    });
+                }
+            }
+
+            visit_impl.append_all(quote! {
+                match *_i {
+                    #visit_variants
+                }
+            });
+        }
+        types::Data::Struct(fields) => {
+            for (field, ty) in fields {
+                let id = Ident::new(&field, Span::call_site());
+                let ref_toks = Owned(quote!(_i.#id));
+                let visit_field = visit(&ty, &s.features, defs, &ref_toks)
+                    .unwrap_or_else(|| noop_visit(&ref_toks));
+                visit_impl.append_all(quote! {
+                    #visit_field;
+                });
+            }
+        }
+        types::Data::Private => {}
+    }
+
+    state.visit_trait.append_all(quote! {
+        #features
+        fn #visit_fn(&mut self, i: &'ast #ty) {
+            #visit_fn(self, i)
+        }
+    });
+
+    state.visit_impl.append_all(quote! {
+        #features
+        pub fn #visit_fn<'ast, V: Visit<'ast> + ?Sized>(
+            _visitor: &mut V, _i: &'ast #ty
+        ) {
+            #visit_impl
+        }
+    });
+}
+
 pub fn generate(defs: &types::Definitions) {
-    let state = gen::traverse(defs, codegen::generate);
+    let state = gen::traverse(defs, node);
     let full_macro = full::get_macro();
     let visit_trait = state.visit_trait;
     let visit_impl = state.visit_impl;

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -1,3 +1,4 @@
+use crate::operand::*;
 use crate::{file, full, gen};
 use inflections::Inflect;
 use proc_macro2::{Span, TokenStream};
@@ -15,35 +16,6 @@ struct State {
 
 fn under_name(name: &str) -> Ident {
     Ident::new(&name.to_snake_case(), Span::call_site())
-}
-
-enum Operand {
-    Borrowed(TokenStream),
-    Owned(TokenStream),
-}
-
-use self::Operand::*;
-
-impl Operand {
-    fn tokens(&self) -> &TokenStream {
-        match self {
-            Borrowed(n) | Owned(n) => n,
-        }
-    }
-
-    fn ref_tokens(&self) -> TokenStream {
-        match self {
-            Borrowed(n) => n.clone(),
-            Owned(n) => quote!(&#n),
-        }
-    }
-
-    fn owned_tokens(&self) -> TokenStream {
-        match self {
-            Borrowed(n) => quote!(*#n),
-            Owned(n) => n.clone(),
-        }
-    }
 }
 
 fn simple_visit(item: &str, name: &Operand) -> TokenStream {

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -26,22 +26,22 @@ use self::Operand::*;
 
 impl Operand {
     fn tokens(&self) -> &TokenStream {
-        match *self {
-            Borrowed(ref n) | Owned(ref n) => n,
+        match self {
+            Borrowed(n) | Owned(n) => n,
         }
     }
 
     fn ref_tokens(&self) -> TokenStream {
-        match *self {
-            Borrowed(ref n) => n.clone(),
-            Owned(ref n) => quote!(&#n),
+        match self {
+            Borrowed(n) => n.clone(),
+            Owned(n) => quote!(&#n),
         }
     }
 
     fn owned_tokens(&self) -> TokenStream {
-        match *self {
-            Borrowed(ref n) => quote!(*#n),
-            Owned(ref n) => n.clone(),
+        match self {
+            Borrowed(n) => quote!(*#n),
+            Owned(n) => n.clone(),
         }
     }
 }

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -112,17 +112,7 @@ fn visit(
     }
 }
 
-fn visit_features(features: &Features) -> TokenStream {
-    let features = &features.any;
-    match features.len() {
-        0 => quote!(),
-        1 => quote!(#[cfg(feature = #(#features)*)]),
-        _ => quote!(#[cfg(any(#(feature = #features),*))]),
-    }
-}
-
 fn node(traits: &mut TokenStream, impls: &mut TokenStream, s: &Node, defs: &Definitions) {
-    let features = visit_features(&s.features);
     let under_name = gen::under_name(&s.ident);
     let ty = Ident::new(&s.ident, Span::call_site());
     let visit_fn = Ident::new(&format!("visit_{}", under_name), Span::call_site());
@@ -191,14 +181,12 @@ fn node(traits: &mut TokenStream, impls: &mut TokenStream, s: &Node, defs: &Defi
     }
 
     traits.extend(quote! {
-        #features
         fn #visit_fn(&mut self, i: &'ast #ty) {
             #visit_fn(self, i)
         }
     });
 
     impls.extend(quote! {
-        #features
         pub fn #visit_fn<'ast, V: Visit<'ast> + ?Sized>(
             _visitor: &mut V, _i: &'ast #ty
         ) {

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -1,6 +1,5 @@
 use crate::operand::*;
 use crate::{file, full, gen};
-use inflections::Inflect;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, TokenStreamExt};
 use syn::*;
@@ -14,12 +13,8 @@ struct State {
     visit_impl: TokenStream,
 }
 
-fn under_name(name: &str) -> Ident {
-    Ident::new(&name.to_snake_case(), Span::call_site())
-}
-
 fn simple_visit(item: &str, name: &Operand) -> TokenStream {
-    let ident = under_name(item);
+    let ident = gen::under_name(item);
     let method = Ident::new(&format!("visit_{}", ident), Span::call_site());
     let name = name.ref_tokens();
     quote! {
@@ -134,7 +129,7 @@ fn visit_features(features: &types::Features) -> TokenStream {
 
 fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
     let features = visit_features(&s.features);
-    let under_name = under_name(&s.ident);
+    let under_name = gen::under_name(&s.ident);
     let ty = Ident::new(&s.ident, Span::call_site());
     let visit_fn = Ident::new(&format!("visit_{}", under_name), Span::call_site());
 

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -1,6 +1,5 @@
 use crate::operand::*;
 use crate::{file, full, gen};
-use inflections::Inflect;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, TokenStreamExt};
 use syn::*;
@@ -14,12 +13,8 @@ struct State {
     visit_mut_impl: TokenStream,
 }
 
-fn under_name(name: &str) -> Ident {
-    Ident::new(&name.to_snake_case(), Span::call_site())
-}
-
 fn simple_visit(item: &str, name: &Operand) -> TokenStream {
-    let ident = under_name(item);
+    let ident = gen::under_name(item);
     let method = Ident::new(&format!("visit_{}_mut", ident), Span::call_site());
     let name = name.ref_mut_tokens();
     quote! {
@@ -134,7 +129,7 @@ fn visit_features(features: &types::Features) -> TokenStream {
 
 fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
     let features = visit_features(&s.features);
-    let under_name = under_name(&s.ident);
+    let under_name = gen::under_name(&s.ident);
     let ty = Ident::new(&s.ident, Span::call_site());
     let visit_mut_fn = Ident::new(&format!("visit_{}_mut", under_name), Span::call_site());
 

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -1,3 +1,4 @@
+use crate::operand::*;
 use crate::{file, full, gen};
 use inflections::Inflect;
 use proc_macro2::{Span, TokenStream};
@@ -15,35 +16,6 @@ struct State {
 
 fn under_name(name: &str) -> Ident {
     Ident::new(&name.to_snake_case(), Span::call_site())
-}
-
-enum Operand {
-    Borrowed(TokenStream),
-    Owned(TokenStream),
-}
-
-use self::Operand::*;
-
-impl Operand {
-    fn tokens(&self) -> &TokenStream {
-        match self {
-            Borrowed(n) | Owned(n) => n,
-        }
-    }
-
-    fn ref_mut_tokens(&self) -> TokenStream {
-        match self {
-            Borrowed(n) => n.clone(),
-            Owned(n) => quote!(&mut #n),
-        }
-    }
-
-    fn owned_tokens(&self) -> TokenStream {
-        match self {
-            Borrowed(n) => quote!(*#n),
-            Owned(n) => n.clone(),
-        }
-    }
 }
 
 fn simple_visit(item: &str, name: &Operand) -> TokenStream {

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -112,17 +112,7 @@ fn visit(
     }
 }
 
-fn visit_features(features: &Features) -> TokenStream {
-    let features = &features.any;
-    match features.len() {
-        0 => quote!(),
-        1 => quote!(#[cfg(feature = #(#features)*)]),
-        _ => quote!(#[cfg(any(#(feature = #features),*))]),
-    }
-}
-
 fn node(traits: &mut TokenStream, impls: &mut TokenStream, s: &Node, defs: &Definitions) {
-    let features = visit_features(&s.features);
     let under_name = gen::under_name(&s.ident);
     let ty = Ident::new(&s.ident, Span::call_site());
     let visit_mut_fn = Ident::new(&format!("visit_{}_mut", under_name), Span::call_site());
@@ -191,14 +181,12 @@ fn node(traits: &mut TokenStream, impls: &mut TokenStream, s: &Node, defs: &Defi
     }
 
     traits.extend(quote! {
-        #features
         fn #visit_mut_fn(&mut self, i: &mut #ty) {
             #visit_mut_fn(self, i)
         }
     });
 
     impls.extend(quote! {
-        #features
         pub fn #visit_mut_fn<V: VisitMut + ?Sized>(
             _visitor: &mut V, _i: &mut #ty
         ) {

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -1,0 +1,385 @@
+use crate::file;
+use quote::quote;
+use syn_codegen as types;
+
+const VISIT_MUT_SRC: &str = "../src/gen/visit_mut.rs";
+
+mod codegen {
+    use inflections::Inflect;
+    use proc_macro2::{Span, TokenStream};
+    use quote::{quote, TokenStreamExt};
+    use syn::*;
+    use syn_codegen as types;
+
+    #[derive(Default)]
+    pub struct State {
+        pub visit_mut_trait: TokenStream,
+        pub visit_mut_impl: TokenStream,
+    }
+
+    fn under_name(name: &str) -> Ident {
+        Ident::new(&name.to_snake_case(), Span::call_site())
+    }
+
+    enum Operand {
+        Borrowed(TokenStream),
+        Owned(TokenStream),
+    }
+
+    use self::Operand::*;
+
+    impl Operand {
+        fn tokens(&self) -> &TokenStream {
+            match *self {
+                Borrowed(ref n) | Owned(ref n) => n,
+            }
+        }
+
+        fn ref_mut_tokens(&self) -> TokenStream {
+            match *self {
+                Borrowed(ref n) => n.clone(),
+                Owned(ref n) => quote!(&mut #n),
+            }
+        }
+
+        fn owned_tokens(&self) -> TokenStream {
+            match *self {
+                Borrowed(ref n) => quote!(*#n),
+                Owned(ref n) => n.clone(),
+            }
+        }
+    }
+
+    fn simple_visit(item: &str, name: &Operand) -> TokenStream {
+        let ident = under_name(item);
+        let method = Ident::new(&format!("visit_{}_mut", ident), Span::call_site());
+        let name = name.ref_mut_tokens();
+        quote! {
+            _visitor.#method(#name)
+        }
+    }
+
+    fn box_visit(
+        elem: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &Operand,
+    ) -> Option<TokenStream> {
+        let name = name.owned_tokens();
+        let res = visit(elem, features, defs, &Owned(quote!(*#name)))?;
+        Some(res)
+    }
+
+    fn vec_visit(
+        elem: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &Operand,
+    ) -> Option<TokenStream> {
+        let operand = Borrowed(quote!(it));
+        let val = visit(elem, features, defs, &operand)?;
+        let name = name.ref_mut_tokens();
+        Some(quote! {
+            for it in #name {
+                #val
+            }
+        })
+    }
+
+    fn punctuated_visit(
+        elem: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &Operand,
+    ) -> Option<TokenStream> {
+        let operand = Borrowed(quote!(it));
+        let val = visit(elem, features, defs, &operand)?;
+        let name = name.ref_mut_tokens();
+        Some(quote! {
+            for mut el in Punctuated::pairs_mut(#name) {
+                let it = el.value_mut();
+                #val
+            }
+        })
+    }
+
+    fn option_visit(
+        elem: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &Operand,
+    ) -> Option<TokenStream> {
+        let it = Borrowed(quote!(it));
+        let val = visit(elem, features, defs, &it)?;
+        let name = name.owned_tokens();
+        Some(quote! {
+            if let Some(ref mut it) = #name {
+                #val
+            }
+        })
+    }
+
+    fn tuple_visit(
+        elems: &[types::Type],
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &Operand,
+    ) -> Option<TokenStream> {
+        if elems.is_empty() {
+            return None;
+        }
+
+        let mut code = TokenStream::new();
+        for (i, elem) in elems.iter().enumerate() {
+            let name = name.tokens();
+            let i = Index::from(i);
+            let it = Owned(quote!((#name).#i));
+            let val = visit(elem, features, defs, &it).unwrap_or_else(|| noop_visit(&it));
+            code.append_all(val);
+            code.append_all(quote!(;));
+        }
+        Some(code)
+    }
+
+    fn token_punct_visit(name: &Operand) -> TokenStream {
+        let name = name.tokens();
+        quote! {
+            tokens_helper(_visitor, &mut #name.spans)
+        }
+    }
+
+    fn token_keyword_visit(name: &Operand) -> TokenStream {
+        let name = name.tokens();
+        quote! {
+            tokens_helper(_visitor, &mut #name.span)
+        }
+    }
+
+    fn token_group_visit(name: &Operand) -> TokenStream {
+        let name = name.tokens();
+        quote! {
+            tokens_helper(_visitor, &mut #name.span)
+        }
+    }
+
+    fn noop_visit(name: &Operand) -> TokenStream {
+        let name = name.tokens();
+        quote! {
+            skip!(#name)
+        }
+    }
+
+    fn visit(
+        ty: &types::Type,
+        features: &types::Features,
+        defs: &types::Definitions,
+        name: &Operand,
+    ) -> Option<TokenStream> {
+        match ty {
+            types::Type::Box(t) => box_visit(&*t, features, defs, name),
+            types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
+            types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
+            types::Type::Option(t) => option_visit(&*t, features, defs, name),
+            types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
+            types::Type::Token(t) => {
+                let repr = &defs.tokens[t];
+                let is_keyword = repr.chars().next().unwrap().is_alphabetic();
+                if is_keyword {
+                    Some(token_keyword_visit(name))
+                } else {
+                    Some(token_punct_visit(name))
+                }
+            }
+            types::Type::Group(_) => Some(token_group_visit(name)),
+            types::Type::Syn(t) => {
+                fn requires_full(features: &types::Features) -> bool {
+                    features.any.contains("full") && features.any.len() == 1
+                }
+
+                let res = simple_visit(t, name);
+
+                let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
+
+                Some(
+                    if requires_full(&target.features) && !requires_full(features) {
+                        quote! {
+                            full!(#res)
+                        }
+                    } else {
+                        res
+                    },
+                )
+            }
+            types::Type::Ext(t) if super::TERMINAL_TYPES.contains(&&t[..]) => {
+                Some(simple_visit(t, name))
+            }
+            types::Type::Ext(_) | types::Type::Std(_) => None,
+        }
+    }
+
+    fn visit_features(features: &types::Features) -> TokenStream {
+        let features = &features.any;
+        match features.len() {
+            0 => quote!(),
+            1 => quote!(#[cfg(feature = #(#features)*)]),
+            _ => quote!(#[cfg(any(#(feature = #features),*))]),
+        }
+    }
+
+    pub fn generate(state: &mut State, s: &types::Node, defs: &types::Definitions) {
+        let features = visit_features(&s.features);
+        let under_name = under_name(&s.ident);
+        let ty = Ident::new(&s.ident, Span::call_site());
+        let visit_mut_fn = Ident::new(&format!("visit_{}_mut", under_name), Span::call_site());
+
+        let mut visit_mut_impl = TokenStream::new();
+
+        match &s.data {
+            types::Data::Enum(variants) => {
+                let mut visit_mut_variants = TokenStream::new();
+
+                for (variant, fields) in variants {
+                    let variant_ident = Ident::new(variant, Span::call_site());
+
+                    if fields.is_empty() {
+                        visit_mut_variants.append_all(quote! {
+                            #ty::#variant_ident => {}
+                        });
+                    } else {
+                        let mut bind_visit_mut_fields = TokenStream::new();
+                        let mut visit_mut_fields = TokenStream::new();
+
+                        for (idx, ty) in fields.iter().enumerate() {
+                            let name = format!("_binding_{}", idx);
+                            let binding = Ident::new(&name, Span::call_site());
+
+                            bind_visit_mut_fields.append_all(quote! {
+                                ref mut #binding,
+                            });
+
+                            let borrowed_binding = Borrowed(quote!(#binding));
+
+                            visit_mut_fields.append_all(
+                                visit(ty, &s.features, defs, &borrowed_binding)
+                                    .unwrap_or_else(|| noop_visit(&borrowed_binding)),
+                            );
+
+                            visit_mut_fields.append_all(quote!(;));
+                        }
+
+                        visit_mut_variants.append_all(quote! {
+                            #ty::#variant_ident(#bind_visit_mut_fields) => {
+                                #visit_mut_fields
+                            }
+                        });
+                    }
+                }
+
+                visit_mut_impl.append_all(quote! {
+                    match *_i {
+                        #visit_mut_variants
+                    }
+                });
+            }
+            types::Data::Struct(fields) => {
+                for (field, ty) in fields {
+                    let id = Ident::new(&field, Span::call_site());
+                    let ref_toks = Owned(quote!(_i.#id));
+                    let visit_mut_field = visit(&ty, &s.features, defs, &ref_toks)
+                        .unwrap_or_else(|| noop_visit(&ref_toks));
+                    visit_mut_impl.append_all(quote! {
+                        #visit_mut_field;
+                    });
+                }
+            }
+            types::Data::Private => {}
+        }
+
+        state.visit_mut_trait.append_all(quote! {
+            #features
+            fn #visit_mut_fn(&mut self, i: &mut #ty) {
+                #visit_mut_fn(self, i)
+            }
+        });
+
+        state.visit_mut_impl.append_all(quote! {
+            #features
+            pub fn #visit_mut_fn<V: VisitMut + ?Sized>(
+                _visitor: &mut V, _i: &mut #ty
+            ) {
+                #visit_mut_impl
+            }
+        });
+    }
+}
+
+const TERMINAL_TYPES: &[&str] = &["Span", "Ident"];
+
+pub fn generate(defs: &types::Definitions) {
+    let mut state = codegen::State::default();
+    for s in &defs.types {
+        codegen::generate(&mut state, s, defs);
+    }
+    for tt in TERMINAL_TYPES {
+        let s = types::Node {
+            ident: tt.to_string(),
+            features: types::Features::default(),
+            data: types::Data::Private,
+        };
+        codegen::generate(&mut state, &s, defs);
+    }
+
+    let full_macro = quote! {
+        #[cfg(feature = "full")]
+        macro_rules! full {
+            ($e:expr) => {
+                $e
+            };
+        }
+
+        #[cfg(all(feature = "derive", not(feature = "full")))]
+        macro_rules! full {
+            ($e:expr) => {
+                unreachable!()
+            };
+        }
+    };
+
+    let skip_macro = quote! {
+        #[cfg(any(feature = "full", feature = "derive"))]
+        macro_rules! skip {
+            ($($tt:tt)*) => {};
+        }
+    };
+
+    let visit_mut_trait = state.visit_mut_trait;
+    let visit_mut_impl = state.visit_mut_impl;
+    file::write(
+        VISIT_MUT_SRC,
+        quote! {
+            use *;
+            #[cfg(any(feature = "full", feature = "derive"))]
+            use punctuated::Punctuated;
+            use proc_macro2::Span;
+            #[cfg(any(feature = "full", feature = "derive"))]
+            use gen::helper::visit_mut::*;
+
+            #full_macro
+            #skip_macro
+
+            /// Syntax tree traversal to mutate an exclusive borrow of a syntax tree in
+            /// place.
+            ///
+            /// See the [module documentation] for details.
+            ///
+            /// [module documentation]: index.html
+            ///
+            /// *This trait is available if Syn is built with the `"visit-mut"` feature.*
+            pub trait VisitMut {
+                #visit_mut_trait
+            }
+
+            #visit_mut_impl
+        },
+    );
+}

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -7,12 +7,6 @@ use syn_codegen::{Data, Definitions, Features, Node, Type};
 
 const VISIT_MUT_SRC: &str = "../src/gen/visit_mut.rs";
 
-#[derive(Default)]
-struct State {
-    visit_mut_trait: TokenStream,
-    visit_mut_impl: TokenStream,
-}
-
 fn simple_visit(item: &str, name: &Operand) -> TokenStream {
     let ident = gen::under_name(item);
     let method = Ident::new(&format!("visit_{}_mut", ident), Span::call_site());
@@ -127,7 +121,7 @@ fn visit_features(features: &Features) -> TokenStream {
     }
 }
 
-fn node(state: &mut State, s: &Node, defs: &Definitions) {
+fn node(traits: &mut TokenStream, impls: &mut TokenStream, s: &Node, defs: &Definitions) {
     let features = visit_features(&s.features);
     let under_name = gen::under_name(&s.ident);
     let ty = Ident::new(&s.ident, Span::call_site());
@@ -196,14 +190,14 @@ fn node(state: &mut State, s: &Node, defs: &Definitions) {
         Data::Private => {}
     }
 
-    state.visit_mut_trait.extend(quote! {
+    traits.extend(quote! {
         #features
         fn #visit_mut_fn(&mut self, i: &mut #ty) {
             #visit_mut_fn(self, i)
         }
     });
 
-    state.visit_mut_impl.extend(quote! {
+    impls.extend(quote! {
         #features
         pub fn #visit_mut_fn<V: VisitMut + ?Sized>(
             _visitor: &mut V, _i: &mut #ty
@@ -214,10 +208,8 @@ fn node(state: &mut State, s: &Node, defs: &Definitions) {
 }
 
 pub fn generate(defs: &Definitions) {
-    let state = gen::traverse(defs, node);
+    let (traits, impls) = gen::traverse(defs, node);
     let full_macro = full::get_macro();
-    let visit_mut_trait = state.visit_mut_trait;
-    let visit_mut_impl = state.visit_mut_impl;
     file::write(
         VISIT_MUT_SRC,
         quote! {
@@ -244,10 +236,10 @@ pub fn generate(defs: &Definitions) {
             ///
             /// *This trait is available if Syn is built with the `"visit-mut"` feature.*
             pub trait VisitMut {
-                #visit_mut_trait
+                #traits
             }
 
-            #visit_mut_impl
+            #impls
         },
     );
 }

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -26,22 +26,22 @@ use self::Operand::*;
 
 impl Operand {
     fn tokens(&self) -> &TokenStream {
-        match *self {
-            Borrowed(ref n) | Owned(ref n) => n,
+        match self {
+            Borrowed(n) | Owned(n) => n,
         }
     }
 
     fn ref_mut_tokens(&self) -> TokenStream {
-        match *self {
-            Borrowed(ref n) => n.clone(),
-            Owned(ref n) => quote!(&mut #n),
+        match self {
+            Borrowed(n) => n.clone(),
+            Owned(n) => quote!(&mut #n),
         }
     }
 
     fn owned_tokens(&self) -> TokenStream {
-        match *self {
-            Borrowed(ref n) => quote!(*#n),
-            Owned(ref n) => n.clone(),
+        match self {
+            Borrowed(n) => quote!(*#n),
+            Owned(n) => n.clone(),
         }
     }
 }

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -1,10 +1,11 @@
-use crate::{file, full};
+use crate::{file, full, gen};
 use quote::quote;
 use syn_codegen as types;
 
 const VISIT_MUT_SRC: &str = "../src/gen/visit_mut.rs";
 
 mod codegen {
+    use crate::gen;
     use inflections::Inflect;
     use proc_macro2::{Span, TokenStream};
     use quote::{quote, TokenStreamExt};
@@ -210,7 +211,7 @@ mod codegen {
                     },
                 )
             }
-            types::Type::Ext(t) if super::TERMINAL_TYPES.contains(&&t[..]) => {
+            types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => {
                 Some(simple_visit(t, name))
             }
             types::Type::Ext(_) | types::Type::Std(_) => None,
@@ -313,22 +314,8 @@ mod codegen {
     }
 }
 
-const TERMINAL_TYPES: &[&str] = &["Span", "Ident"];
-
 pub fn generate(defs: &types::Definitions) {
-    let mut state = codegen::State::default();
-    for s in &defs.types {
-        codegen::generate(&mut state, s, defs);
-    }
-    for tt in TERMINAL_TYPES {
-        let s = types::Node {
-            ident: tt.to_string(),
-            features: types::Features::default(),
-            data: types::Data::Private,
-        };
-        codegen::generate(&mut state, &s, defs);
-    }
-
+    let state = gen::traverse(defs, codegen::generate);
     let full_macro = full::get_macro();
     let visit_mut_trait = state.visit_mut_trait;
     let visit_mut_impl = state.visit_mut_impl;

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -55,109 +55,6 @@ fn simple_visit(item: &str, name: &Operand) -> TokenStream {
     }
 }
 
-fn box_visit(
-    elem: &types::Type,
-    features: &types::Features,
-    defs: &types::Definitions,
-    name: &Operand,
-) -> Option<TokenStream> {
-    let name = name.owned_tokens();
-    let res = visit(elem, features, defs, &Owned(quote!(*#name)))?;
-    Some(res)
-}
-
-fn vec_visit(
-    elem: &types::Type,
-    features: &types::Features,
-    defs: &types::Definitions,
-    name: &Operand,
-) -> Option<TokenStream> {
-    let operand = Borrowed(quote!(it));
-    let val = visit(elem, features, defs, &operand)?;
-    let name = name.ref_mut_tokens();
-    Some(quote! {
-        for it in #name {
-            #val
-        }
-    })
-}
-
-fn punctuated_visit(
-    elem: &types::Type,
-    features: &types::Features,
-    defs: &types::Definitions,
-    name: &Operand,
-) -> Option<TokenStream> {
-    let operand = Borrowed(quote!(it));
-    let val = visit(elem, features, defs, &operand)?;
-    let name = name.ref_mut_tokens();
-    Some(quote! {
-        for mut el in Punctuated::pairs_mut(#name) {
-            let it = el.value_mut();
-            #val
-        }
-    })
-}
-
-fn option_visit(
-    elem: &types::Type,
-    features: &types::Features,
-    defs: &types::Definitions,
-    name: &Operand,
-) -> Option<TokenStream> {
-    let it = Borrowed(quote!(it));
-    let val = visit(elem, features, defs, &it)?;
-    let name = name.owned_tokens();
-    Some(quote! {
-        if let Some(ref mut it) = #name {
-            #val
-        }
-    })
-}
-
-fn tuple_visit(
-    elems: &[types::Type],
-    features: &types::Features,
-    defs: &types::Definitions,
-    name: &Operand,
-) -> Option<TokenStream> {
-    if elems.is_empty() {
-        return None;
-    }
-
-    let mut code = TokenStream::new();
-    for (i, elem) in elems.iter().enumerate() {
-        let name = name.tokens();
-        let i = Index::from(i);
-        let it = Owned(quote!((#name).#i));
-        let val = visit(elem, features, defs, &it).unwrap_or_else(|| noop_visit(&it));
-        code.append_all(val);
-        code.append_all(quote!(;));
-    }
-    Some(code)
-}
-
-fn token_punct_visit(name: &Operand) -> TokenStream {
-    let name = name.tokens();
-    quote! {
-        tokens_helper(_visitor, &mut #name.spans)
-    }
-}
-
-fn token_keyword_visit(name: &Operand) -> TokenStream {
-    let name = name.tokens();
-    quote! {
-        tokens_helper(_visitor, &mut #name.span)
-    }
-}
-
-fn token_group_visit(name: &Operand) -> TokenStream {
-    let name = name.tokens();
-    quote! {
-        tokens_helper(_visitor, &mut #name.span)
-    }
-}
-
 fn noop_visit(name: &Operand) -> TokenStream {
     let name = name.tokens();
     quote! {
@@ -172,39 +69,82 @@ fn visit(
     name: &Operand,
 ) -> Option<TokenStream> {
     match ty {
-        types::Type::Box(t) => box_visit(&*t, features, defs, name),
-        types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
-        types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
-        types::Type::Option(t) => option_visit(&*t, features, defs, name),
-        types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
+        types::Type::Box(t) => {
+            let name = name.owned_tokens();
+            visit(t, features, defs, &Owned(quote!(*#name)))
+        }
+        types::Type::Vec(t) => {
+            let operand = Borrowed(quote!(it));
+            let val = visit(t, features, defs, &operand)?;
+            let name = name.ref_mut_tokens();
+            Some(quote! {
+                for it in #name {
+                    #val
+                }
+            })
+        }
+        types::Type::Punctuated(p) => {
+            let operand = Borrowed(quote!(it));
+            let val = visit(&p.element, features, defs, &operand)?;
+            let name = name.ref_mut_tokens();
+            Some(quote! {
+                for mut el in Punctuated::pairs_mut(#name) {
+                    let it = el.value_mut();
+                    #val
+                }
+            })
+        }
+        types::Type::Option(t) => {
+            let it = Borrowed(quote!(it));
+            let val = visit(t, features, defs, &it)?;
+            let name = name.owned_tokens();
+            Some(quote! {
+                if let Some(ref mut it) = #name {
+                    #val
+                }
+            })
+        }
+        types::Type::Tuple(t) => {
+            let mut code = TokenStream::new();
+            for (i, elem) in t.iter().enumerate() {
+                let name = name.tokens();
+                let i = Index::from(i);
+                let it = Owned(quote!((#name).#i));
+                let val = visit(elem, features, defs, &it).unwrap_or_else(|| noop_visit(&it));
+                code.append_all(val);
+                code.append_all(quote!(;));
+            }
+            Some(code)
+        }
         types::Type::Token(t) => {
+            let name = name.tokens();
             let repr = &defs.tokens[t];
             let is_keyword = repr.chars().next().unwrap().is_alphabetic();
-            if is_keyword {
-                Some(token_keyword_visit(name))
+            let spans = if is_keyword {
+                quote!(span)
             } else {
-                Some(token_punct_visit(name))
-            }
+                quote!(spans)
+            };
+            Some(quote! {
+                tokens_helper(_visitor, &mut #name.#spans)
+            })
         }
-        types::Type::Group(_) => Some(token_group_visit(name)),
+        types::Type::Group(_) => {
+            let name = name.tokens();
+            Some(quote! {
+                tokens_helper(_visitor, &mut #name.span)
+            })
+        }
         types::Type::Syn(t) => {
             fn requires_full(features: &types::Features) -> bool {
                 features.any.contains("full") && features.any.len() == 1
             }
-
-            let res = simple_visit(t, name);
-
+            let mut res = simple_visit(t, name);
             let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
-
-            Some(
-                if requires_full(&target.features) && !requires_full(features) {
-                    quote! {
-                        full!(#res)
-                    }
-                } else {
-                    res
-                },
-            )
+            if requires_full(&target.features) && !requires_full(features) {
+                res = quote!(full!(#res));
+            }
+            Some(res)
         }
         types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => Some(simple_visit(t, name)),
         types::Type::Ext(_) | types::Type::Std(_) => None,

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -1,9 +1,9 @@
-use crate::operand::*;
+use crate::operand::{Borrowed, Operand, Owned};
 use crate::{file, full, gen};
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, TokenStreamExt};
-use syn::*;
-use syn_codegen as types;
+use syn::Index;
+use syn_codegen::{Data, Definitions, Features, Node, Type};
 
 const VISIT_MUT_SRC: &str = "../src/gen/visit_mut.rs";
 
@@ -30,17 +30,17 @@ fn noop_visit(name: &Operand) -> TokenStream {
 }
 
 fn visit(
-    ty: &types::Type,
-    features: &types::Features,
-    defs: &types::Definitions,
+    ty: &Type,
+    features: &Features,
+    defs: &Definitions,
     name: &Operand,
 ) -> Option<TokenStream> {
     match ty {
-        types::Type::Box(t) => {
+        Type::Box(t) => {
             let name = name.owned_tokens();
             visit(t, features, defs, &Owned(quote!(*#name)))
         }
-        types::Type::Vec(t) => {
+        Type::Vec(t) => {
             let operand = Borrowed(quote!(it));
             let val = visit(t, features, defs, &operand)?;
             let name = name.ref_mut_tokens();
@@ -50,7 +50,7 @@ fn visit(
                 }
             })
         }
-        types::Type::Punctuated(p) => {
+        Type::Punctuated(p) => {
             let operand = Borrowed(quote!(it));
             let val = visit(&p.element, features, defs, &operand)?;
             let name = name.ref_mut_tokens();
@@ -61,7 +61,7 @@ fn visit(
                 }
             })
         }
-        types::Type::Option(t) => {
+        Type::Option(t) => {
             let it = Borrowed(quote!(it));
             let val = visit(t, features, defs, &it)?;
             let name = name.owned_tokens();
@@ -71,7 +71,7 @@ fn visit(
                 }
             })
         }
-        types::Type::Tuple(t) => {
+        Type::Tuple(t) => {
             let mut code = TokenStream::new();
             for (i, elem) in t.iter().enumerate() {
                 let name = name.tokens();
@@ -83,7 +83,7 @@ fn visit(
             }
             Some(code)
         }
-        types::Type::Token(t) => {
+        Type::Token(t) => {
             let name = name.tokens();
             let repr = &defs.tokens[t];
             let is_keyword = repr.chars().next().unwrap().is_alphabetic();
@@ -96,14 +96,14 @@ fn visit(
                 tokens_helper(_visitor, &mut #name.#spans)
             })
         }
-        types::Type::Group(_) => {
+        Type::Group(_) => {
             let name = name.tokens();
             Some(quote! {
                 tokens_helper(_visitor, &mut #name.span)
             })
         }
-        types::Type::Syn(t) => {
-            fn requires_full(features: &types::Features) -> bool {
+        Type::Syn(t) => {
+            fn requires_full(features: &Features) -> bool {
                 features.any.contains("full") && features.any.len() == 1
             }
             let mut res = simple_visit(t, name);
@@ -113,12 +113,12 @@ fn visit(
             }
             Some(res)
         }
-        types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => Some(simple_visit(t, name)),
-        types::Type::Ext(_) | types::Type::Std(_) => None,
+        Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => Some(simple_visit(t, name)),
+        Type::Ext(_) | Type::Std(_) => None,
     }
 }
 
-fn visit_features(features: &types::Features) -> TokenStream {
+fn visit_features(features: &Features) -> TokenStream {
     let features = &features.any;
     match features.len() {
         0 => quote!(),
@@ -127,7 +127,7 @@ fn visit_features(features: &types::Features) -> TokenStream {
     }
 }
 
-fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
+fn node(state: &mut State, s: &Node, defs: &Definitions) {
     let features = visit_features(&s.features);
     let under_name = gen::under_name(&s.ident);
     let ty = Ident::new(&s.ident, Span::call_site());
@@ -136,7 +136,7 @@ fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
     let mut visit_mut_impl = TokenStream::new();
 
     match &s.data {
-        types::Data::Enum(variants) => {
+        Data::Enum(variants) => {
             let mut visit_mut_variants = TokenStream::new();
 
             for (variant, fields) in variants {
@@ -182,7 +182,7 @@ fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
                 }
             });
         }
-        types::Data::Struct(fields) => {
+        Data::Struct(fields) => {
             for (field, ty) in fields {
                 let id = Ident::new(&field, Span::call_site());
                 let ref_toks = Owned(quote!(_i.#id));
@@ -193,7 +193,7 @@ fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
                 });
             }
         }
-        types::Data::Private => {}
+        Data::Private => {}
     }
 
     state.visit_mut_trait.append_all(quote! {
@@ -213,7 +213,7 @@ fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
     });
 }
 
-pub fn generate(defs: &types::Definitions) {
+pub fn generate(defs: &Definitions) {
     let state = gen::traverse(defs, node);
     let full_macro = full::get_macro();
     let visit_mut_trait = state.visit_mut_trait;

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -1,321 +1,313 @@
 use crate::{file, full, gen};
-use quote::quote;
+use inflections::Inflect;
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, TokenStreamExt};
+use syn::*;
 use syn_codegen as types;
 
 const VISIT_MUT_SRC: &str = "../src/gen/visit_mut.rs";
 
-mod codegen {
-    use crate::gen;
-    use inflections::Inflect;
-    use proc_macro2::{Span, TokenStream};
-    use quote::{quote, TokenStreamExt};
-    use syn::*;
-    use syn_codegen as types;
+#[derive(Default)]
+struct State {
+    visit_mut_trait: TokenStream,
+    visit_mut_impl: TokenStream,
+}
 
-    #[derive(Default)]
-    pub struct State {
-        pub visit_mut_trait: TokenStream,
-        pub visit_mut_impl: TokenStream,
-    }
+fn under_name(name: &str) -> Ident {
+    Ident::new(&name.to_snake_case(), Span::call_site())
+}
 
-    fn under_name(name: &str) -> Ident {
-        Ident::new(&name.to_snake_case(), Span::call_site())
-    }
+enum Operand {
+    Borrowed(TokenStream),
+    Owned(TokenStream),
+}
 
-    enum Operand {
-        Borrowed(TokenStream),
-        Owned(TokenStream),
-    }
+use self::Operand::*;
 
-    use self::Operand::*;
-
-    impl Operand {
-        fn tokens(&self) -> &TokenStream {
-            match *self {
-                Borrowed(ref n) | Owned(ref n) => n,
-            }
-        }
-
-        fn ref_mut_tokens(&self) -> TokenStream {
-            match *self {
-                Borrowed(ref n) => n.clone(),
-                Owned(ref n) => quote!(&mut #n),
-            }
-        }
-
-        fn owned_tokens(&self) -> TokenStream {
-            match *self {
-                Borrowed(ref n) => quote!(*#n),
-                Owned(ref n) => n.clone(),
-            }
+impl Operand {
+    fn tokens(&self) -> &TokenStream {
+        match *self {
+            Borrowed(ref n) | Owned(ref n) => n,
         }
     }
 
-    fn simple_visit(item: &str, name: &Operand) -> TokenStream {
-        let ident = under_name(item);
-        let method = Ident::new(&format!("visit_{}_mut", ident), Span::call_site());
-        let name = name.ref_mut_tokens();
-        quote! {
-            _visitor.#method(#name)
+    fn ref_mut_tokens(&self) -> TokenStream {
+        match *self {
+            Borrowed(ref n) => n.clone(),
+            Owned(ref n) => quote!(&mut #n),
         }
     }
 
-    fn box_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        let name = name.owned_tokens();
-        let res = visit(elem, features, defs, &Owned(quote!(*#name)))?;
-        Some(res)
-    }
-
-    fn vec_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        let operand = Borrowed(quote!(it));
-        let val = visit(elem, features, defs, &operand)?;
-        let name = name.ref_mut_tokens();
-        Some(quote! {
-            for it in #name {
-                #val
-            }
-        })
-    }
-
-    fn punctuated_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        let operand = Borrowed(quote!(it));
-        let val = visit(elem, features, defs, &operand)?;
-        let name = name.ref_mut_tokens();
-        Some(quote! {
-            for mut el in Punctuated::pairs_mut(#name) {
-                let it = el.value_mut();
-                #val
-            }
-        })
-    }
-
-    fn option_visit(
-        elem: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        let it = Borrowed(quote!(it));
-        let val = visit(elem, features, defs, &it)?;
-        let name = name.owned_tokens();
-        Some(quote! {
-            if let Some(ref mut it) = #name {
-                #val
-            }
-        })
-    }
-
-    fn tuple_visit(
-        elems: &[types::Type],
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        if elems.is_empty() {
-            return None;
+    fn owned_tokens(&self) -> TokenStream {
+        match *self {
+            Borrowed(ref n) => quote!(*#n),
+            Owned(ref n) => n.clone(),
         }
-
-        let mut code = TokenStream::new();
-        for (i, elem) in elems.iter().enumerate() {
-            let name = name.tokens();
-            let i = Index::from(i);
-            let it = Owned(quote!((#name).#i));
-            let val = visit(elem, features, defs, &it).unwrap_or_else(|| noop_visit(&it));
-            code.append_all(val);
-            code.append_all(quote!(;));
-        }
-        Some(code)
-    }
-
-    fn token_punct_visit(name: &Operand) -> TokenStream {
-        let name = name.tokens();
-        quote! {
-            tokens_helper(_visitor, &mut #name.spans)
-        }
-    }
-
-    fn token_keyword_visit(name: &Operand) -> TokenStream {
-        let name = name.tokens();
-        quote! {
-            tokens_helper(_visitor, &mut #name.span)
-        }
-    }
-
-    fn token_group_visit(name: &Operand) -> TokenStream {
-        let name = name.tokens();
-        quote! {
-            tokens_helper(_visitor, &mut #name.span)
-        }
-    }
-
-    fn noop_visit(name: &Operand) -> TokenStream {
-        let name = name.tokens();
-        quote! {
-            skip!(#name)
-        }
-    }
-
-    fn visit(
-        ty: &types::Type,
-        features: &types::Features,
-        defs: &types::Definitions,
-        name: &Operand,
-    ) -> Option<TokenStream> {
-        match ty {
-            types::Type::Box(t) => box_visit(&*t, features, defs, name),
-            types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
-            types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
-            types::Type::Option(t) => option_visit(&*t, features, defs, name),
-            types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
-            types::Type::Token(t) => {
-                let repr = &defs.tokens[t];
-                let is_keyword = repr.chars().next().unwrap().is_alphabetic();
-                if is_keyword {
-                    Some(token_keyword_visit(name))
-                } else {
-                    Some(token_punct_visit(name))
-                }
-            }
-            types::Type::Group(_) => Some(token_group_visit(name)),
-            types::Type::Syn(t) => {
-                fn requires_full(features: &types::Features) -> bool {
-                    features.any.contains("full") && features.any.len() == 1
-                }
-
-                let res = simple_visit(t, name);
-
-                let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
-
-                Some(
-                    if requires_full(&target.features) && !requires_full(features) {
-                        quote! {
-                            full!(#res)
-                        }
-                    } else {
-                        res
-                    },
-                )
-            }
-            types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => {
-                Some(simple_visit(t, name))
-            }
-            types::Type::Ext(_) | types::Type::Std(_) => None,
-        }
-    }
-
-    fn visit_features(features: &types::Features) -> TokenStream {
-        let features = &features.any;
-        match features.len() {
-            0 => quote!(),
-            1 => quote!(#[cfg(feature = #(#features)*)]),
-            _ => quote!(#[cfg(any(#(feature = #features),*))]),
-        }
-    }
-
-    pub fn generate(state: &mut State, s: &types::Node, defs: &types::Definitions) {
-        let features = visit_features(&s.features);
-        let under_name = under_name(&s.ident);
-        let ty = Ident::new(&s.ident, Span::call_site());
-        let visit_mut_fn = Ident::new(&format!("visit_{}_mut", under_name), Span::call_site());
-
-        let mut visit_mut_impl = TokenStream::new();
-
-        match &s.data {
-            types::Data::Enum(variants) => {
-                let mut visit_mut_variants = TokenStream::new();
-
-                for (variant, fields) in variants {
-                    let variant_ident = Ident::new(variant, Span::call_site());
-
-                    if fields.is_empty() {
-                        visit_mut_variants.append_all(quote! {
-                            #ty::#variant_ident => {}
-                        });
-                    } else {
-                        let mut bind_visit_mut_fields = TokenStream::new();
-                        let mut visit_mut_fields = TokenStream::new();
-
-                        for (idx, ty) in fields.iter().enumerate() {
-                            let name = format!("_binding_{}", idx);
-                            let binding = Ident::new(&name, Span::call_site());
-
-                            bind_visit_mut_fields.append_all(quote! {
-                                ref mut #binding,
-                            });
-
-                            let borrowed_binding = Borrowed(quote!(#binding));
-
-                            visit_mut_fields.append_all(
-                                visit(ty, &s.features, defs, &borrowed_binding)
-                                    .unwrap_or_else(|| noop_visit(&borrowed_binding)),
-                            );
-
-                            visit_mut_fields.append_all(quote!(;));
-                        }
-
-                        visit_mut_variants.append_all(quote! {
-                            #ty::#variant_ident(#bind_visit_mut_fields) => {
-                                #visit_mut_fields
-                            }
-                        });
-                    }
-                }
-
-                visit_mut_impl.append_all(quote! {
-                    match *_i {
-                        #visit_mut_variants
-                    }
-                });
-            }
-            types::Data::Struct(fields) => {
-                for (field, ty) in fields {
-                    let id = Ident::new(&field, Span::call_site());
-                    let ref_toks = Owned(quote!(_i.#id));
-                    let visit_mut_field = visit(&ty, &s.features, defs, &ref_toks)
-                        .unwrap_or_else(|| noop_visit(&ref_toks));
-                    visit_mut_impl.append_all(quote! {
-                        #visit_mut_field;
-                    });
-                }
-            }
-            types::Data::Private => {}
-        }
-
-        state.visit_mut_trait.append_all(quote! {
-            #features
-            fn #visit_mut_fn(&mut self, i: &mut #ty) {
-                #visit_mut_fn(self, i)
-            }
-        });
-
-        state.visit_mut_impl.append_all(quote! {
-            #features
-            pub fn #visit_mut_fn<V: VisitMut + ?Sized>(
-                _visitor: &mut V, _i: &mut #ty
-            ) {
-                #visit_mut_impl
-            }
-        });
     }
 }
 
+fn simple_visit(item: &str, name: &Operand) -> TokenStream {
+    let ident = under_name(item);
+    let method = Ident::new(&format!("visit_{}_mut", ident), Span::call_site());
+    let name = name.ref_mut_tokens();
+    quote! {
+        _visitor.#method(#name)
+    }
+}
+
+fn box_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    let name = name.owned_tokens();
+    let res = visit(elem, features, defs, &Owned(quote!(*#name)))?;
+    Some(res)
+}
+
+fn vec_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    let operand = Borrowed(quote!(it));
+    let val = visit(elem, features, defs, &operand)?;
+    let name = name.ref_mut_tokens();
+    Some(quote! {
+        for it in #name {
+            #val
+        }
+    })
+}
+
+fn punctuated_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    let operand = Borrowed(quote!(it));
+    let val = visit(elem, features, defs, &operand)?;
+    let name = name.ref_mut_tokens();
+    Some(quote! {
+        for mut el in Punctuated::pairs_mut(#name) {
+            let it = el.value_mut();
+            #val
+        }
+    })
+}
+
+fn option_visit(
+    elem: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    let it = Borrowed(quote!(it));
+    let val = visit(elem, features, defs, &it)?;
+    let name = name.owned_tokens();
+    Some(quote! {
+        if let Some(ref mut it) = #name {
+            #val
+        }
+    })
+}
+
+fn tuple_visit(
+    elems: &[types::Type],
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    if elems.is_empty() {
+        return None;
+    }
+
+    let mut code = TokenStream::new();
+    for (i, elem) in elems.iter().enumerate() {
+        let name = name.tokens();
+        let i = Index::from(i);
+        let it = Owned(quote!((#name).#i));
+        let val = visit(elem, features, defs, &it).unwrap_or_else(|| noop_visit(&it));
+        code.append_all(val);
+        code.append_all(quote!(;));
+    }
+    Some(code)
+}
+
+fn token_punct_visit(name: &Operand) -> TokenStream {
+    let name = name.tokens();
+    quote! {
+        tokens_helper(_visitor, &mut #name.spans)
+    }
+}
+
+fn token_keyword_visit(name: &Operand) -> TokenStream {
+    let name = name.tokens();
+    quote! {
+        tokens_helper(_visitor, &mut #name.span)
+    }
+}
+
+fn token_group_visit(name: &Operand) -> TokenStream {
+    let name = name.tokens();
+    quote! {
+        tokens_helper(_visitor, &mut #name.span)
+    }
+}
+
+fn noop_visit(name: &Operand) -> TokenStream {
+    let name = name.tokens();
+    quote! {
+        skip!(#name)
+    }
+}
+
+fn visit(
+    ty: &types::Type,
+    features: &types::Features,
+    defs: &types::Definitions,
+    name: &Operand,
+) -> Option<TokenStream> {
+    match ty {
+        types::Type::Box(t) => box_visit(&*t, features, defs, name),
+        types::Type::Vec(t) => vec_visit(&*t, features, defs, name),
+        types::Type::Punctuated(p) => punctuated_visit(&p.element, features, defs, name),
+        types::Type::Option(t) => option_visit(&*t, features, defs, name),
+        types::Type::Tuple(t) => tuple_visit(t, features, defs, name),
+        types::Type::Token(t) => {
+            let repr = &defs.tokens[t];
+            let is_keyword = repr.chars().next().unwrap().is_alphabetic();
+            if is_keyword {
+                Some(token_keyword_visit(name))
+            } else {
+                Some(token_punct_visit(name))
+            }
+        }
+        types::Type::Group(_) => Some(token_group_visit(name)),
+        types::Type::Syn(t) => {
+            fn requires_full(features: &types::Features) -> bool {
+                features.any.contains("full") && features.any.len() == 1
+            }
+
+            let res = simple_visit(t, name);
+
+            let target = defs.types.iter().find(|ty| ty.ident == *t).unwrap();
+
+            Some(
+                if requires_full(&target.features) && !requires_full(features) {
+                    quote! {
+                        full!(#res)
+                    }
+                } else {
+                    res
+                },
+            )
+        }
+        types::Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => Some(simple_visit(t, name)),
+        types::Type::Ext(_) | types::Type::Std(_) => None,
+    }
+}
+
+fn visit_features(features: &types::Features) -> TokenStream {
+    let features = &features.any;
+    match features.len() {
+        0 => quote!(),
+        1 => quote!(#[cfg(feature = #(#features)*)]),
+        _ => quote!(#[cfg(any(#(feature = #features),*))]),
+    }
+}
+
+fn node(state: &mut State, s: &types::Node, defs: &types::Definitions) {
+    let features = visit_features(&s.features);
+    let under_name = under_name(&s.ident);
+    let ty = Ident::new(&s.ident, Span::call_site());
+    let visit_mut_fn = Ident::new(&format!("visit_{}_mut", under_name), Span::call_site());
+
+    let mut visit_mut_impl = TokenStream::new();
+
+    match &s.data {
+        types::Data::Enum(variants) => {
+            let mut visit_mut_variants = TokenStream::new();
+
+            for (variant, fields) in variants {
+                let variant_ident = Ident::new(variant, Span::call_site());
+
+                if fields.is_empty() {
+                    visit_mut_variants.append_all(quote! {
+                        #ty::#variant_ident => {}
+                    });
+                } else {
+                    let mut bind_visit_mut_fields = TokenStream::new();
+                    let mut visit_mut_fields = TokenStream::new();
+
+                    for (idx, ty) in fields.iter().enumerate() {
+                        let name = format!("_binding_{}", idx);
+                        let binding = Ident::new(&name, Span::call_site());
+
+                        bind_visit_mut_fields.append_all(quote! {
+                            ref mut #binding,
+                        });
+
+                        let borrowed_binding = Borrowed(quote!(#binding));
+
+                        visit_mut_fields.append_all(
+                            visit(ty, &s.features, defs, &borrowed_binding)
+                                .unwrap_or_else(|| noop_visit(&borrowed_binding)),
+                        );
+
+                        visit_mut_fields.append_all(quote!(;));
+                    }
+
+                    visit_mut_variants.append_all(quote! {
+                        #ty::#variant_ident(#bind_visit_mut_fields) => {
+                            #visit_mut_fields
+                        }
+                    });
+                }
+            }
+
+            visit_mut_impl.append_all(quote! {
+                match *_i {
+                    #visit_mut_variants
+                }
+            });
+        }
+        types::Data::Struct(fields) => {
+            for (field, ty) in fields {
+                let id = Ident::new(&field, Span::call_site());
+                let ref_toks = Owned(quote!(_i.#id));
+                let visit_mut_field = visit(&ty, &s.features, defs, &ref_toks)
+                    .unwrap_or_else(|| noop_visit(&ref_toks));
+                visit_mut_impl.append_all(quote! {
+                    #visit_mut_field;
+                });
+            }
+        }
+        types::Data::Private => {}
+    }
+
+    state.visit_mut_trait.append_all(quote! {
+        #features
+        fn #visit_mut_fn(&mut self, i: &mut #ty) {
+            #visit_mut_fn(self, i)
+        }
+    });
+
+    state.visit_mut_impl.append_all(quote! {
+        #features
+        pub fn #visit_mut_fn<V: VisitMut + ?Sized>(
+            _visitor: &mut V, _i: &mut #ty
+        ) {
+            #visit_mut_impl
+        }
+    });
+}
+
 pub fn generate(defs: &types::Definitions) {
-    let state = gen::traverse(defs, codegen::generate);
+    let state = gen::traverse(defs, node);
     let full_macro = full::get_macro();
     let visit_mut_trait = state.visit_mut_trait;
     let visit_mut_impl = state.visit_mut_impl;

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -1,4 +1,4 @@
-use crate::file;
+use crate::{file, full};
 use quote::quote;
 use syn_codegen as types;
 
@@ -329,29 +329,7 @@ pub fn generate(defs: &types::Definitions) {
         codegen::generate(&mut state, &s, defs);
     }
 
-    let full_macro = quote! {
-        #[cfg(feature = "full")]
-        macro_rules! full {
-            ($e:expr) => {
-                $e
-            };
-        }
-
-        #[cfg(all(feature = "derive", not(feature = "full")))]
-        macro_rules! full {
-            ($e:expr) => {
-                unreachable!()
-            };
-        }
-    };
-
-    let skip_macro = quote! {
-        #[cfg(any(feature = "full", feature = "derive"))]
-        macro_rules! skip {
-            ($($tt:tt)*) => {};
-        }
-    };
-
+    let full_macro = full::get_macro();
     let visit_mut_trait = state.visit_mut_trait;
     let visit_mut_impl = state.visit_mut_impl;
     file::write(
@@ -365,7 +343,11 @@ pub fn generate(defs: &types::Definitions) {
             use gen::helper::visit_mut::*;
 
             #full_macro
-            #skip_macro
+
+            #[cfg(any(feature = "full", feature = "derive"))]
+            macro_rules! skip {
+                ($($tt:tt)*) => {};
+            }
 
             /// Syntax tree traversal to mutate an exclusive borrow of a syntax tree in
             /// place.

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -819,28 +819,6 @@ pub trait Fold {
         fold_ident(self, i)
     }
 }
-#[cfg(any(feature = "full", feature = "derive"))]
-macro_rules! fold_span_only {
-    ($f:ident : $t:ident) => {
-        pub fn $f<V: Fold + ?Sized>(_visitor: &mut V, mut _i: $t) -> $t {
-            let span = _visitor.fold_span(_i.span());
-            _i.set_span(span);
-            _i
-        }
-    };
-}
-#[cfg(any(feature = "full", feature = "derive"))]
-fold_span_only!(fold_lit_byte: LitByte);
-#[cfg(any(feature = "full", feature = "derive"))]
-fold_span_only!(fold_lit_byte_str: LitByteStr);
-#[cfg(any(feature = "full", feature = "derive"))]
-fold_span_only!(fold_lit_char: LitChar);
-#[cfg(any(feature = "full", feature = "derive"))]
-fold_span_only!(fold_lit_float: LitFloat);
-#[cfg(any(feature = "full", feature = "derive"))]
-fold_span_only!(fold_lit_int: LitInt);
-#[cfg(any(feature = "full", feature = "derive"))]
-fold_span_only!(fold_lit_str: LitStr);
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn fold_abi<V: Fold + ?Sized>(_visitor: &mut V, _i: Abi) -> Abi {
     Abi {
@@ -2174,6 +2152,48 @@ pub fn fold_lit_bool<V: Fold + ?Sized>(_visitor: &mut V, _i: LitBool) -> LitBool
         value: _i.value,
         span: _visitor.fold_span(_i.span),
     }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+pub fn fold_lit_byte<V: Fold + ?Sized>(_visitor: &mut V, _i: LitByte) -> LitByte {
+    let span = _visitor.fold_span(_i.span());
+    let mut _i = _i;
+    _i.set_span(span);
+    _i
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+pub fn fold_lit_byte_str<V: Fold + ?Sized>(_visitor: &mut V, _i: LitByteStr) -> LitByteStr {
+    let span = _visitor.fold_span(_i.span());
+    let mut _i = _i;
+    _i.set_span(span);
+    _i
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+pub fn fold_lit_char<V: Fold + ?Sized>(_visitor: &mut V, _i: LitChar) -> LitChar {
+    let span = _visitor.fold_span(_i.span());
+    let mut _i = _i;
+    _i.set_span(span);
+    _i
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+pub fn fold_lit_float<V: Fold + ?Sized>(_visitor: &mut V, _i: LitFloat) -> LitFloat {
+    let span = _visitor.fold_span(_i.span());
+    let mut _i = _i;
+    _i.set_span(span);
+    _i
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+pub fn fold_lit_int<V: Fold + ?Sized>(_visitor: &mut V, _i: LitInt) -> LitInt {
+    let span = _visitor.fold_span(_i.span());
+    let mut _i = _i;
+    _i.set_span(span);
+    _i
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+pub fn fold_lit_str<V: Fold + ?Sized>(_visitor: &mut V, _i: LitStr) -> LitStr {
+    let span = _visitor.fold_span(_i.span());
+    let mut _i = _i;
+    _i.set_span(span);
+    _i
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn fold_lit_verbatim<V: Fold + ?Sized>(_visitor: &mut V, _i: LitVerbatim) -> LitVerbatim {


### PR DESCRIPTION
Separating the three mostly independent codegen steps into separate modules gives code that is much easier to follow for only 8% increase in lines of code.

```console
$ git diff --stat origin/master..HEAD -- codegen
 codegen/src/fold.rs      | 260 +++++++++++++++++++
 codegen/src/full.rs      |  20 ++
 codegen/src/gen.rs       | 775 ++-------------------------------------------------------
 codegen/src/main.rs      |   9 +-
 codegen/src/operand.rs   |  38 +++
 codegen/src/visit.rs     | 234 +++++++++++++++++
 codegen/src/visit_mut.rs | 233 +++++++++++++++++
 7 files changed, 817 insertions(+), 752 deletions(-)
```