### PR TITLE
Make the group::parse_group public (and others)

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2661,9 +2661,14 @@ pub(crate) mod parsing {
         }
     }
 
+
+    /// Determines whether this is a named member or not
+    ///
+    /// *This function is available if Syn is built with the `"full"`
+    /// feature.*
     #[cfg(feature = "full")]
     impl Member {
-        fn is_named(&self) -> bool {
+        pub fn is_named(&self) -> bool {
             match *self {
                 Member::Named(_) => true,
                 Member::Unnamed(_) => false,

--- a/src/group.rs
+++ b/src/group.rs
@@ -60,8 +60,10 @@ pub fn parse_brackets<'a>(input: &ParseBuffer<'a>) -> Result<Brackets<'a>> {
     })
 }
 
+// Not public API
+#[doc(hidden)]
 #[cfg(any(feature = "full", feature = "derive"))]
-pub(crate) fn parse_group<'a>(input: &ParseBuffer<'a>) -> Result<Group<'a>> {
+pub fn parse_group<'a>(input: &ParseBuffer<'a>) -> Result<Group<'a>> {
     parse_delimited(input, Delimiter::None).map(|(span, content)| Group {
         token: token::Group(span),
         content,


### PR DESCRIPTION
I am working on building a substitute `Expr` enum which only allows a subset of Rust expressions. I was able to finish off it except for this one small thing that I needed to use.

This small function contains a lot of code I don't want to duplication since it doesn't depend on `Expr`. If you make this `pub`, my use case would be satisfied.

Can you please merge and release a new version ASAP? Thanks.