### PR TITLE
Fix order to be "const async unsafe" everywhere

### DIFF
--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -1935,8 +1935,8 @@ pub fn fold_item_fn<V: Fold + ?Sized>(_visitor: &mut V, _i: ItemFn) -> ItemFn {
         attrs: FoldHelper::lift(_i.attrs, |it| _visitor.fold_attribute(it)),
         vis: _visitor.fold_visibility(_i.vis),
         constness: (_i.constness).map(|it| Token![const](tokens_helper(_visitor, &it.span))),
-        unsafety: (_i.unsafety).map(|it| Token![unsafe](tokens_helper(_visitor, &it.span))),
         asyncness: (_i.asyncness).map(|it| Token![async](tokens_helper(_visitor, &it.span))),
+        unsafety: (_i.unsafety).map(|it| Token![unsafe](tokens_helper(_visitor, &it.span))),
         abi: (_i.abi).map(|it| _visitor.fold_abi(it)),
         ident: _visitor.fold_ident(_i.ident),
         decl: Box::new(_visitor.fold_fn_decl(*_i.decl)),
@@ -2285,8 +2285,8 @@ pub fn fold_meta_name_value<V: Fold + ?Sized>(
 pub fn fold_method_sig<V: Fold + ?Sized>(_visitor: &mut V, _i: MethodSig) -> MethodSig {
     MethodSig {
         constness: (_i.constness).map(|it| Token![const](tokens_helper(_visitor, &it.span))),
-        unsafety: (_i.unsafety).map(|it| Token![unsafe](tokens_helper(_visitor, &it.span))),
         asyncness: (_i.asyncness).map(|it| Token![async](tokens_helper(_visitor, &it.span))),
+        unsafety: (_i.unsafety).map(|it| Token![unsafe](tokens_helper(_visitor, &it.span))),
         abi: (_i.abi).map(|it| _visitor.fold_abi(it)),
         ident: _visitor.fold_ident(_i.ident),
         decl: _visitor.fold_fn_decl(_i.decl),

--- a/src/item.rs
+++ b/src/item.rs
@@ -84,8 +84,8 @@ ast_enum_of_structs! {
             pub attrs: Vec<Attribute>,
             pub vis: Visibility,
             pub constness: Option<Token![const]>,
-            pub unsafety: Option<Token![unsafe]>,
             pub asyncness: Option<Token![async]>,
+            pub unsafety: Option<Token![unsafe]>,
             pub abi: Option<Abi>,
             pub ident: Ident,
             pub decl: Box<FnDecl>,
@@ -687,8 +687,8 @@ ast_struct! {
     /// *This type is available if Syn is built with the `"full"` feature.*
     pub struct MethodSig {
         pub constness: Option<Token![const]>,
-        pub unsafety: Option<Token![unsafe]>,
         pub asyncness: Option<Token![async]>,
+        pub unsafety: Option<Token![unsafe]>,
         pub abi: Option<Abi>,
         pub ident: Ident,
         pub decl: FnDecl,
@@ -1114,8 +1114,8 @@ pub mod parsing {
                 attrs: private::attrs(outer_attrs, inner_attrs),
                 vis: vis,
                 constness: constness,
-                unsafety: unsafety,
                 asyncness: asyncness,
+                unsafety: unsafety,
                 abi: abi,
                 ident: ident,
                 decl: Box::new(FnDecl {
@@ -1759,8 +1759,8 @@ pub mod parsing {
                 attrs: private::attrs(outer_attrs, inner_attrs),
                 sig: MethodSig {
                     constness: constness,
-                    unsafety: unsafety,
                     asyncness: None,
+                    unsafety: unsafety,
                     abi: abi,
                     ident: ident,
                     decl: FnDecl {
@@ -1987,8 +1987,8 @@ pub mod parsing {
             let vis: Visibility = input.parse()?;
             let defaultness: Option<Token![default]> = input.parse()?;
             let constness: Option<Token![const]> = input.parse()?;
-            let unsafety: Option<Token![unsafe]> = input.parse()?;
             let asyncness: Option<Token![async]> = input.parse()?;
+            let unsafety: Option<Token![unsafe]> = input.parse()?;
             let abi: Option<Abi> = input.parse()?;
             let fn_token: Token![fn] = input.parse()?;
             let ident: Ident = input.parse()?;
@@ -2012,8 +2012,8 @@ pub mod parsing {
                 defaultness: defaultness,
                 sig: MethodSig {
                     constness: constness,
-                    unsafety: unsafety,
                     asyncness: asyncness,
+                    unsafety: unsafety,
                     abi: abi,
                     ident: ident,
                     decl: FnDecl {
@@ -2625,8 +2625,8 @@ mod printing {
     impl ToTokens for MethodSig {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             self.constness.to_tokens(tokens);
-            self.unsafety.to_tokens(tokens);
             self.asyncness.to_tokens(tokens);
+            self.unsafety.to_tokens(tokens);
             self.abi.to_tokens(tokens);
             NamedDecl(&self.decl, &self.ident).to_tokens(tokens);
         }

--- a/syn.json
+++ b/syn.json
@@ -3055,14 +3055,14 @@
             "token": "Const"
           }
         },
-        "unsafety": {
-          "option": {
-            "token": "Unsafe"
-          }
-        },
         "asyncness": {
           "option": {
             "token": "Async"
+          }
+        },
+        "unsafety": {
+          "option": {
+            "token": "Unsafe"
           }
         },
         "abi": {
@@ -3983,14 +3983,14 @@
             "token": "Const"
           }
         },
-        "unsafety": {
-          "option": {
-            "token": "Unsafe"
-          }
-        },
         "asyncness": {
           "option": {
             "token": "Async"
+          }
+        },
+        "unsafety": {
+          "option": {
+            "token": "Unsafe"
           }
         },
         "abi": {

--- a/tests/common/eq.rs
+++ b/tests/common/eq.rs
@@ -277,7 +277,7 @@ spanless_eq_struct!(Expr; id node span attrs);
 spanless_eq_struct!(Field; ident expr span is_shorthand attrs);
 spanless_eq_struct!(FieldPat; ident pat is_shorthand attrs);
 spanless_eq_struct!(FnDecl; inputs output c_variadic);
-spanless_eq_struct!(FnHeader; unsafety asyncness constness abi);
+spanless_eq_struct!(FnHeader; constness asyncness unsafety abi);
 spanless_eq_struct!(ForeignItem; ident attrs node id span vis);
 spanless_eq_struct!(ForeignMod; abi items);
 spanless_eq_struct!(GenericParam; id ident attrs bounds kind);


### PR DESCRIPTION
Found them with `rg --sort path -C1 asyncness`.

As for the tests – I've run `cargo test --release --all-features` with rustc
nightly on macOS 10.13, but only after ignoring the two `#[test]` sections in
tests/test_precedence.rs, because it was giving me a stack overflow.