### PR TITLE
Improve error message

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -321,13 +321,13 @@ fn enter_args<'a>(attr: &Attribute, input: ParseStream<'a>) -> Result<ParseBuffe
     } else if input.peek(token::Brace) {
         braced!(content in input);
     } else {
-        return Err(input.error("unexpected token in attribute arguments"));
+        return Err(input.error("expected one of `{`, `[`, `(`"));
     }
 
     if input.is_empty() {
         Ok(content)
     } else {
-        Err(input.error("unexpected token in attribute arguments"))
+        Err(input.error("expected one of `{`, `[`, `(`, found end of input"))
     }
 }
 


### PR DESCRIPTION
When `Attribute::parse_args_with` is used with an attribute in `#[path = "..."]` form, we're gonna get the following error:
```text
error: unexpected token in attribute arguments
  --> $DIR/structopt_name_value_attr.rs:14:17
   |
14 |     #[structopt = "short"]
   |                 ^
```
which is next to useless from user's perspective. 

I propose to change it to something that can be understood by end user, like `expected one of {, [, (`.