### PR TITLE
Add `len` and `is_empty` methods to `Fields`

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -93,6 +93,24 @@ impl Fields {
             Fields::Unnamed(f) => f.unnamed.iter_mut(),
         }
     }
+
+    /// Returns the number of fields.
+    pub fn len(&self) -> usize {
+        match self {
+            Fields::Unit => 0,
+            Fields::Named(f) => f.named.len(),
+            Fields::Unnamed(f) => f.unnamed.len(),
+        }
+    }
+
+    /// Returns `true` if there are zero fields.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Fields::Unit => true,
+            Fields::Named(f) => f.named.is_empty(),
+            Fields::Unnamed(f) => f.unnamed.is_empty(),
+        }
+    }
 }
 
 impl IntoIterator for Fields {


### PR DESCRIPTION
There are a few situations where I've been using `fields.iter().len()`. This works, but having inherent `len()` and `is_empty()` methods would make things feel more idiomatic.