### PR TITLE
Closure-based speculative parsing API

### DIFF
--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -2,3 +2,8 @@
 pub mod lookahead {
     pub trait Sealed: Copy {}
 }
+
+#[cfg(feature = "parsing")]
+pub mod discouraged {
+    pub trait Sealed {}
+}


### PR DESCRIPTION
This is a (very early draft of a) potential fix for the speculative parsing issues in #720 and #721. It introduces a new API for speculative parsing. The `speculate` method takes a `FnOnce(ParseStream) -> Result<T>`, and returns an `Option<T>`, only advancing the `ParseStream` if the inner parse succeeds.

The primary difference between this method and `fork`/`advance_to` is the interaction with the `unexpected` attribute. The forked `ParseStream` is checked for `unexpected` errors before determining whether the speculative parse succeeded. The introduction of a closure scope helps ensure that nested `ParseBuffer`s have been dropped before the check occurs, which helps with issue 2 in #721. 

I also introduce a `speculate_peek` method (all names super bikesheddable) which also checks `unexpected` errors, but does not `advance_to` if the inner parse succeeds.

## Example

A number of `fork()` callers have been changed in the 2nd commit, including the `Visibility::parse_pub` method which caused #720. The implementation now looks as follows:

```rust
let pub_token = input.parse::<Token![pub]>()?;

match input.speculate(|ahead| {
    let content;
    let paren_token = parenthesized!(content in ahead);

    if content.peek(Token![crate])
        || content.peek(Token![self])
        || content.peek(Token![super])
    {
        Ok(VisRestricted {
            pub_token,
            paren_token,
            in_token: None,
            path: Box::new(Path::from(content.call(Ident::parse_any)?)),
        })
    } else {
        Ok(VisRestricted {
            pub_token,
            paren_token,
            in_token: Some(content.parse()?),
            path: Box::new(content.call(Path::parse_mod_style)?),
        })
    }
}) {
    Some(restricted) => Ok(Visibility::Restricted(restricted)),
    None => Ok(Visibility::Public(VisPublic { pub_token })),
}
```

## Known Problems

* The function boundary can encourage too much to be parsed speculatively. For example, in the previous "example" code, the `path` field in `pub(in FOO)` should not be parsed speculatively, however performing the parse outside of the `speculate` call would be much more verbose.
   
   It may be possible to add a `ahead.nonspeculative(|ahead| ...)` helper if the input & return types of the `speculate`  are custom wrapper types. Alternatively, a `ahead.commit()` (`ahead.stop_speculating()`?) method could also be used to halt speculation, and make errors produced after that point trigger a "real" error rather than a speculation one by setting a flag on the forked ParseBuffer. (The `commit()` would have to be ignored if an `unexpected` flag had already been set to ensure the parse recovers in that scenario)
   
   Either of these approaches would require changing the return type to `Result<Option<T>>`, which should be OK.

* It's fairly common to perform a series of `peek` checks while speculating, and then return a dummy error (which will be ignored) if they fail. It might be worthwhile to use a different error type so these are easier to write & read.

* Documentation needs a lot of updating. The current docs are largely copy-pasted from `advance_to`.

## Breaking Changes

I wanted to add this new method to the `parse::discouraged::Speculative` extension trait, as it fills the same role as the existing `advance_to` method. That extension trait is not `Sealed`, meaning it is _technically_ possible for downstream crates to implement it for local types.

In this patch stack I change this trait to be `Sealed`, and add new methods to it. This is technically a breaking change.