### PR TITLE
Emit `..=` instead of `...` for inclusive range syntax in patterns.

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3703,7 +3703,7 @@ mod printing {
             self.lo.to_tokens(tokens);
             match self.limits {
                 RangeLimits::HalfOpen(ref t) => t.to_tokens(tokens),
-                RangeLimits::Closed(ref t) => Token![...](t.spans).to_tokens(tokens),
+                RangeLimits::Closed(ref t) => t.to_tokens(tokens),
             }
             self.hi.to_tokens(tokens);
         }


### PR DESCRIPTION
Fixes #650.

This requires Rust 1.26.0, released May 2018: https://blog.rust-lang.org/2018/05/10/Rust-1.26.html#inclusive-ranges-with-.= . If that's not acceptable, I can implement another solution.