### PR TITLE
Switch to intra rustdoc links

### DIFF
--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -248,7 +248,7 @@ pub fn generate(defs: &Definitions) -> Result<()> {
             ///
             /// See the [module documentation] for details.
             ///
-            /// [module documentation]: index.html
+            /// [module documentation]: self
             ///
             /// *This trait is available if Syn is built with the `"fold"` feature.*
             pub trait Fold {

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -222,7 +222,7 @@ pub fn generate(defs: &Definitions) -> Result<()> {
             ///
             /// See the [module documentation] for details.
             ///
-            /// [module documentation]: index.html
+            /// [module documentation]: self
             ///
             /// *This trait is available if Syn is built with the `"visit"` feature.*
             pub trait Visit<'ast> {

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -221,7 +221,7 @@ pub fn generate(defs: &Definitions) -> Result<()> {
             ///
             /// See the [module documentation] for details.
             ///
-            /// [module documentation]: index.html
+            /// [module documentation]: self
             ///
             /// *This trait is available if Syn is built with the `"visit-mut"` feature.*
             pub trait VisitMut {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -53,7 +53,7 @@ ast_struct! {
     /// into the structured representation that is used by convention across
     /// most Rust libraries.
     ///
-    /// [`parse_meta`]: #method.parse_meta
+    /// [`parse_meta`]: Attribute::parse_meta
     ///
     /// # Parsing
     ///
@@ -63,11 +63,9 @@ ast_struct! {
     /// [`Attribute::parse_outer`] or [`Attribute::parse_inner`] depending on
     /// which you intend to parse.
     ///
-    /// [`Parse`]: parse/trait.Parse.html
-    /// [`ParseStream::parse`]: parse/struct.ParseBuffer.html#method.parse
-    /// [`ParseStream::call`]: parse/struct.ParseBuffer.html#method.call
-    /// [`Attribute::parse_outer`]: #method.parse_outer
-    /// [`Attribute::parse_inner`]: #method.parse_inner
+    /// [`Parse`]: parse::Parse
+    /// [`ParseStream::parse`]: parse::ParseBuffer::parse
+    /// [`ParseStream::call`]: parse::ParseBuffer::call
     ///
     /// ```edition2018
     /// use syn::{Attribute, Ident, Result, Token};
@@ -134,7 +132,7 @@ impl Hash for Attribute {
 
 impl Attribute {
     /// Parses the content of the attribute, consisting of the path and tts, as
-    /// a [`Meta`](enum.Meta.html) if possible.
+    /// a [`Meta`] if possible.
     ///
     /// Deprecated; use `parse_meta` instead.
     #[doc(hidden)]
@@ -175,7 +173,7 @@ impl Attribute {
     }
 
     /// Parses the content of the attribute, consisting of the path and tts, as
-    /// a [`Meta`](enum.Meta.html) if possible.
+    /// a [`Meta`] if possible.
     #[cfg(feature = "parsing")]
     pub fn parse_meta(&self) -> Result<Meta> {
         if let Some(ref colon) = self.path.leading_colon {
@@ -412,6 +410,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum Meta {
         pub Word(Ident),
         /// A structured list within an attribute, like `derive(Copy, Clone)`.

--- a/src/custom_keyword.rs
+++ b/src/custom_keyword.rs
@@ -26,10 +26,10 @@
 ///
 /// - Field access to its span — `let sp = whatever_token.span`
 ///
-/// [Peeking]: parse/struct.ParseBuffer.html#method.peek
-/// [Parsing]: parse/struct.ParseBuffer.html#method.parse
-/// [Printing]: https://docs.rs/quote/0.6/quote/trait.ToTokens.html
-/// [`Span`]: https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html
+/// [Peeking]: parse::ParseBuffer::peek
+/// [Parsing]: parse::ParseBuffer::parse
+/// [Printing]: quote::ToTokens
+/// [`Span`]: proc_macro2::Span
 ///
 /// # Example
 ///

--- a/src/custom_punctuation.rs
+++ b/src/custom_punctuation.rs
@@ -22,10 +22,10 @@
 ///
 /// - Field access to its spans — `let spans = lrarrow.spans`
 ///
-/// [Peeking]: parse/struct.ParseBuffer.html#method.peek
-/// [Parsing]: parse/struct.ParseBuffer.html#method.parse
-/// [Printing]: https://docs.rs/quote/0.6/quote/trait.ToTokens.html
-/// [`Span`]: https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html
+/// [Peeking]: parse::ParseBuffer::peek
+/// [Parsing]: parse::ParseBuffer::parse
+/// [Printing]: quote::ToTokens
+/// [`Span`]: proc_macro2::Span
 ///
 /// # Example
 ///

--- a/src/data.rs
+++ b/src/data.rs
@@ -32,6 +32,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum Fields {
         /// Named fields of a struct or struct variant such as `Point { x: f64,
         /// y: f64 }`.
@@ -61,8 +64,6 @@ impl Fields {
     /// Get an iterator over the borrowed [`Field`] items in this object. This
     /// iterator can be used to iterate over a named or unnamed struct or
     /// variant's fields uniformly.
-    ///
-    /// [`Field`]: struct.Field.html
     pub fn iter(&self) -> punctuated::Iter<Field> {
         match *self {
             Fields::Unit => private::empty_punctuated_iter(),
@@ -74,8 +75,6 @@ impl Fields {
     /// Get an iterator over the mutably borrowed [`Field`] items in this
     /// object. This iterator can be used to iterate over a named or unnamed
     /// struct or variant's fields uniformly.
-    ///
-    /// [`Field`]: struct.Field.html
     pub fn iter_mut(&mut self) -> punctuated::IterMut<Field> {
         match *self {
             Fields::Unit => private::empty_punctuated_iter_mut(),
@@ -139,6 +138,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum Visibility {
         /// A public visibility level: `pub`.
         ///

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -33,6 +33,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum Data {
         /// A struct input to a `proc_macro_derive` macro.
         ///

--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -24,7 +24,7 @@ pub trait Speculative {
     /// repetition, bypassing the need to involve the downsides associated with
     /// speculative parsing.
     ///
-    /// [`ParseStream::fork`]: ../struct.ParseBuffer.html#method.fork
+    /// [`ParseStream::fork`]: ParseBuffer::fork
     ///
     /// # Example
     ///
@@ -143,7 +143,7 @@ pub trait Speculative {
     /// possible, displaying reasonable errors becomes much more simple.
     ///
     /// [RFC 2544]: https://github.com/rust-lang/rfcs/pull/2544
-    /// [`PathSegment`]: ../../struct.PathSegment.html
+    /// [`PathSegment`]: crate::PathSegment
     ///
     /// # Performance
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// [module documentation]: index.html
 ///
 /// *This type is available if Syn is built with the `"parsing"` feature.*
+//
+// TODO: change the parse module link to an intra rustdoc link, currently
+// blocked on https://github.com/rust-lang/rust/issues/62830
 pub struct Error {
     // Span is implemented as an index into a thread-local interner to keep the
     // size small. It is not safe to access from a different thread. We want
@@ -48,7 +51,7 @@ impl Error {
     /// Use `Error::new` when the error needs to be triggered on some span other
     /// than where the parse stream is currently positioned.
     ///
-    /// [`ParseStream::error`]: struct.ParseBuffer.html#method.error
+    /// [`ParseStream::error`]: crate::parse::ParseBuffer::error
     ///
     /// # Example
     ///
@@ -135,7 +138,6 @@ impl Error {
     /// this method correctly in a procedural macro.
     ///
     /// [`compile_error!`]: https://doc.rust-lang.org/std/macro.compile_error.html
-    /// [`parse_macro_input!`]: ../macro.parse_macro_input.html
     pub fn to_compile_error(&self) -> TokenStream {
         let start = self
             .start_span

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -748,6 +748,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum Pat {
         /// A pattern that matches any value: `_`.
         ///

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -24,7 +24,7 @@ macro_rules! full {
 ///
 /// See the [module documentation] for details.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 ///
 /// *This trait is available if Syn is built with the `"fold"` feature.*
 pub trait Fold {

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -28,7 +28,7 @@ macro_rules! skip {
 ///
 /// See the [module documentation] for details.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 ///
 /// *This trait is available if Syn is built with the `"visit"` feature.*
 pub trait Visit<'ast> {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -28,7 +28,7 @@ macro_rules! skip {
 ///
 /// See the [module documentation] for details.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 ///
 /// *This trait is available if Syn is built with the `"visit-mut"` feature.*
 pub trait VisitMut {

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -28,6 +28,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum GenericParam {
         /// A generic type parameter: `T: Into<String>`.
         ///
@@ -432,6 +435,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum WherePredicate {
         /// A type predicate in a `where` clause: `for<'c> Foo<'c>: Trait<'c>`.
         ///

--- a/src/item.rs
+++ b/src/item.rs
@@ -19,6 +19,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum Item {
         /// An `extern crate` item: `extern crate serde`.
         ///
@@ -361,6 +364,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum UseTree {
         /// A path prefix of imports in a `use` item: `std::...`.
         ///
@@ -414,6 +420,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum ForeignItem {
         /// A foreign function in an `extern` block.
         ///
@@ -499,6 +508,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum TraitItem {
         /// An associated constant within the definition of a trait.
         ///
@@ -585,6 +597,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum ImplItem {
         /// An associated constant within an impl block.
         ///
@@ -719,6 +734,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum FnArg {
         /// Self captured by reference in a function signature: `&self` or `&mut
         /// self`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,7 @@ mod gen {
     /// default, every method recursively visits the substructure of the input
     /// by invoking the right visitor method of each of its fields.
     ///
-    /// [`Visit`]: trait.Visit.html
+    /// [`Visit`]: visit::Visit
     ///
     /// ```edition2018
     /// # use syn::{Attribute, BinOp, Expr, ExprBinary};
@@ -475,7 +475,7 @@ mod gen {
     /// By default, every method recursively visits the substructure of the
     /// input by invoking the right visitor method of each of its fields.
     ///
-    /// [`VisitMut`]: trait.VisitMut.html
+    /// [`VisitMut`]: visit_mut::VisitMut
     ///
     /// ```edition2018
     /// # use syn::{Attribute, BinOp, Expr, ExprBinary};
@@ -511,7 +511,7 @@ mod gen {
     /// By default, every method recursively visits the substructure of the
     /// input by invoking the right visitor method of each of its fields.
     ///
-    /// [`Fold`]: trait.Fold.html
+    /// [`Fold`]: fold::Fold
     ///
     /// ```edition2018
     /// # use syn::{Attribute, BinOp, Expr, ExprBinary};
@@ -591,7 +591,7 @@ pub use error::{Error, Result};
 /// interop with the compiler in a procedural macro. To parse a
 /// `proc_macro2::TokenStream`, use [`syn::parse2`] instead.
 ///
-/// [`syn::parse2`]: fn.parse2.html
+/// [`syn::parse2`]: parse2
 ///
 /// *This function is available if Syn is built with both the `"parsing"` and
 /// `"proc-macro"` features.*
@@ -638,8 +638,7 @@ pub fn parse<T: parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T> {
 /// `proc_macro::TokenStream` provided by the compiler, use [`syn::parse`]
 /// instead.
 ///
-/// [`Macro`]: struct.Macro.html
-/// [`syn::parse`]: fn.parse.html
+/// [`syn::parse`]: parse()
 ///
 /// *This function is available if Syn is built with the `"parsing"` feature.*
 #[cfg(feature = "parsing")]

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -28,6 +28,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum Lit {
         /// A UTF-8 string literal: `"foo"`.
         ///
@@ -644,7 +647,7 @@ mod value {
         /// doc comments are considered by proc-macro2 to be literals but in Syn
         /// they are [`Attribute`].
         ///
-        /// [`Attribute`]: struct.Attribute.html
+        /// [`Attribute`]: crate::Attribute
         ///
         /// # Panics
         ///

--- a/src/lookahead.rs
+++ b/src/lookahead.rs
@@ -17,8 +17,8 @@ use token::Token;
 ///
 /// Use [`ParseStream::lookahead1`] to construct this object.
 ///
-/// [`ParseStream::peek`]: struct.ParseBuffer.html#method.peek
-/// [`ParseStream::lookahead1`]: struct.ParseBuffer.html#method.lookahead1
+/// [`ParseStream::peek`]: crate::parse::ParseBuffer::peek
+/// [`ParseStream::lookahead1`]: crate::parse::ParseBuffer::lookahead1
 ///
 /// # Example
 ///
@@ -142,7 +142,7 @@ impl<'a> Lookahead1<'a> {
 ///
 /// This trait is sealed and cannot be implemented for types outside of Syn.
 ///
-/// [`ParseStream::peek`]: struct.ParseBuffer.html#method.peek
+/// [`ParseStream::peek`]: crate::parse::ParseBuffer::peek
 pub trait Peek: Sealed {
     // Not public API.
     #[doc(hidden)]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -227,7 +227,7 @@ pub trait Parse: Sized {
 /// See the methods of this type under the documentation of [`ParseBuffer`]. For
 /// an overview of parsing in Syn, refer to the [module documentation].
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 pub type ParseStream<'a> = &'a ParseBuffer<'a>;
 
 /// Cursor position within a buffered token stream.
@@ -248,7 +248,6 @@ pub type ParseStream<'a> = &'a ParseBuffer<'a>;
 /// - One of [the `syn::parse*` functions][syn-parse]; or
 /// - A method of the [`Parser`] trait.
 ///
-/// [`parse_macro_input!`]: ../macro.parse_macro_input.html
 /// [syn-parse]: index.html#the-synparse-functions
 pub struct ParseBuffer<'a> {
     scope: Span,
@@ -292,7 +291,7 @@ impl<'a> Debug for ParseBuffer<'a> {
 ///
 /// This type is the input of the closure provided to [`ParseStream::step`].
 ///
-/// [`ParseStream::step`]: struct.ParseBuffer.html#method.step
+/// [`ParseStream::step`]: ParseBuffer::step
 ///
 /// # Example
 ///
@@ -428,7 +427,7 @@ impl<'a> ParseBuffer<'a> {
     /// The parser below invokes [`Attribute::parse_outer`] to parse a vector of
     /// zero or more outer attributes.
     ///
-    /// [`Attribute::parse_outer`]: ../struct.Attribute.html#method.parse_outer
+    /// [`Attribute::parse_outer`]: crate::Attribute::parse_outer
     ///
     /// ```edition2018
     /// use syn::{Attribute, Ident, Result, Token};
@@ -756,8 +755,8 @@ impl<'a> ParseBuffer<'a> {
     /// For a lower level way to perform speculative parsing at the token level,
     /// consider using [`ParseStream::step`] instead.
     ///
-    /// [`parse::discouraged::Speculative`]: ./discouraged/trait.Speculative.html
-    /// [`ParseStream::step`]: #method.step
+    /// [`parse::discouraged::Speculative`]: discouraged::Speculative
+    /// [`ParseStream::step`]: ParseBuffer::step
     ///
     /// # Example
     ///
@@ -1052,7 +1051,7 @@ impl Parse for Literal {
 ///
 /// Refer to the [module documentation] for details about parsing in Syn.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 ///
 /// *This trait is available if Syn is built with the `"parsing"` feature.*
 pub trait Parser: Sized {

--- a/src/parse_macro_input.rs
+++ b/src/parse_macro_input.rs
@@ -36,6 +36,9 @@
 /// #   "".parse().unwrap()
 /// }
 /// ```
+//
+// TODO: change the parse module link to an intra rustdoc link, currently
+// blocked on https://github.com/rust-lang/rust/issues/62830
 #[macro_export(local_inner_macros)]
 macro_rules! parse_macro_input {
     ($tokenstream:ident as $ty:ty) => {

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -6,7 +6,7 @@
 /// The return type can be any syntax tree node that implements the [`Parse`]
 /// trait.
 ///
-/// [`Parse`]: parse/trait.Parse.html
+/// [`Parse`]: parse::Parse
 ///
 /// ```edition2018
 /// use quote::quote;
@@ -57,14 +57,16 @@
 /// - [`Punctuated<T, P>`] — parses zero or more `T` separated by punctuation
 ///   `P` with optional trailing punctuation
 ///
-/// [`Attribute`]: struct.Attribute.html
-/// [`Punctuated<T, P>`]: punctuated/struct.Punctuated.html
+/// [`Punctuated<T, P>`]: punctuated::Punctuated
 ///
 /// # Panics
 ///
 /// Panics if the tokens fail to parse as the expected syntax tree type. The
 /// caller is responsible for ensuring that the input tokens are syntactically
 /// valid.
+//
+// TODO: allow Punctuated to be inferred as intra doc link, currently blocked on
+// https://github.com/rust-lang/rust/issues/62834
 #[macro_export(local_inner_macros)]
 macro_rules! parse_quote {
     ($($tt:tt)*) => {

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -43,7 +43,7 @@ use token::Token;
 ///
 /// Refer to the [module documentation] for details about punctuated sequences.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 #[cfg_attr(feature = "extra-traits", derive(Eq, PartialEq, Hash))]
 #[cfg_attr(feature = "clone-impls", derive(Clone))]
 pub struct Punctuated<T, P> {
@@ -155,7 +155,7 @@ impl<T, P> Punctuated<T, P> {
     /// Use [`push`] instead if the punctuated sequence may or may not already
     /// have trailing punctuation.
     ///
-    /// [`push`]: #method.push
+    /// [`push`]: Punctuated::push
     ///
     /// # Panics
     ///
@@ -261,7 +261,7 @@ impl<T, P> Punctuated<T, P> {
     /// Like [`parse_terminated`], the entire content of this stream is expected
     /// to be parsed.
     ///
-    /// [`parse_terminated`]: #method.parse_terminated
+    /// [`parse_terminated`]: Punctuated::parse_terminated
     ///
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
@@ -317,7 +317,7 @@ impl<T, P> Punctuated<T, P> {
     /// Like [`parse_separated_nonempty`], may complete early without parsing
     /// the entire content of this stream.
     ///
-    /// [`parse_separated_nonempty`]: #method.parse_separated_nonempty
+    /// [`parse_separated_nonempty`]: Punctuated::parse_separated_nonempty
     ///
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
@@ -453,7 +453,7 @@ impl<T, P> Default for Punctuated<T, P> {
 ///
 /// Refer to the [module documentation] for details about punctuated sequences.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 pub struct Pairs<'a, T: 'a, P: 'a> {
     inner: slice::Iter<'a, (T, P)>,
     last: option::IntoIter<&'a T>,
@@ -490,7 +490,7 @@ impl<'a, T, P> Clone for Pairs<'a, T, P> {
 ///
 /// Refer to the [module documentation] for details about punctuated sequences.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 pub struct PairsMut<'a, T: 'a, P: 'a> {
     inner: slice::IterMut<'a, (T, P)>,
     last: option::IntoIter<&'a mut T>,
@@ -517,7 +517,7 @@ impl<'a, T, P> ExactSizeIterator for PairsMut<'a, T, P> {
 ///
 /// Refer to the [module documentation] for details about punctuated sequences.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 #[derive(Clone)]
 pub struct IntoPairs<T, P> {
     inner: vec::IntoIter<(T, P)>,
@@ -545,7 +545,7 @@ impl<T, P> ExactSizeIterator for IntoPairs<T, P> {
 ///
 /// Refer to the [module documentation] for details about punctuated sequences.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 #[derive(Clone)]
 pub struct IntoIter<T, P> {
     inner: vec::IntoIter<T>,
@@ -572,7 +572,7 @@ impl<T, P> ExactSizeIterator for IntoIter<T, P> {
 ///
 /// Refer to the [module documentation] for details about punctuated sequences.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 pub struct Iter<'a, T: 'a> {
     // The `Item = &'a T` needs to be specified to support rustc 1.31 and older.
     // On modern compilers we would be able to write just IterTrait<'a, T> where
@@ -661,7 +661,7 @@ where
 ///
 /// Refer to the [module documentation] for details about punctuated sequences.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 pub struct IterMut<'a, T: 'a> {
     inner: Box<ExactSizeIterator<Item = &'a mut T> + 'a>,
 }
@@ -716,7 +716,7 @@ impl<'a, T, P> ExactSizeIterator for PrivateIterMut<'a, T, P> {
 ///
 /// Refer to the [module documentation] for details about punctuated sequences.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 #[cfg_attr(feature = "clone-impls", derive(Clone))]
 pub enum Pair<T, P> {
     Punctuated(T, P),

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -74,11 +74,11 @@ use quote::ToTokens;
 /// [`ToTokens`] from the `quote` crate. It is sealed and cannot be implemented
 /// outside of the Syn crate other than by implementing `ToTokens`.
 ///
-/// [`ToTokens`]: https://docs.rs/quote/0.6/quote/trait.ToTokens.html
+/// [`ToTokens`]: quote::ToTokens
 ///
 /// See the [module documentation] for an example.
 ///
-/// [module documentation]: index.html
+/// [module documentation]: self
 ///
 /// *This trait is available if Syn is built with both the `"parsing"` and
 /// `"printing"` features.*
@@ -86,7 +86,7 @@ pub trait Spanned: private::Sealed {
     /// Returns a `Span` covering the complete contents of this syntax tree
     /// node, or [`Span::call_site()`] if this node is empty.
     ///
-    /// [`Span::call_site()`]: https://docs.rs/proc-macro2/0.4/proc_macro2/struct.Span.html#method.call_site
+    /// [`Span::call_site()`]: proc_macro2::Span::call_site
     fn span(&self) -> Span;
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -239,7 +239,7 @@ macro_rules! define_keywords {
             /// Don't try to remember the name of this type -- use the [`Token!`]
             /// macro instead.
             ///
-            /// [`Token!`]: index.html
+            /// [`Token!`]: crate::token
             pub struct $name {
                 pub span: Span,
             }
@@ -345,7 +345,7 @@ macro_rules! define_punctuation_structs {
             /// Don't try to remember the name of this type -- use the [`Token!`]
             /// macro instead.
             ///
-            /// [`Token!`]: index.html
+            /// [`Token!`]: crate::token
             pub struct $name {
                 pub spans: [Span; $len],
             }
@@ -708,7 +708,7 @@ macro_rules! export_token_macro {
         ///
         /// See the [token module] documentation for details and examples.
         ///
-        /// [token module]: token/index.html
+        /// [token module]: crate::token
         // Unfortunate duplication due to a rustdoc bug.
         // https://github.com/rust-lang/rust/issues/45939
         #[macro_export]

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -17,6 +17,9 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: enum.Expr.html#syntax-tree-enums
+    //
+    // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
+    // blocked on https://github.com/rust-lang/rust/issues/62833
     pub enum Type {
         /// A dynamically sized slice type: `[T]`.
         ///


### PR DESCRIPTION
Fixes #670.

Nightly rustdoc is required to render these links for now, but that should be fine. At least this way they all point to the right place!

Some rustdoc issues that would have made this better:

- https://github.com/rust-lang/rust/issues/62830
- https://github.com/rust-lang/rust/issues/62833
- https://github.com/rust-lang/rust/issues/62834