### PR TITLE
Method to parse Attribute with better spans

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1092,6 +1092,12 @@ pub trait Parser: Sized {
         let _ = scope;
         self.parse2(tokens)
     }
+
+    // Not public API.
+    #[doc(hidden)]
+    fn __parse_stream(self, input: ParseStream) -> Result<Self::Output> {
+        input.parse().and_then(|tokens| self.parse2(tokens))
+    }
 }
 
 fn tokens_to_parse_buffer(tokens: &TokenBuffer) -> ParseBuffer {
@@ -1133,10 +1139,19 @@ where
             Err(state.error("unexpected token"))
         }
     }
+
+    #[doc(hidden)]
+    fn __parse_stream(self, input: ParseStream) -> Result<Self::Output> {
+        self(input)
+    }
 }
 
 pub(crate) fn parse_scoped<F: Parser>(f: F, scope: Span, tokens: TokenStream) -> Result<F::Output> {
     f.__parse_scoped(scope, tokens)
+}
+
+pub(crate) fn parse_stream<F: Parser>(f: F, input: ParseStream) -> Result<F::Output> {
+    f.__parse_stream(input)
 }
 
 /// An empty syntax tree node that consumes no tokens when parsed.


### PR DESCRIPTION
Fixes #523.

For example:

```rust
let e = item.attrs[0].parse_args::<Expr>()?;
```

- When there is no arg provided:

```console
error: expected attribute arguments: #[m::my_attr(...)]
 --> src/main.rs:2:5
  |
2 |     #[m::my_attr]
  |     ^^^^^^^^^^^^^
```

- When the arg is unexpectedly empty:

```console
error: unexpected end of input, expected expression
 --> src/main.rs:2:18
  |
2 |     #[m::my_attr()]
  |                  ^
```

- When the arg is weird in some way:

```console
error: unexpected token in attribute arguments
 --> src/main.rs:2:18
  |
2 |     #[m::my_attr >>]
  |                  ^^
```