### PR TITLE
Apply #[doc(cfg(feature = "..."))] banners in docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ required-features = ["full", "parsing"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "syn_enable_doc_cfg"]
 
 [package.metadata.playground]
 all-features = true

--- a/build.rs
+++ b/build.rs
@@ -17,8 +17,6 @@ fn main() {
 
     if !compiler.nightly {
         println!("cargo:rustc-cfg=syn_disable_nightly_tests");
-    } else {
-        println!("cargo:rustc-cfg=syn_enable_doc_cfg");
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,8 @@ fn main() {
 
     if !compiler.nightly {
         println!("cargo:rustc-cfg=syn_disable_nightly_tests");
+    } else {
+        println!("cargo:rustc-cfg=syn_enable_doc_cfg");
     }
 }
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -196,6 +196,10 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
+    )]
     pub fn parse_meta(&self) -> Result<Meta> {
         fn clone_ident_segment(segment: &PathSegment) -> PathSegment {
             PathSegment {
@@ -243,6 +247,10 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
+    )]
     pub fn parse_args<T: Parse>(&self) -> Result<T> {
         self.parse_args_with(T::parse)
     }
@@ -252,6 +260,10 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
+    )]
     pub fn parse_args_with<F: Parser>(&self, parser: F) -> Result<F::Output> {
         let parser = |input: ParseStream| {
             let args = enter_args(self, input)?;
@@ -265,6 +277,10 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
+    )]
     pub fn parse_outer(input: ParseStream) -> Result<Vec<Self>> {
         let mut attrs = Vec::new();
         while input.peek(Token![#]) {
@@ -278,6 +294,10 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
+    )]
     pub fn parse_inner(input: ParseStream) -> Result<Vec<Self>> {
         let mut attrs = Vec::new();
         while input.peek(Token![#]) && input.peek2(Token![!]) {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -148,6 +148,10 @@ ast_struct! {
     /// };
     /// assert_eq!(doc, attr);
     /// ```
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Attribute #manual_extra_traits {
         pub pound_token: Token![#],
         pub style: AttrStyle,
@@ -349,6 +353,10 @@ ast_enum! {
     /// - `#![feature(proc_macro)]`
     /// - `//! # Example`
     /// - `/*! Please file an issue */`
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     #[cfg_attr(feature = "clone-impls", derive(Copy))]
     pub enum AttrStyle {
         Outer,
@@ -383,6 +391,10 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum Meta {
         Path(Path),
 
@@ -399,6 +411,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct MetaList {
         pub path: Path,
         pub paren_token: token::Paren,
@@ -411,6 +427,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct MetaNameValue {
         pub path: Path,
         pub eq_token: Token![=],
@@ -437,6 +457,10 @@ ast_enum_of_structs! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum NestedMeta {
         /// A structured meta item, like the `Copy` in `#[derive(Copy)]` which
         /// would be a nested `Meta::Path`.
@@ -482,6 +506,10 @@ ast_enum_of_structs! {
 /// #   "".parse().unwrap()
 /// }
 /// ```
+#[cfg_attr(
+    syn_enable_doc_cfg,
+    doc(cfg(any(feature = "derive", feature = "full")))
+)]
 pub type AttributeArgs = Vec<NestedMeta>;
 
 pub trait FilterAttrs<'a> {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -196,10 +196,7 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
-    #[cfg_attr(
-        syn_enable_doc_cfg,
-        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
-    )]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_meta(&self) -> Result<Meta> {
         fn clone_ident_segment(segment: &PathSegment) -> PathSegment {
             PathSegment {
@@ -247,10 +244,7 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
-    #[cfg_attr(
-        syn_enable_doc_cfg,
-        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
-    )]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_args<T: Parse>(&self) -> Result<T> {
         self.parse_args_with(T::parse)
     }
@@ -260,10 +254,7 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
-    #[cfg_attr(
-        syn_enable_doc_cfg,
-        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
-    )]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_args_with<F: Parser>(&self, parser: F) -> Result<F::Output> {
         let parser = |input: ParseStream| {
             let args = enter_args(self, input)?;
@@ -277,10 +268,7 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
-    #[cfg_attr(
-        syn_enable_doc_cfg,
-        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
-    )]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_outer(input: ParseStream) -> Result<Vec<Self>> {
         let mut attrs = Vec::new();
         while input.peek(Token![#]) {
@@ -294,10 +282,7 @@ impl Attribute {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
-    #[cfg_attr(
-        syn_enable_doc_cfg,
-        doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
-    )]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_inner(input: ParseStream) -> Result<Vec<Self>> {
         let mut attrs = Vec::new();
         while input.peek(Token![#]) && input.peek2(Token![!]) {

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,6 +6,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Variant {
         /// Attributes tagged on the variant.
         pub attrs: Vec<Attribute>,
@@ -35,6 +39,10 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum Fields {
         /// Named fields of a struct or struct variant such as `Point { x: f64,
         /// y: f64 }`.
@@ -54,6 +62,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct FieldsNamed {
         pub brace_token: token::Brace,
         pub named: Punctuated<Field, Token![,]>,
@@ -65,6 +77,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct FieldsUnnamed {
         pub paren_token: token::Paren,
         pub unnamed: Punctuated<Field, Token![,]>,
@@ -149,6 +165,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Field {
         /// Attributes tagged on the field.
         pub attrs: Vec<Attribute>,
@@ -183,6 +203,10 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum Visibility {
         /// A public visibility level: `pub`.
         Public(VisPublic),
@@ -204,6 +228,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct VisPublic {
         pub pub_token: Token![pub],
     }
@@ -214,6 +242,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct VisCrate {
         pub crate_token: Token![crate],
     }
@@ -225,6 +257,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct VisRestricted {
         pub pub_token: Token![pub],
         pub paren_token: token::Paren,

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -5,6 +5,7 @@ ast_struct! {
     /// Data structure sent to a `proc_macro_derive` macro.
     ///
     /// *This type is available if Syn is built with the `"derive"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "derive")))]
     pub struct DeriveInput {
         /// Attributes tagged on the whole struct or enum.
         pub attrs: Vec<Attribute>,
@@ -36,6 +37,7 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "derive")))]
     pub enum Data {
         /// A struct input to a `proc_macro_derive` macro.
         Struct(DataStruct),
@@ -55,6 +57,7 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"`
     /// feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "derive")))]
     pub struct DataStruct {
         pub struct_token: Token![struct],
         pub fields: Fields,
@@ -67,6 +70,7 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"`
     /// feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "derive")))]
     pub struct DataEnum {
         pub enum_token: Token![enum],
         pub brace_token: token::Brace,
@@ -79,6 +83,7 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"`
     /// feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "derive")))]
     pub struct DataUnion {
         pub union_token: Token![union],
         pub fields: FieldsNamed,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -86,6 +86,10 @@ ast_enum_of_structs! {
     /// A sign that you may not be choosing the right variable names is if you
     /// see names getting repeated in your code, like accessing
     /// `receiver.receiver` or `pat.pat` or `cond.cond`.
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum Expr #manual_extra_traits {
         /// A slice literal expression: `[a, b, c, d]`.
         Array(ExprArray),
@@ -232,6 +236,7 @@ ast_struct! {
     /// A slice literal expression: `[a, b, c, d]`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprArray #full {
         pub attrs: Vec<Attribute>,
         pub bracket_token: token::Bracket,
@@ -243,6 +248,7 @@ ast_struct! {
     /// An assignment expression: `a = compute()`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprAssign #full {
         pub attrs: Vec<Attribute>,
         pub left: Box<Expr>,
@@ -255,6 +261,7 @@ ast_struct! {
     /// A compound assignment expression: `counter += 1`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprAssignOp #full {
         pub attrs: Vec<Attribute>,
         pub left: Box<Expr>,
@@ -267,6 +274,7 @@ ast_struct! {
     /// An async block: `async { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprAsync #full {
         pub attrs: Vec<Attribute>,
         pub async_token: Token![async],
@@ -279,6 +287,7 @@ ast_struct! {
     /// An await expression: `fut.await`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprAwait #full {
         pub attrs: Vec<Attribute>,
         pub base: Box<Expr>,
@@ -292,6 +301,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ExprBinary {
         pub attrs: Vec<Attribute>,
         pub left: Box<Expr>,
@@ -304,6 +317,7 @@ ast_struct! {
     /// A blocked scope: `{ ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprBlock #full {
         pub attrs: Vec<Attribute>,
         pub label: Option<Label>,
@@ -315,6 +329,7 @@ ast_struct! {
     /// A box expression: `box f`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprBox #full {
         pub attrs: Vec<Attribute>,
         pub box_token: Token![box],
@@ -327,6 +342,7 @@ ast_struct! {
     /// expression.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprBreak #full {
         pub attrs: Vec<Attribute>,
         pub break_token: Token![break],
@@ -340,6 +356,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ExprCall {
         pub attrs: Vec<Attribute>,
         pub func: Box<Expr>,
@@ -353,6 +373,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ExprCast {
         pub attrs: Vec<Attribute>,
         pub expr: Box<Expr>,
@@ -365,6 +389,7 @@ ast_struct! {
     /// A closure expression: `|a, b| a + b`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprClosure #full {
         pub attrs: Vec<Attribute>,
         pub asyncness: Option<Token![async]>,
@@ -382,6 +407,7 @@ ast_struct! {
     /// A `continue`, with an optional label.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprContinue #full {
         pub attrs: Vec<Attribute>,
         pub continue_token: Token![continue],
@@ -394,6 +420,7 @@ ast_struct! {
     /// field (`obj.0`).
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprField {
         pub attrs: Vec<Attribute>,
         pub base: Box<Expr>,
@@ -406,6 +433,7 @@ ast_struct! {
     /// A for loop: `for pat in expr { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprForLoop #full {
         pub attrs: Vec<Attribute>,
         pub label: Option<Label>,
@@ -425,6 +453,7 @@ ast_struct! {
     /// `TokenStream`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprGroup #full {
         pub attrs: Vec<Attribute>,
         pub group_token: token::Group,
@@ -440,6 +469,7 @@ ast_struct! {
     /// expression, not any of the other types of expression.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprIf #full {
         pub attrs: Vec<Attribute>,
         pub if_token: Token![if],
@@ -454,6 +484,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ExprIndex {
         pub attrs: Vec<Attribute>,
         pub expr: Box<Expr>,
@@ -466,6 +500,7 @@ ast_struct! {
     /// A `let` guard: `let Some(x) = opt`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprLet #full {
         pub attrs: Vec<Attribute>,
         pub let_token: Token![let],
@@ -480,6 +515,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ExprLit {
         pub attrs: Vec<Attribute>,
         pub lit: Lit,
@@ -490,6 +529,7 @@ ast_struct! {
     /// Conditionless loop: `loop { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprLoop #full {
         pub attrs: Vec<Attribute>,
         pub label: Option<Label>,
@@ -502,6 +542,7 @@ ast_struct! {
     /// A macro invocation expression: `format!("{}", q)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprMacro #full {
         pub attrs: Vec<Attribute>,
         pub mac: Macro,
@@ -512,6 +553,7 @@ ast_struct! {
     /// A `match` expression: `match n { Some(n) => {}, None => {} }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprMatch #full {
         pub attrs: Vec<Attribute>,
         pub match_token: Token![match],
@@ -525,6 +567,7 @@ ast_struct! {
     /// A method call expression: `x.foo::<T>(a, b)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprMethodCall #full {
         pub attrs: Vec<Attribute>,
         pub receiver: Box<Expr>,
@@ -540,6 +583,7 @@ ast_struct! {
     /// A parenthesized expression: `(a + b)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprParen {
         pub attrs: Vec<Attribute>,
         pub paren_token: token::Paren,
@@ -555,6 +599,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ExprPath {
         pub attrs: Vec<Attribute>,
         pub qself: Option<QSelf>,
@@ -566,6 +614,7 @@ ast_struct! {
     /// A range expression: `1..2`, `1..`, `..2`, `1..=2`, `..=2`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprRange #full {
         pub attrs: Vec<Attribute>,
         pub from: Option<Box<Expr>>,
@@ -578,6 +627,7 @@ ast_struct! {
     /// A referencing operation: `&a` or `&mut a`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprReference #full {
         pub attrs: Vec<Attribute>,
         pub and_token: Token![&],
@@ -591,6 +641,7 @@ ast_struct! {
     /// An array literal constructed from one repeated element: `[0u8; N]`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprRepeat #full {
         pub attrs: Vec<Attribute>,
         pub bracket_token: token::Bracket,
@@ -604,6 +655,7 @@ ast_struct! {
     /// A `return`, with an optional value to be returned.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprReturn #full {
         pub attrs: Vec<Attribute>,
         pub return_token: Token![return],
@@ -618,6 +670,7 @@ ast_struct! {
     /// 1, b: 1, ..rest }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprStruct #full {
         pub attrs: Vec<Attribute>,
         pub path: Path,
@@ -632,6 +685,7 @@ ast_struct! {
     /// A try-expression: `expr?`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprTry #full {
         pub attrs: Vec<Attribute>,
         pub expr: Box<Expr>,
@@ -643,6 +697,7 @@ ast_struct! {
     /// A try block: `try { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprTryBlock #full {
         pub attrs: Vec<Attribute>,
         pub try_token: Token![try],
@@ -654,6 +709,7 @@ ast_struct! {
     /// A tuple expression: `(a, b, c, d)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprTuple #full {
         pub attrs: Vec<Attribute>,
         pub paren_token: token::Paren,
@@ -665,6 +721,7 @@ ast_struct! {
     /// A type ascription expression: `foo: f64`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprType #full {
         pub attrs: Vec<Attribute>,
         pub expr: Box<Expr>,
@@ -678,6 +735,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ExprUnary {
         pub attrs: Vec<Attribute>,
         pub op: UnOp,
@@ -689,6 +750,7 @@ ast_struct! {
     /// An unsafe block: `unsafe { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprUnsafe #full {
         pub attrs: Vec<Attribute>,
         pub unsafe_token: Token![unsafe],
@@ -700,6 +762,7 @@ ast_struct! {
     /// A while loop: `while expr { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprWhile #full {
         pub attrs: Vec<Attribute>,
         pub label: Option<Label>,
@@ -713,6 +776,7 @@ ast_struct! {
     /// A yield expression: `yield expr`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprYield #full {
         pub attrs: Vec<Attribute>,
         pub yield_token: Token![yield],
@@ -1001,6 +1065,10 @@ ast_enum! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     #[derive(Eq, PartialEq, Hash)]
     pub enum Member #manual_extra_traits {
         /// A named field like `self.x`.
@@ -1032,6 +1100,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Index #manual_extra_traits {
         pub index: u32,
         pub span: Span,
@@ -1087,6 +1159,7 @@ ast_struct! {
     /// `parse::<u64>()`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct MethodTurbofish {
         pub colon2_token: Token![::],
         pub lt_token: Token![<],
@@ -1100,6 +1173,7 @@ ast_enum! {
     /// An individual generic argument to a method, like `T`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum GenericMethodArgument {
         /// A type argument.
         Type(Type),
@@ -1116,6 +1190,7 @@ ast_struct! {
     /// A field-value pair in a struct literal.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct FieldValue {
         /// Attributes tagged on the field.
         pub attrs: Vec<Attribute>,
@@ -1137,6 +1212,7 @@ ast_struct! {
     /// A lifetime labeling a `for`, `while`, or `loop`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct Label {
         pub name: Lifetime,
         pub colon_token: Token![:],
@@ -1164,6 +1240,7 @@ ast_struct! {
     /// ```
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct Arm {
         pub attrs: Vec<Attribute>,
         pub pat: Pat,
@@ -1179,6 +1256,7 @@ ast_enum! {
     /// Limit types of a range, inclusive or exclusive.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     #[cfg_attr(feature = "clone-impls", derive(Copy))]
     pub enum RangeLimits {
         /// Inclusive at the beginning, exclusive at the end.

--- a/src/file.rs
+++ b/src/file.rs
@@ -67,6 +67,7 @@ ast_struct! {
     ///         ),
     /// ...
     /// ```
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct File {
         pub shebang: Option<String>,
         pub attrs: Vec<Attribute>,

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -7,6 +7,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     #[derive(Default)]
     pub struct Generics {
         pub lt_token: Option<Token![<]>,
@@ -31,6 +35,10 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum GenericParam {
         /// A generic type parameter: `T: Into<String>`.
         Type(TypeParam),
@@ -48,6 +56,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeParam {
         pub attrs: Vec<Attribute>,
         pub ident: Ident,
@@ -63,6 +75,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct LifetimeDef {
         pub attrs: Vec<Attribute>,
         pub lifetime: Lifetime,
@@ -76,6 +92,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ConstParam {
         pub attrs: Vec<Attribute>,
         pub const_token: Token![const],
@@ -282,6 +302,10 @@ impl<'a> Iterator for ConstParamsMut<'a> {
 ///
 /// *This type is available if Syn is built with the `"derive"` or `"full"`
 /// feature and the `"printing"` feature.*
+#[cfg_attr(
+    syn_enable_doc_cfg,
+    doc(cfg(all(any(feature = "derive", feature = "full"), feature = "printing")))
+)]
 #[cfg(feature = "printing")]
 #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
 #[cfg_attr(feature = "clone-impls", derive(Clone))]
@@ -291,6 +315,10 @@ pub struct ImplGenerics<'a>(&'a Generics);
 ///
 /// *This type is available if Syn is built with the `"derive"` or `"full"`
 /// feature and the `"printing"` feature.*
+#[cfg_attr(
+    syn_enable_doc_cfg,
+    doc(cfg(all(any(feature = "derive", feature = "full"), feature = "printing")))
+)]
 #[cfg(feature = "printing")]
 #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
 #[cfg_attr(feature = "clone-impls", derive(Clone))]
@@ -300,6 +328,10 @@ pub struct TypeGenerics<'a>(&'a Generics);
 ///
 /// *This type is available if Syn is built with the `"derive"` or `"full"`
 /// feature and the `"printing"` feature.*
+#[cfg_attr(
+    syn_enable_doc_cfg,
+    doc(cfg(all(any(feature = "derive", feature = "full"), feature = "printing")))
+)]
 #[cfg(feature = "printing")]
 #[cfg_attr(feature = "extra-traits", derive(Debug, Eq, PartialEq, Hash))]
 #[cfg_attr(feature = "clone-impls", derive(Clone))]
@@ -353,6 +385,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     #[derive(Default)]
     pub struct BoundLifetimes {
         pub for_token: Token![for],
@@ -391,6 +427,10 @@ ast_enum_of_structs! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum TypeParamBound {
         Trait(TraitBound),
         Lifetime(Lifetime),
@@ -402,6 +442,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TraitBound {
         pub paren_token: Option<token::Paren>,
         pub modifier: TraitBoundModifier,
@@ -418,6 +462,10 @@ ast_enum! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     #[cfg_attr(feature = "clone-impls", derive(Copy))]
     pub enum TraitBoundModifier {
         None,
@@ -431,6 +479,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct WhereClause {
         pub where_token: Token![where],
         pub predicates: Punctuated<WherePredicate, Token![,]>,
@@ -451,6 +503,10 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum WherePredicate {
         /// A type predicate in a `where` clause: `for<'c> Foo<'c>: Trait<'c>`.
         Type(PredicateType),
@@ -468,6 +524,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct PredicateType {
         /// Any lifetimes from a `for` binding
         pub lifetimes: Option<BoundLifetimes>,
@@ -484,6 +544,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct PredicateLifetime {
         pub lifetime: Lifetime,
         pub colon_token: Token![:],
@@ -496,6 +560,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct PredicateEq {
         pub lhs_ty: Type,
         pub eq_token: Token![=],

--- a/src/item.rs
+++ b/src/item.rs
@@ -23,6 +23,7 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum Item #manual_extra_traits {
         /// A constant item: `const MAX: u16 = 65535`.
         Const(ItemConst),
@@ -86,6 +87,7 @@ ast_struct! {
     /// A constant item: `const MAX: u16 = 65535`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemConst {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -103,6 +105,7 @@ ast_struct! {
     /// An enum definition: `enum Foo<A, B> { A(A), B(B) }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemEnum {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -118,6 +121,7 @@ ast_struct! {
     /// An `extern crate` item: `extern crate serde`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemExternCrate {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -134,6 +138,7 @@ ast_struct! {
     /// }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemFn {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -146,6 +151,7 @@ ast_struct! {
     /// A block of foreign items: `extern "C" { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemForeignMod {
         pub attrs: Vec<Attribute>,
         pub abi: Abi,
@@ -159,6 +165,7 @@ ast_struct! {
     /// for Data<A> { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemImpl {
         pub attrs: Vec<Attribute>,
         pub defaultness: Option<Token![default]>,
@@ -178,6 +185,7 @@ ast_struct! {
     /// A macro invocation, which includes `macro_rules!` definitions.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemMacro {
         pub attrs: Vec<Attribute>,
         /// The `example` in `macro_rules! example { ... }`.
@@ -191,6 +199,7 @@ ast_struct! {
     /// A 2.0-style declarative macro introduced by the `macro` keyword.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemMacro2 #manual_extra_traits {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -204,6 +213,7 @@ ast_struct! {
     /// A module or module declaration: `mod m` or `mod m { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemMod {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -218,6 +228,7 @@ ast_struct! {
     /// A static item: `static BIKE: Shed = Shed(42)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemStatic {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -236,6 +247,7 @@ ast_struct! {
     /// A struct definition: `struct Foo<A> { x: A }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemStruct {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -251,6 +263,7 @@ ast_struct! {
     /// A trait definition: `pub trait Iterator { ... }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemTrait {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -270,6 +283,7 @@ ast_struct! {
     /// A trait alias: `pub trait SharableIterator = Iterator + Sync`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemTraitAlias {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -286,6 +300,7 @@ ast_struct! {
     /// A type alias: `type Result<T> = std::result::Result<T, MyError>`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemType {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -302,6 +317,7 @@ ast_struct! {
     /// A union definition: `union Foo<A, B> { x: A, y: B }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemUnion {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -316,6 +332,7 @@ ast_struct! {
     /// A use declaration: `use std::collections::HashMap`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemUse {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -584,6 +601,7 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum UseTree {
         /// A path prefix of imports in a `use` item: `std::...`.
         Path(UsePath),
@@ -606,6 +624,7 @@ ast_struct! {
     /// A path prefix of imports in a `use` item: `std::...`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct UsePath {
         pub ident: Ident,
         pub colon2_token: Token![::],
@@ -617,6 +636,7 @@ ast_struct! {
     /// An identifier imported by a `use` item: `HashMap`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct UseName {
         pub ident: Ident,
     }
@@ -626,6 +646,7 @@ ast_struct! {
     /// An renamed identifier imported by a `use` item: `HashMap as Map`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct UseRename {
         pub ident: Ident,
         pub as_token: Token![as],
@@ -637,6 +658,7 @@ ast_struct! {
     /// A glob import in a `use` item: `*`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct UseGlob {
         pub star_token: Token![*],
     }
@@ -646,6 +668,7 @@ ast_struct! {
     /// A braced group of imports in a `use` item: `{A, B, C}`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct UseGroup {
         pub brace_token: token::Brace,
         pub items: Punctuated<UseTree, Token![,]>,
@@ -665,6 +688,7 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum ForeignItem #manual_extra_traits {
         /// A foreign function in an `extern` block.
         Fn(ForeignItemFn),
@@ -690,6 +714,7 @@ ast_struct! {
     /// A foreign function in an `extern` block.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ForeignItemFn {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -702,6 +727,7 @@ ast_struct! {
     /// A foreign static item in an `extern` block: `static ext: u8`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ForeignItemStatic {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -718,6 +744,7 @@ ast_struct! {
     /// A foreign type in an `extern` block: `type void`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ForeignItemType {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -731,6 +758,7 @@ ast_struct! {
     /// A macro invocation within an extern block.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ForeignItemMacro {
         pub attrs: Vec<Attribute>,
         pub mac: Macro,
@@ -802,6 +830,7 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum TraitItem #manual_extra_traits {
         /// An associated constant within the definition of a trait.
         Const(TraitItemConst),
@@ -827,6 +856,7 @@ ast_struct! {
     /// An associated constant within the definition of a trait.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct TraitItemConst {
         pub attrs: Vec<Attribute>,
         pub const_token: Token![const],
@@ -842,6 +872,7 @@ ast_struct! {
     /// A trait method within the definition of a trait.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct TraitItemMethod {
         pub attrs: Vec<Attribute>,
         pub sig: Signature,
@@ -854,6 +885,7 @@ ast_struct! {
     /// An associated type within the definition of a trait.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct TraitItemType {
         pub attrs: Vec<Attribute>,
         pub type_token: Token![type],
@@ -870,6 +902,7 @@ ast_struct! {
     /// A macro invocation within the definition of a trait.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct TraitItemMacro {
         pub attrs: Vec<Attribute>,
         pub mac: Macro,
@@ -941,6 +974,7 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum ImplItem #manual_extra_traits {
         /// An associated constant within an impl block.
         Const(ImplItemConst),
@@ -966,6 +1000,7 @@ ast_struct! {
     /// An associated constant within an impl block.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ImplItemConst {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -984,6 +1019,7 @@ ast_struct! {
     /// A method within an impl block.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ImplItemMethod {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -997,6 +1033,7 @@ ast_struct! {
     /// An associated type within an impl block.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ImplItemType {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
@@ -1014,6 +1051,7 @@ ast_struct! {
     /// A macro invocation within an impl block.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct ImplItemMacro {
         pub attrs: Vec<Attribute>,
         pub mac: Macro,
@@ -1077,6 +1115,7 @@ ast_struct! {
     /// initialize(&self)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct Signature {
         pub constness: Option<Token![const]>,
         pub asyncness: Option<Token![async]>,
@@ -1114,6 +1153,7 @@ ast_enum_of_structs! {
     /// An argument in a function signature: the `n: usize` in `fn f(n: usize)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum FnArg {
         /// The `self` argument of an associated method, whether taken by value
         /// or by reference.
@@ -1135,6 +1175,7 @@ ast_struct! {
     /// Box<Self>`, are parsed as a `FnArg::Typed`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct Receiver {
         pub attrs: Vec<Attribute>,
         pub reference: Option<(Token![&], Option<Lifetime>)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,6 +847,10 @@ pub use crate::error::{Error, Result};
     feature = "parsing",
     feature = "proc-macro"
 ))]
+#[cfg_attr(
+    syn_enable_doc_cfg,
+    doc(cfg(all(feature = "parsing", feature = "proc-macro")))
+)]
 pub fn parse<T: parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T> {
     parse::Parser::parse(T::parse, tokens)
 }
@@ -863,6 +867,7 @@ pub fn parse<T: parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T> {
 ///
 /// *This function is available if Syn is built with the `"parsing"` feature.*
 #[cfg(feature = "parsing")]
+#[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
 pub fn parse2<T: parse::Parse>(tokens: proc_macro2::TokenStream) -> Result<T> {
     parse::Parser::parse2(T::parse, tokens)
 }
@@ -891,6 +896,7 @@ pub fn parse2<T: parse::Parse>(tokens: proc_macro2::TokenStream) -> Result<T> {
 /// # run().unwrap();
 /// ```
 #[cfg(feature = "parsing")]
+#[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
 pub fn parse_str<T: parse::Parse>(s: &str) -> Result<T> {
     parse::Parser::parse_str(T::parse, s)
 }
@@ -933,6 +939,10 @@ pub fn parse_str<T: parse::Parse>(s: &str) -> Result<T> {
 /// # run().unwrap();
 /// ```
 #[cfg(all(feature = "parsing", feature = "full"))]
+#[cfg_attr(
+    syn_enable_doc_cfg,
+    doc(cfg(all(feature = "parsing", feature = "full")))
+)]
 pub fn parse_file(mut content: &str) -> Result<File> {
     // Strip the BOM if it is present
     const BOM: &str = "\u{feff}";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@
 // Syn types in rustdoc of other crates get linked to here.
 #![doc(html_root_url = "https://docs.rs/syn/1.0.11")]
 #![deny(clippy::all, clippy::pedantic)]
+#![cfg_attr(syn_enable_doc_cfg, feature(doc_cfg))]
 // Ignored clippy lints.
 #![allow(
     clippy::block_in_if_condition_stmt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,8 +421,10 @@ pub use crate::path::{
 };
 
 #[cfg(feature = "parsing")]
+#[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
 pub mod buffer;
 #[cfg(feature = "parsing")]
+#[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
 pub mod ext;
 pub mod punctuated;
 #[cfg(all(any(feature = "full", feature = "derive"), feature = "extra-traits"))]
@@ -443,6 +445,10 @@ pub mod parse_quote;
 pub mod parse_macro_input;
 
 #[cfg(all(feature = "parsing", feature = "printing"))]
+#[cfg_attr(
+    syn_enable_doc_cfg,
+    doc(cfg(any(feature = "parsing", features = "printing")))
+)]
 pub mod spanned;
 
 mod gen {
@@ -563,6 +569,7 @@ mod gen {
     /// }
     /// ```
     #[cfg(feature = "visit")]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "visit")))]
     #[rustfmt::skip]
     pub mod visit;
 
@@ -659,6 +666,7 @@ mod gen {
     /// }
     /// ```
     #[cfg(feature = "visit-mut")]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "visit-mut")))]
     #[rustfmt::skip]
     pub mod visit_mut;
 
@@ -745,6 +753,7 @@ mod gen {
     /// }
     /// ```
     #[cfg(feature = "fold")]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "fold")))]
     #[rustfmt::skip]
     pub mod fold;
 
@@ -766,6 +775,7 @@ mod sealed;
 mod lookahead;
 
 #[cfg(feature = "parsing")]
+#[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
 pub mod parse;
 
 mod span;

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -33,6 +33,10 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum Lit #manual_extra_traits {
         /// A UTF-8 string literal: `"foo"`.
         Str(LitStr),
@@ -67,6 +71,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct LitStr #manual_extra_traits_debug {
         repr: Box<LitStrRepr>,
     }
@@ -83,6 +91,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct LitByteStr #manual_extra_traits_debug {
         token: Literal,
     }
@@ -93,6 +105,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct LitByte #manual_extra_traits_debug {
         token: Literal,
     }
@@ -103,6 +119,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct LitChar #manual_extra_traits_debug {
         token: Literal,
     }
@@ -113,6 +133,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct LitInt #manual_extra_traits_debug {
         repr: Box<LitIntRepr>,
     }
@@ -132,6 +156,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct LitFloat #manual_extra_traits_debug {
         repr: Box<LitFloatRepr>,
     }
@@ -149,6 +177,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct LitBool #manual_extra_traits_debug {
         pub value: bool,
         pub span: Span,
@@ -671,6 +703,10 @@ ast_enum! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum StrStyle #no_visit {
         /// An ordinary string like `"data"`.
         Cooked,

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -16,6 +16,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Macro #manual_extra_traits {
         pub path: Path,
         pub bang_token: Token![!],
@@ -29,6 +33,10 @@ ast_enum! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum MacroDelimiter {
         Paren(Paren),
         Brace(Brace),

--- a/src/op.rs
+++ b/src/op.rs
@@ -3,6 +3,10 @@ ast_enum! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     #[cfg_attr(feature = "clone-impls", derive(Copy))]
     pub enum BinOp {
         /// The `+` operator (addition)
@@ -69,6 +73,10 @@ ast_enum! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     #[cfg_attr(feature = "clone-impls", derive(Copy))]
     pub enum UnOp {
         /// The `*` operator for dereferencing

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -68,6 +68,7 @@
 // TODO: allow Punctuated to be inferred as intra doc link, currently blocked on
 // https://github.com/rust-lang/rust/issues/62834
 #[macro_export(local_inner_macros)]
+#[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
 macro_rules! parse_quote {
     ($($tt:tt)*) => {
         $crate::parse_quote::parse(

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -20,6 +20,7 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum Pat #manual_extra_traits {
         /// A box pattern: `box v`.
         Box(PatBox),
@@ -87,6 +88,7 @@ ast_struct! {
     /// A box pattern: `box v`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatBox {
         pub attrs: Vec<Attribute>,
         pub box_token: Token![box],
@@ -98,6 +100,7 @@ ast_struct! {
     /// A pattern that binds a new variable: `ref mut binding @ SUBPATTERN`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatIdent {
         pub attrs: Vec<Attribute>,
         pub by_ref: Option<Token![ref]>,
@@ -114,6 +117,7 @@ ast_struct! {
     /// are represented as an `Expr::Unary`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatLit {
         pub attrs: Vec<Attribute>,
         pub expr: Box<Expr>,
@@ -124,6 +128,7 @@ ast_struct! {
     /// A macro in pattern position.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatMacro {
         pub attrs: Vec<Attribute>,
         pub mac: Macro,
@@ -134,6 +139,7 @@ ast_struct! {
     /// A pattern that matches any one of a set of cases.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatOr {
         pub attrs: Vec<Attribute>,
         pub leading_vert: Option<Token![|]>,
@@ -151,6 +157,7 @@ ast_struct! {
     /// associated constants.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatPath {
         pub attrs: Vec<Attribute>,
         pub qself: Option<QSelf>,
@@ -162,6 +169,7 @@ ast_struct! {
     /// A range pattern: `1..=2`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatRange {
         pub attrs: Vec<Attribute>,
         pub lo: Box<Expr>,
@@ -174,6 +182,7 @@ ast_struct! {
     /// A reference pattern: `&mut var`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatReference {
         pub attrs: Vec<Attribute>,
         pub and_token: Token![&],
@@ -186,6 +195,7 @@ ast_struct! {
     /// The dots in a tuple or slice pattern: `[0, 1, ..]`
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatRest {
         pub attrs: Vec<Attribute>,
         pub dot2_token: Token![..],
@@ -196,6 +206,7 @@ ast_struct! {
     /// A dynamically sized slice pattern: `[a, b, ref i @ .., y, z]`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatSlice {
         pub attrs: Vec<Attribute>,
         pub bracket_token: token::Bracket,
@@ -207,6 +218,7 @@ ast_struct! {
     /// A struct or struct variant pattern: `Variant { x, y, .. }`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatStruct {
         pub attrs: Vec<Attribute>,
         pub path: Path,
@@ -220,6 +232,7 @@ ast_struct! {
     /// A tuple pattern: `(a, b)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatTuple {
         pub attrs: Vec<Attribute>,
         pub paren_token: token::Paren,
@@ -231,6 +244,7 @@ ast_struct! {
     /// A tuple struct or tuple variant pattern: `Variant(x, y, .., z)`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatTupleStruct {
         pub attrs: Vec<Attribute>,
         pub path: Path,
@@ -242,6 +256,7 @@ ast_struct! {
     /// A type ascription pattern: `foo: f64`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatType {
         pub attrs: Vec<Attribute>,
         pub pat: Box<Pat>,
@@ -254,6 +269,7 @@ ast_struct! {
     /// A pattern that matches any value: `_`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatWild {
         pub attrs: Vec<Attribute>,
         pub underscore_token: Token![_],
@@ -267,6 +283,7 @@ ast_struct! {
     /// the same as `x: x, y: ref y, z: ref mut z` but there is no colon token.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct FieldPat {
         pub attrs: Vec<Attribute>,
         pub member: Member,

--- a/src/path.rs
+++ b/src/path.rs
@@ -425,6 +425,10 @@ pub mod parsing {
         ///     }
         /// }
         /// ```
+        #[cfg_attr(
+            syn_enable_doc_cfg,
+            doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
+        )]
         pub fn parse_mod_style(input: ParseStream) -> Result<Self> {
             Ok(Path {
                 leading_colon: input.parse()?,
@@ -489,6 +493,10 @@ pub mod parsing {
         ///     }
         /// }
         /// ```
+        #[cfg_attr(
+            syn_enable_doc_cfg,
+            doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
+        )]
         pub fn is_ident<I: ?Sized>(&self, ident: &I) -> bool
         where
             Ident: PartialEq<I>,
@@ -510,6 +518,10 @@ pub mod parsing {
         ///
         /// *This function is available if Syn is built with the `"parsing"`
         /// feature.*
+        #[cfg_attr(
+            syn_enable_doc_cfg,
+            doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
+        )]
         pub fn get_ident(&self) -> Option<&Ident> {
             if self.leading_colon.is_none()
                 && self.segments.len() == 1

--- a/src/path.rs
+++ b/src/path.rs
@@ -6,6 +6,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Path {
         pub leading_colon: Option<Token![::]>,
         pub segments: Punctuated<PathSegment, Token![::]>,
@@ -31,6 +35,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct PathSegment {
         pub ident: Ident,
         pub arguments: PathArguments,
@@ -62,6 +70,10 @@ ast_enum! {
     /// ## Parenthesized
     ///
     /// The `(A, B) -> C` in `Fn(A, B) -> C`.
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum PathArguments {
         None,
         /// The `<'a, T>` in `std::slice::iter<'a, T>`.
@@ -100,6 +112,10 @@ ast_enum! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum GenericArgument {
         /// A lifetime argument.
         Lifetime(Lifetime),
@@ -124,6 +140,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct AngleBracketedGenericArguments {
         pub colon2_token: Option<Token![::]>,
         pub lt_token: Token![<],
@@ -137,6 +157,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Binding {
         pub ident: Ident,
         pub eq_token: Token![=],
@@ -149,6 +173,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Constraint {
         pub ident: Ident,
         pub colon_token: Token![:],
@@ -162,6 +190,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct ParenthesizedGenericArguments {
         pub paren_token: token::Paren,
         /// `(A, B)`
@@ -191,6 +223,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct QSelf {
         pub lt_token: Token![<],
         pub ty: Box<Type>,

--- a/src/path.rs
+++ b/src/path.rs
@@ -425,10 +425,7 @@ pub mod parsing {
         ///     }
         /// }
         /// ```
-        #[cfg_attr(
-            syn_enable_doc_cfg,
-            doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
-        )]
+        #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
         pub fn parse_mod_style(input: ParseStream) -> Result<Self> {
             Ok(Path {
                 leading_colon: input.parse()?,
@@ -493,10 +490,7 @@ pub mod parsing {
         ///     }
         /// }
         /// ```
-        #[cfg_attr(
-            syn_enable_doc_cfg,
-            doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
-        )]
+        #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
         pub fn is_ident<I: ?Sized>(&self, ident: &I) -> bool
         where
             Ident: PartialEq<I>,
@@ -518,10 +512,7 @@ pub mod parsing {
         ///
         /// *This function is available if Syn is built with the `"parsing"`
         /// feature.*
-        #[cfg_attr(
-            syn_enable_doc_cfg,
-            doc(cfg(all(any(feature = "derive", feature = "full"), feature = "parsing")))
-        )]
+        #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
         pub fn get_ident(&self) -> Option<&Ident> {
             if self.leading_colon.is_none()
                 && self.segments.len() == 1

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -239,6 +239,7 @@ impl<T, P> Punctuated<T, P> {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_terminated(input: ParseStream) -> Result<Self>
     where
         T: Parse,
@@ -259,6 +260,7 @@ impl<T, P> Punctuated<T, P> {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_terminated_with(
         input: ParseStream,
         parser: fn(ParseStream) -> Result<T>,
@@ -295,6 +297,7 @@ impl<T, P> Punctuated<T, P> {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_separated_nonempty(input: ParseStream) -> Result<Self>
     where
         T: Parse,
@@ -315,6 +318,7 @@ impl<T, P> Punctuated<T, P> {
     /// *This function is available if Syn is built with the `"parsing"`
     /// feature.*
     #[cfg(feature = "parsing")]
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_separated_nonempty_with(
         input: ParseStream,
         parser: fn(ParseStream) -> Result<T>,

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -107,10 +107,7 @@ pub mod parsing {
         ///     }
         /// }
         /// ```
-        #[cfg_attr(
-            syn_enable_doc_cfg,
-            doc(cfg(all(feature = "full", feature = "parsing")))
-        )]
+        #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "parsing")))]
         pub fn parse_within(input: ParseStream) -> Result<Vec<Stmt>> {
             let mut stmts = Vec::new();
             loop {

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -4,6 +4,7 @@ ast_struct! {
     /// A braced block containing Rust statements.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct Block {
         pub brace_token: token::Brace,
         /// Statements in a block
@@ -15,6 +16,7 @@ ast_enum! {
     /// A statement, usually ending in a semicolon.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub enum Stmt {
         /// A local (let) binding.
         Local(Local),
@@ -34,6 +36,7 @@ ast_struct! {
     /// A local `let` binding: `let x: u64 = s.parse()?`.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
+    #[cfg_attr(syn_enable_doc_cfg, doc(cfg(feature = "full")))]
     pub struct Local {
         pub attrs: Vec<Attribute>,
         pub let_token: Token![let],

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -107,6 +107,10 @@ pub mod parsing {
         ///     }
         /// }
         /// ```
+        #[cfg_attr(
+            syn_enable_doc_cfg,
+            doc(cfg(all(feature = "full", feature = "parsing")))
+        )]
         pub fn parse_within(input: ParseStream) -> Result<Vec<Stmt>> {
             let mut stmts = Vec::new();
             loop {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -20,6 +20,10 @@ ast_enum_of_structs! {
     //
     // TODO: change syntax-tree-enum link to an intra rustdoc link, currently
     // blocked on https://github.com/rust-lang/rust/issues/62833
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum Type #manual_extra_traits {
         /// A fixed size array type: `[T; n]`.
         Array(TypeArray),
@@ -79,6 +83,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeArray {
         pub bracket_token: token::Bracket,
         pub elem: Box<Type>,
@@ -92,6 +100,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeBareFn {
         pub lifetimes: Option<BoundLifetimes>,
         pub unsafety: Option<Token![unsafe]>,
@@ -109,6 +121,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeGroup {
         pub group_token: token::Group,
         pub elem: Box<Type>,
@@ -121,6 +137,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeImplTrait {
         pub impl_token: Token![impl],
         pub bounds: Punctuated<TypeParamBound, Token![+]>,
@@ -132,6 +152,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeInfer {
         pub underscore_token: Token![_],
     }
@@ -142,6 +166,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeMacro {
         pub mac: Macro,
     }
@@ -152,6 +180,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeNever {
         pub bang_token: Token![!],
     }
@@ -162,6 +194,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeParen {
         pub paren_token: token::Paren,
         pub elem: Box<Type>,
@@ -174,6 +210,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypePath {
         pub qself: Option<QSelf>,
         pub path: Path,
@@ -185,6 +225,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypePtr {
         pub star_token: Token![*],
         pub const_token: Option<Token![const]>,
@@ -198,6 +242,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeReference {
         pub and_token: Token![&],
         pub lifetime: Option<Lifetime>,
@@ -211,6 +259,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeSlice {
         pub bracket_token: token::Bracket,
         pub elem: Box<Type>,
@@ -223,6 +275,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeTraitObject {
         pub dyn_token: Option<Token![dyn]>,
         pub bounds: Punctuated<TypeParamBound, Token![+]>,
@@ -234,6 +290,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or
     /// `"full"` feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct TypeTuple {
         pub paren_token: token::Paren,
         pub elems: Punctuated<Type, Token![,]>,
@@ -346,6 +406,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Abi {
         pub extern_token: Token![extern],
         pub name: Option<LitStr>,
@@ -357,6 +421,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct BareFnArg {
         pub attrs: Vec<Attribute>,
         pub name: Option<(Ident, Token![:])>,
@@ -379,6 +447,10 @@ ast_struct! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub struct Variadic {
         pub attrs: Vec<Attribute>,
         pub dots: Token![...],
@@ -390,6 +462,10 @@ ast_enum! {
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
     /// feature.*
+    #[cfg_attr(
+        syn_enable_doc_cfg,
+        doc(cfg(any(feature = "derive", feature = "full")))
+    )]
     pub enum ReturnType {
         /// Return type is not specified.
         ///


### PR DESCRIPTION
This PR adds the `#[doc(cfg(..))]` banners for all `#[cfg(..)]` attributes. The result can be seen here:
![image](https://user-images.githubusercontent.com/31166235/70865790-c8d65580-1f61-11ea-934b-8e58afaa2692.png)

This is achieved by providing a new config option called `syn_enable_doc_cfg`, that is either set by the build script, if a nightly compiler is used, or from docs.rs directly (via crate metadata).

Closes #731.