### PR TITLE
Added functionality to parse a Pat::Or

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2269,7 +2269,7 @@ pub(crate) mod parsing {
     #[cfg(feature = "full")]
     fn closure_arg(input: ParseStream) -> Result<Pat> {
         let attrs = input.call(Attribute::parse_outer)?;
-        let mut pat: Pat = input.parse()?;
+        let mut pat: Pat = Pat::parse_closure_arg(input)?;
 
         if input.peek(Token![:]) {
             Ok(Pat::Type(PatType {

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -401,7 +401,7 @@ mod parsing {
     // We need some way to persist whether or not we are in a closure between functions without having
     // to pass an fn pointer to each function telling it which to use.
     struct PatParseContext {
-        parse_fn: fn(ParseStream, &Self) -> Result<Pat>,
+        parse_fn: fn(ParseStream, &PatParseContext) -> Result<Pat>,
     }
 
     impl PatParseContext {

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -1,7 +1,7 @@
 mod features;
 
 use quote::quote;
-use syn::Pat;
+use syn::{PatOr, Pat};
 
 #[test]
 fn test_pat_ident() {
@@ -16,5 +16,18 @@ fn test_pat_path() {
     match syn::parse2(quote!(self::CONST)).unwrap() {
         Pat::Path(_) => (),
         value => panic!("expected PatPath, got {:?}", value),
+    }
+}
+
+#[test]
+fn test_pat_or() {
+    match syn::parse2(quote!("0" | "1")).unwrap() {
+        Pat::Or(_) => (),
+        value => panic!("expected PatOr, got {:?}", value),
+    }
+
+    match syn::parse2(quote!(| "0" | "1")).unwrap() {
+        Pat::Or(PatOr { leading_vert: Some(_), .. } ) => (),
+        value => panic!("expected PatOr, got {:?}", value),
     }
 }


### PR DESCRIPTION
While working on a project I found that syn didn't have the ability to parse a PatOr. I had a bit of trouble initially when I came across the reason it probably hadn't been implemented yet: closures.

I did some tinkering though, everything works as intended and all the tests passed.