### PR TITLE
Point to closing delimiter when parsing punct past end of group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ extra-traits = []
 proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro"]
 
 [dependencies]
-proc-macro2 = { version = "1.0", default-features = false }
+proc-macro2 = { version = "1.0.7", default-features = false }
 quote = { version = "1.0", optional = true, default-features = false }
 unicode-xid = "0.2"
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -978,6 +978,18 @@ impl<'a> ParseBuffer<'a> {
         Ok(node)
     }
 
+    /// Returns the `Span` of the next token in the parse stream, or
+    /// `Span::call_site()` if this parse stream has completely exhausted its
+    /// input `TokenStream`.
+    pub fn span(&self) -> Span {
+        let cursor = self.cursor();
+        if cursor.eof() {
+            self.scope
+        } else {
+            crate::buffer::open_span_of_group(cursor)
+        }
+    }
+
     /// Provides low-level access to the token representation underlying this
     /// parse stream.
     ///

--- a/src/token.rs
+++ b/src/token.rs
@@ -856,7 +856,7 @@ pub mod parsing {
     }
 
     pub fn punct<S: FromSpans>(input: ParseStream, token: &str) -> Result<S> {
-        let mut spans = [input.cursor().span(); 3];
+        let mut spans = [input.span(); 3];
         punct_helper(input, token, &mut spans)?;
         Ok(S::from_spans(&spans))
     }


### PR DESCRIPTION
Before:

```console
impl Foo { fn b(a: i32, String) {} }
^ expected `:`
```

After:

```console
impl Foo { fn b(a: i32, String) {} }
                              ^ expected `:`
```

Fixes #739.