### PR TITLE
Switch to base10_digits() as the main numeric literal accessor

### DIFF
--- a/codegen/src/debug.rs
+++ b/codegen/src/debug.rs
@@ -251,8 +251,14 @@ fn expand_impl_body(defs: &Definitions, node: &Node, name: &str) -> TokenStream 
             }
         }
         Data::Private => {
-            quote! {
-                write!(formatter, "{:?}", _val.value())
+            if node.ident == "LitInt" || node.ident == "LitFloat" {
+                quote! {
+                    write!(formatter, "{}", _val)
+                }
+            } else {
+                quote! {
+                    write!(formatter, "{:?}", _val.value())
+                }
             }
         }
     }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -15,12 +15,28 @@ impl BigInt {
     pub fn to_string(&self) -> String {
         unimplemented!()
     }
+
+    fn reserve_two_digits(&mut self) {
+        let len = self.digits.len();
+        let desired = len
+            + !self.digits.ends_with(&[0, 0]) as usize
+            + !self.digits.ends_with(&[0]) as usize;
+        self.digits.resize(desired, 0);
+    }
 }
 
 impl AddAssign<u8> for BigInt {
-    fn add_assign(&mut self, increment: u8) {
-        let _ = increment;
-        unimplemented!()
+    // Assumes increment <16.
+    fn add_assign(&mut self, mut increment: u8) {
+        self.reserve_two_digits();
+
+        let mut i = 0;
+        while increment > 0 {
+            let sum = self.digits[i] + increment;
+            self.digits[i] = sum % 10;
+            increment = sum / 10;
+            i += 1;
+        }
     }
 }
 

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -41,8 +41,15 @@ impl AddAssign<u8> for BigInt {
 }
 
 impl MulAssign<u8> for BigInt {
+    // Assumes base <=16.
     fn mul_assign(&mut self, base: u8) {
-        let _ = base;
-        unimplemented!()
+        self.reserve_two_digits();
+
+        let mut carry = 0;
+        for digit in &mut self.digits {
+            let prod = *digit * base + carry;
+            *digit = prod % 10;
+            carry = prod / 10;
+        }
     }
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -13,7 +13,21 @@ impl BigInt {
     }
 
     pub fn to_string(&self) -> String {
-        unimplemented!()
+        let mut repr = String::with_capacity(self.digits.len());
+
+        let mut has_nonzero = false;
+        for digit in self.digits.iter().rev() {
+            has_nonzero |= *digit != 0;
+            if has_nonzero {
+                repr.push((*digit + b'0') as char);
+            }
+        }
+
+        if repr.is_empty() {
+            repr.push('0');
+        }
+
+        repr
     }
 
     fn reserve_two_digits(&mut self) {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1,0 +1,32 @@
+use std::ops::{AddAssign, MulAssign};
+
+// For implementing base10_digits() accessor on LitInt.
+pub struct BigInt {
+    digits: Vec<u8>,
+}
+
+impl BigInt {
+    pub fn new() -> Self {
+        BigInt {
+            digits: Vec::new(),
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        unimplemented!()
+    }
+}
+
+impl AddAssign<u8> for BigInt {
+    fn add_assign(&mut self, increment: u8) {
+        let _ = increment;
+        unimplemented!()
+    }
+}
+
+impl MulAssign<u8> for BigInt {
+    fn mul_assign(&mut self, base: u8) {
+        let _ = base;
+        unimplemented!()
+    }
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2968,9 +2968,12 @@ pub mod parsing {
     impl Parse for Index {
         fn parse(input: ParseStream) -> Result<Self> {
             let lit: LitInt = input.parse()?;
-            if let IntSuffix::None = lit.suffix() {
+            if lit.suffix().is_empty() {
                 Ok(Index {
-                    index: lit.value() as u32,
+                    index: lit
+                        .base10_digits()
+                        .parse()
+                        .map_err(|err| Error::new(lit.span(), err))?,
                     span: lit.span(),
                 })
             } else {

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -6,6 +6,7 @@ use crate::lookahead;
 use crate::parse::{Parse, ParseStream, Result};
 #[cfg(feature = "parsing")]
 use crate::token::Token;
+use unicode_xid::UnicodeXID;
 
 pub use proc_macro2::Ident;
 
@@ -83,4 +84,18 @@ impl From<Token![_]> for Ident {
     fn from(token: Token![_]) -> Ident {
         Ident::new("_", token.span)
     }
+}
+
+pub fn xid_ok(symbol: &str) -> bool {
+    let mut chars = symbol.chars();
+    let first = chars.next().unwrap();
+    if !(UnicodeXID::is_xid_start(first) || first == '_') {
+        return false;
+    }
+    for ch in chars {
+        if !UnicodeXID::is_xid_continue(ch) {
+            return false;
+        }
+    }
+    true
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,9 @@ pub use crate::attr::{
 };
 
 #[cfg(any(feature = "full", feature = "derive"))]
+mod bigint;
+
+#[cfg(any(feature = "full", feature = "derive"))]
 mod data;
 #[cfg(any(feature = "full", feature = "derive"))]
 pub use crate::data::{
@@ -372,8 +375,7 @@ pub use crate::lifetime::Lifetime;
 mod lit;
 #[cfg(any(feature = "full", feature = "derive"))]
 pub use crate::lit::{
-    FloatSuffix, IntSuffix, Lit, LitBool, LitByte, LitByteStr, LitChar, LitFloat, LitInt, LitStr,
-    StrStyle,
+    Lit, LitBool, LitByte, LitByteStr, LitChar, LitFloat, LitInt, LitStr, StrStyle,
 };
 
 #[cfg(any(feature = "full", feature = "derive"))]

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -3,7 +3,6 @@ use std::fmt::{self, Display};
 use std::hash::{Hash, Hasher};
 
 use proc_macro2::{Ident, Span};
-use unicode_xid::UnicodeXID;
 
 #[cfg(feature = "parsing")]
 use crate::lookahead;
@@ -55,21 +54,7 @@ impl Lifetime {
             panic!("lifetime name must not be empty");
         }
 
-        fn xid_ok(symbol: &str) -> bool {
-            let mut chars = symbol.chars();
-            let first = chars.next().unwrap();
-            if !(UnicodeXID::is_xid_start(first) || first == '_') {
-                return false;
-            }
-            for ch in chars {
-                if !UnicodeXID::is_xid_continue(ch) {
-                    return false;
-                }
-            }
-            true
-        }
-
-        if !xid_ok(&symbol[1..]) {
+        if !crate::ident::xid_ok(&symbol[1..]) {
             panic!("{:?} is not a valid lifetime name", symbol);
         }
 

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -1091,7 +1091,7 @@ mod value {
         let mut write = start;
         let mut has_dot = false;
         let mut has_e = false;
-        let mut has_neg = false;
+        let mut has_sign = false;
         let mut has_exponent = false;
         while read < bytes.len() {
             match bytes[read] {
@@ -1100,11 +1100,11 @@ mod value {
                     read += 1;
                     continue;
                 }
-                b @ b'0'..=b'9' => {
+                b'0'..=b'9' => {
                     if has_e {
                         has_exponent = true;
                     }
-                    bytes[write] = b;
+                    bytes[write] = bytes[read];
                 }
                 b'.' => {
                     if has_e || has_dot {
@@ -1120,12 +1120,18 @@ mod value {
                     has_e = true;
                     bytes[write] = b'e';
                 }
-                b'-' => {
-                    if has_neg || has_exponent || !has_e {
+                b'-' | b'+' => {
+                    if has_sign || has_exponent || !has_e {
                         return None;
                     }
-                    has_neg = true;
-                    bytes[write] = b'-';
+                    has_sign = true;
+                    if bytes[read] == b'-' {
+                        bytes[write] = bytes[read];
+                    } else {
+                        // Omit '+'
+                        read += 1;
+                        continue;
+                    }
                 }
                 _ => break,
             }

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -3591,8 +3591,8 @@ impl Debug for Lite<syn::Lit> {
             syn::Lit::ByteStr(_val) => write!(formatter, "{:?}", _val.value()),
             syn::Lit::Byte(_val) => write!(formatter, "{:?}", _val.value()),
             syn::Lit::Char(_val) => write!(formatter, "{:?}", _val.value()),
-            syn::Lit::Int(_val) => write!(formatter, "{:?}", _val.value()),
-            syn::Lit::Float(_val) => write!(formatter, "{:?}", _val.value()),
+            syn::Lit::Int(_val) => write!(formatter, "{}", _val),
+            syn::Lit::Float(_val) => write!(formatter, "{}", _val),
             syn::Lit::Bool(_val) => {
                 let mut formatter = formatter.debug_struct("Lit::Bool");
                 formatter.field("value", Lite(&_val.value));
@@ -3637,13 +3637,13 @@ impl Debug for Lite<syn::LitChar> {
 impl Debug for Lite<syn::LitFloat> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let _val = &self.value;
-        write!(formatter, "{:?}", _val.value())
+        write!(formatter, "{}", _val)
     }
 }
 impl Debug for Lite<syn::LitInt> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let _val = &self.value;
-        write!(formatter, "{:?}", _val.value())
+        write!(formatter, "{}", _val)
     }
 }
 impl Debug for Lite<syn::LitStr> {

--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -299,7 +299,7 @@ fn test_enum() {
    ⋮                ident: "Surprise",
    ⋮                fields: Unit,
    ⋮                discriminant: Some(Expr::Lit {
-   ⋮                    lit: 0,
+   ⋮                    lit: 0isize,
    ⋮                }),
    ⋮            },
    ⋮            Variant {

--- a/tests/test_grouping.rs
+++ b/tests/test_grouping.rs
@@ -33,24 +33,24 @@ fn test_grouping() {
     snapshot!(tokens as Expr, @r###"
    ⋮Expr::Binary {
    ⋮    left: Expr::Lit {
-   ⋮        lit: 1,
+   ⋮        lit: 1i32,
    ⋮    },
    ⋮    op: Add,
    ⋮    right: Expr::Binary {
    ⋮        left: Expr::Group {
    ⋮            expr: Expr::Binary {
    ⋮                left: Expr::Lit {
-   ⋮                    lit: 2,
+   ⋮                    lit: 2i32,
    ⋮                },
    ⋮                op: Add,
    ⋮                right: Expr::Lit {
-   ⋮                    lit: 3,
+   ⋮                    lit: 3i32,
    ⋮                },
    ⋮            },
    ⋮        },
    ⋮        op: Mul,
    ⋮        right: Expr::Lit {
-   ⋮            lit: 4,
+   ⋮            lit: 4i32,
    ⋮        },
    ⋮    },
    ⋮}

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -7,7 +7,7 @@ mod features;
 use proc_macro2::{TokenStream, TokenTree};
 use quote::ToTokens;
 use std::str::FromStr;
-use syn::{FloatSuffix, IntSuffix, Lit};
+use syn::Lit;
 
 fn lit(s: &str) -> Lit {
     match TokenStream::from_str(s)
@@ -129,10 +129,10 @@ fn chars() {
 
 #[test]
 fn ints() {
-    fn test_int(s: &str, value: u64, suffix: IntSuffix) {
+    fn test_int(s: &str, value: u64, suffix: &str) {
         match lit(s) {
             Lit::Int(lit) => {
-                assert_eq!(lit.value(), value);
+                assert_eq!(lit.base10_digits().parse::<u64>().unwrap(), value);
                 assert_eq!(lit.suffix(), suffix);
                 let again = lit.into_token_stream().to_string();
                 if again != s {
@@ -143,34 +143,33 @@ fn ints() {
         }
     }
 
-    use syn::IntSuffix::*;
-    test_int("5", 5, None);
-    test_int("5u32", 5, U32);
-    test_int("5_0", 50, None);
-    test_int("5_____0_____", 50, None);
-    test_int("0x7f", 127, None);
-    test_int("0x7F", 127, None);
-    test_int("0b1001", 9, None);
-    test_int("0o73", 59, None);
-    test_int("0x7Fu8", 127, U8);
-    test_int("0b1001i8", 9, I8);
-    test_int("0o73u32", 59, U32);
-    test_int("0x__7___f_", 127, None);
-    test_int("0x__7___F_", 127, None);
-    test_int("0b_1_0__01", 9, None);
-    test_int("0o_7__3", 59, None);
-    test_int("0x_7F__u8", 127, U8);
-    test_int("0b__10__0_1i8", 9, I8);
-    test_int("0o__7__________________3u32", 59, U32);
+    test_int("5", 5, "");
+    test_int("5u32", 5, "u32");
+    test_int("5_0", 50, "");
+    test_int("5_____0_____", 50, "");
+    test_int("0x7f", 127, "");
+    test_int("0x7F", 127, "");
+    test_int("0b1001", 9, "");
+    test_int("0o73", 59, "");
+    test_int("0x7Fu8", 127, "u8");
+    test_int("0b1001i8", 9, "i8");
+    test_int("0o73u32", 59, "u32");
+    test_int("0x__7___f_", 127, "");
+    test_int("0x__7___F_", 127, "");
+    test_int("0b_1_0__01", 9, "");
+    test_int("0o_7__3", 59, "");
+    test_int("0x_7F__u8", 127, "u8");
+    test_int("0b__10__0_1i8", 9, "i8");
+    test_int("0o__7__________________3u32", 59, "u32");
 }
 
 #[test]
 fn floats() {
     #[cfg_attr(feature = "cargo-clippy", allow(float_cmp))]
-    fn test_float(s: &str, value: f64, suffix: FloatSuffix) {
+    fn test_float(s: &str, value: f64, suffix: &str) {
         match lit(s) {
             Lit::Float(lit) => {
-                assert_eq!(lit.value(), value);
+                assert_eq!(lit.base10_digits().parse::<f64>().unwrap(), value);
                 assert_eq!(lit.suffix(), suffix);
                 let again = lit.into_token_stream().to_string();
                 if again != s {
@@ -181,10 +180,9 @@ fn floats() {
         }
     }
 
-    use syn::FloatSuffix::*;
-    test_float("5.5", 5.5, None);
-    test_float("5.5E12", 5.5e12, None);
-    test_float("5.5e12", 5.5e12, None);
-    test_float("1.0__3e-12", 1.03e-12, None);
-    test_float("1.03e+12", 1.03e12, None);
+    test_float("5.5", 5.5, "");
+    test_float("5.5E12", 5.5e12, "");
+    test_float("5.5e12", 5.5e12, "");
+    test_float("1.0__3e-12", 1.03e-12, "");
+    test_float("1.03e+12", 1.03e12, "");
 }


### PR DESCRIPTION
Closes #663. Closes #664.