### PR TITLE
Add Error::set_span

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -188,6 +188,14 @@ impl Error {
         start.join(end).unwrap_or(start)
     }
 
+    /// Set the source location of the error for all contained messages.
+    pub fn set_span(&mut self, span: Span) {
+        for message in self.messages.iter_mut() {
+            message.start_span = ThreadBound::new(span);
+            message.end_span = ThreadBound::new(span);
+        }
+    }
+
     /// Render the error as an invocation of [`compile_error!`].
     ///
     /// The [`parse_macro_input!`] macro provides a convenient way to invoke


### PR DESCRIPTION
This function is quite usefult for patching error messages, like
```rust
let res: Visibility = syn::parse_str("...").map_err(|e| {
    // the current span is call_site(), but we have the more fitting place to point to 
    e.set_span(some);
    e
})?;