### PR TITLE
Fix Visibility parsing errors, and optimize with 'advance_to'

### DIFF
--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -164,6 +164,29 @@ impl<'a> Speculative for ParseBuffer<'a> {
             panic!("Fork was not derived from the advancing parse stream");
         }
 
+        let (self_unexp, self_sp) = inner_unexpected(self);
+        let (fork_unexp, fork_sp) = inner_unexpected(fork);
+        if !Rc::ptr_eq(&self_unexp, &fork_unexp) {
+            match (fork_sp, self_sp) {
+                // Unexpected set on the fork, but not on `self`, copy it over.
+                (Some(span), None) => {
+                    self_unexp.set(Unexpected::Some(span));
+                }
+                // Unexpected unset. Use chain to propagate errors from fork.
+                (None, None) => {
+                    fork_unexp.set(Unexpected::Chain(self_unexp));
+
+                    // Ensure toplevel 'unexpected' tokens from the fork don't
+                    // bubble up the chain by replacing the root `unexpected`
+                    // pointer, only 'unexpected' tokens from existing group
+                    // parsers should bubble.
+                    fork.unexpected.set(Some(Default::default()));
+                }
+                // Unexpected has been set on `self`. No changes needed.
+                (_, Some(_)) => {}
+            }
+        }
+
         // See comment on `cell` in the struct definition.
         self.cell
             .set(unsafe { mem::transmute::<Cursor, Cursor<'static>>(fork.cursor()) })

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -261,13 +261,16 @@ pub struct ParseBuffer<'a> {
     // the cell.
     cell: Cell<Cursor<'static>>,
     marker: PhantomData<Cursor<'a>>,
-    unexpected: Rc<Cell<Option<Span>>>,
+    unexpected: Cell<Option<Rc<Cell<Unexpected>>>>,
 }
 
 impl<'a> Drop for ParseBuffer<'a> {
     fn drop(&mut self) {
-        if !self.is_empty() && self.unexpected.get().is_none() {
-            self.unexpected.set(Some(self.cursor().span()));
+        if !self.is_empty() {
+            let (inner, old_span) = inner_unexpected(self);
+            if old_span.is_none() {
+                inner.set(Unexpected::Some(self.cursor().span()));
+            }
         }
     }
 }
@@ -388,19 +391,56 @@ fn skip(input: ParseStream) -> bool {
 pub(crate) fn new_parse_buffer(
     scope: Span,
     cursor: Cursor,
-    unexpected: Rc<Cell<Option<Span>>>,
+    unexpected: Rc<Cell<Unexpected>>,
 ) -> ParseBuffer {
     ParseBuffer {
         scope,
         // See comment on `cell` in the struct definition.
         cell: Cell::new(unsafe { mem::transmute::<Cursor, Cursor<'static>>(cursor) }),
         marker: PhantomData,
-        unexpected,
+        unexpected: Cell::new(Some(unexpected)),
     }
 }
 
-pub(crate) fn get_unexpected(buffer: &ParseBuffer) -> Rc<Cell<Option<Span>>> {
-    buffer.unexpected.clone()
+#[derive(Clone)]
+pub(crate) enum Unexpected {
+    None,
+    Some(Span),
+    Chain(Rc<Cell<Unexpected>>),
+}
+
+impl Default for Unexpected {
+    fn default() -> Self {
+        Unexpected::None
+    }
+}
+
+// If `Default::default()` for `T` is expensive, this can be slow, but allows us
+// to operate on a value within a `Cell<T>`.
+//
+// NOTE: The types we clone with this (`Unexpected` and `Rc<T>`) would be "safe"
+// to clone in-place. If this ends up beig a perf issue, we can opimize with
+// unsafe code.
+fn cell_clone<T: Default + Clone>(cell: &Cell<T>) -> T {
+    let prev = cell.take();
+    let ret = prev.clone();
+    cell.set(prev);
+    ret
+}
+
+fn inner_unexpected(buffer: &ParseBuffer) -> (Rc<Cell<Unexpected>>, Option<Span>) {
+    let mut unexpected = get_unexpected(buffer);
+    loop {
+        match cell_clone(&unexpected) {
+            Unexpected::None => return (unexpected, None),
+            Unexpected::Some(span) => return (unexpected, Some(span)),
+            Unexpected::Chain(next) => unexpected = next,
+        }
+    }
+}
+
+pub(crate) fn get_unexpected(buffer: &ParseBuffer) -> Rc<Cell<Unexpected>> {
+    cell_clone(&buffer.unexpected).unwrap()
 }
 
 impl<'a> ParseBuffer<'a> {
@@ -841,8 +881,8 @@ impl<'a> ParseBuffer<'a> {
             cell: self.cell.clone(),
             marker: PhantomData,
             // Not the parent's unexpected. Nothing cares whether the clone
-            // parses all the way.
-            unexpected: Rc::new(Cell::new(None)),
+            // parses all the way unless we `advance_to`.
+            unexpected: Cell::new(Some(Default::default())),
         }
     }
 
@@ -963,10 +1003,10 @@ impl<'a> ParseBuffer<'a> {
     }
 
     fn check_unexpected(&self) -> Result<()> {
-        match self.unexpected.get() {
-            Some(span) => Err(Error::new(span, "unexpected token")),
-            None => Ok(()),
+        if let (_, Some(span)) = inner_unexpected(self) {
+            return Err(Error::new(span, "unexpected token"));
         }
+        Ok(())
     }
 }
 
@@ -1095,7 +1135,7 @@ pub trait Parser: Sized {
 fn tokens_to_parse_buffer(tokens: &TokenBuffer) -> ParseBuffer {
     let scope = Span::call_site();
     let cursor = tokens.begin();
-    let unexpected = Rc::new(Cell::new(None));
+    let unexpected = Default::default();
     new_parse_buffer(scope, cursor, unexpected)
 }
 
@@ -1121,7 +1161,7 @@ where
     fn __parse_scoped(self, scope: Span, tokens: TokenStream) -> Result<Self::Output> {
         let buf = TokenBuffer::new2(tokens);
         let cursor = buf.begin();
-        let unexpected = Rc::new(Cell::new(None));
+        let unexpected = Default::default();
         let state = new_parse_buffer(scope, cursor, unexpected);
         let node = self(&state)?;
         state.check_unexpected()?;

--- a/src/token.rs
+++ b/src/token.rs
@@ -158,11 +158,10 @@ impl private::Sealed for Ident {}
 #[cfg(any(feature = "full", feature = "derive"))]
 #[cfg(feature = "parsing")]
 fn peek_impl(cursor: Cursor, peek: fn(ParseStream) -> bool) -> bool {
-    use std::cell::Cell;
-    use std::rc::Rc;
+    use std::default::Default;
 
     let scope = Span::call_site();
-    let unexpected = Rc::new(Cell::new(None));
+    let unexpected = Default::default();
     let buffer = crate::parse::new_parse_buffer(scope, cursor, unexpected);
     peek(&buffer)
 }

--- a/tests/test_visibility.rs
+++ b/tests/test_visibility.rs
@@ -1,0 +1,99 @@
+mod features;
+
+use proc_macro2::TokenStream;
+use syn::{Result, Visibility};
+use syn::parse::{Parse, ParseStream};
+
+#[derive(Debug)]
+struct VisRest {
+    vis: Visibility,
+    rest: TokenStream,
+}
+
+impl Parse for VisRest {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(VisRest {
+            vis: input.parse()?,
+            rest: input.parse()?,
+        })
+    }
+}
+
+macro_rules! assert_vis_parse {
+    ($input:expr, Ok($p:pat)) => {
+        assert_vis_parse!($input, Ok($p) + "");
+    };
+
+    ($input:expr, Ok($p:pat) + $rest:expr) => {
+        let expected = $rest.parse::<TokenStream>().unwrap();
+        let parse: VisRest = syn::parse_str($input).unwrap();
+
+        match parse.vis {
+            $p => {}
+            _ => panic!("Expected {}, got {:?}", stringify!($p), parse.vis),
+        }
+
+        // NOTE: Round-trips through `to_string` to avoid potential whitespace
+        // diffs.
+        assert_eq!(parse.rest.to_string(), expected.to_string());
+    };
+
+    ($input:expr, Err) => {
+        syn::parse2::<VisRest>($input.parse().unwrap()).unwrap_err();
+    };
+}
+
+#[test]
+fn test_pub() {
+    assert_vis_parse!("pub", Ok(Visibility::Public(_)));
+}
+
+#[test]
+fn test_crate() {
+    assert_vis_parse!("crate", Ok(Visibility::Crate(_)));
+}
+
+#[test]
+fn test_inherited() {
+    assert_vis_parse!("", Ok(Visibility::Inherited));
+}
+
+#[test]
+fn test_in() {
+    assert_vis_parse!("pub(in foo::bar)", Ok(Visibility::Restricted(_)));
+}
+
+#[test]
+fn test_pub_crate() {
+    assert_vis_parse!("pub(crate)", Ok(Visibility::Restricted(_)));
+}
+
+#[test]
+fn test_pub_self() {
+    assert_vis_parse!("pub(self)", Ok(Visibility::Restricted(_)));
+}
+
+#[test]
+fn test_pub_super() {
+    assert_vis_parse!("pub(super)", Ok(Visibility::Restricted(_)));
+}
+
+#[test]
+fn test_missing_in() {
+    assert_vis_parse!("pub(foo::bar)", Ok(Visibility::Public(_)) + "(foo::bar)");
+}
+
+#[test]
+fn test_missing_in_path() {
+    assert_vis_parse!("pub(in)", Err);
+}
+
+#[test]
+fn test_crate_path() {
+    assert_vis_parse!("pub(crate::A, crate::B)", Ok(Visibility::Public(_)) + "(crate::A, crate::B)");
+}
+
+#[test]
+fn test_junk_after_in() {
+    assert_vis_parse!("pub(in some::path @@garbage)", Err);
+}


### PR DESCRIPTION
As suggested in https://github.com/dtolnay/syn/pull/722#issuecomment-558451027, the Visibility patch (patch 2) does not introduce new APIs for observing 'unexpected' errors, and instead manually checks for 'content.is_empty()' when speculatively parsing in `Visibility`.

The final patch fixes 'unexpected' error propagation when using 'advance_to'. This ended up being more complex than I expected, as the fork's root parser is likely to set `unexpected` when it is dropped, which should not cause an error in the advanced stream. This was worked around using `Cell` directly within `ParseBuffer`, in addition to within `Rc`s. 

Fixes #720, #721 
