### PR TITLE
Add a receiver getter to Signature, and clarify parsing behaviour

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1017,6 +1017,24 @@ ast_struct! {
     }
 }
 
+impl Signature {
+    /// A method's `self` receiver, such as `&self` or `self: Box<Self>`.
+    pub fn receiver(&self) -> Option<&FnArg> {
+        let arg = self.inputs.first()?;
+        match arg {
+            FnArg::Receiver(_) => Some(arg),
+            FnArg::Typed(PatType { pat, .. }) => {
+                if let Pat::Ident(PatIdent { ident, .. }) = &**pat {
+                    if ident == "self" {
+                        return Some(arg);
+                    }
+                }
+                None
+            }
+        }
+    }
+}
+
 ast_enum_of_structs! {
     /// An argument in a function signature: the `n: usize` in `fn f(n: usize)`.
     ///
@@ -1024,6 +1042,9 @@ ast_enum_of_structs! {
     pub enum FnArg {
         /// The `self` argument of an associated method, whether taken by value
         /// or by reference.
+        ///
+        /// Note that `self` receivers with a specified type, such as `self:
+        /// Box<Self>`, are parsed as a `FnArg::Typed`.
         Receiver(Receiver),
 
         /// A function argument accepted by pattern and type.
@@ -1034,6 +1055,9 @@ ast_enum_of_structs! {
 ast_struct! {
     /// The `self` argument of an associated method, whether taken by value
     /// or by reference.
+    ///
+    /// Note that `self` receivers with a specified type, such as `self:
+    /// Box<Self>`, are parsed as a `FnArg::Typed`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
     pub struct Receiver {

--- a/tests/test_receiver.rs
+++ b/tests/test_receiver.rs
@@ -1,0 +1,109 @@
+mod features;
+
+use syn::{FnArg, Receiver, TraitItemMethod};
+
+#[test]
+fn test_by_value() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn by_value(self: Self););
+    match sig.receiver() {
+        Some(FnArg::Typed(_)) => (),
+        value => panic!("expected FnArg::Typed, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_by_mut_value() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn by_mut(mut self: Self););
+    match sig.receiver() {
+        Some(FnArg::Typed(_)) => (),
+        value => panic!("expected FnArg::Typed, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_by_ref() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn by_ref(self: &Self););
+    match sig.receiver() {
+        Some(FnArg::Typed(_)) => (),
+        value => panic!("expected FnArg::Typed, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_by_box() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn by_box(self: Box<Self>););
+    match sig.receiver() {
+        Some(FnArg::Typed(_)) => (),
+        value => panic!("expected FnArg::Typed, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_by_pin() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn by_pin(self: Pin<Self>););
+    match sig.receiver() {
+        Some(FnArg::Typed(_)) => (),
+        value => panic!("expected FnArg::Typed, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_explicit_type() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn explicit_type(self: Pin<MyType>););
+    match sig.receiver() {
+        Some(FnArg::Typed(_)) => (),
+        value => panic!("expected FnArg::Typed, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_value_shorthand() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn value_shorthand(self););
+    match sig.receiver() {
+        Some(FnArg::Receiver(Receiver {
+            reference: None,
+            mutability: None,
+            ..
+        })) => (),
+        value => panic!("expected FnArg::Receiver without ref/mut, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_mut_value_shorthand() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn mut_value_shorthand(mut self););
+    match sig.receiver() {
+        Some(FnArg::Receiver(Receiver {
+            reference: None,
+            mutability: Some(_),
+            ..
+        })) => (),
+        value => panic!("expected FnArg::Receiver with mut, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_ref_shorthand() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn ref_shorthand(&self););
+    match sig.receiver() {
+        Some(FnArg::Receiver(Receiver {
+            reference: Some(_),
+            mutability: None,
+            ..
+        })) => (),
+        value => panic!("expected FnArg::Receiver with ref, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_ref_mut_shorthand() {
+    let TraitItemMethod { sig, .. } = syn::parse_quote!(fn ref_mut_shorthand(&mut self););
+    match sig.receiver() {
+        Some(FnArg::Receiver(Receiver {
+            reference: Some(_),
+            mutability: Some(_),
+            ..
+        })) => (),
+        value => panic!("expected FnArg::Receiver with ref+mut, got {:?}", value),
+    }
+}


### PR DESCRIPTION
The current behaviour of receiver parsing in syn is a bit complex, but I don't see a way to simplify it without making some breaking changes. I think we'd want the receiver would be a separate member of `Signature`, like `variadic`, and would support both the shorthand and typed forms. The remaining arguments would then be stored in `Signature` directly as a `Punctuated<PatType, Token![,]>`.