### PR TITLE
Fix raw operator parsing to require const keyword

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1480,10 +1480,16 @@ pub(crate) mod parsing {
             input.advance_to(&ahead);
             if input.peek(Token![&]) {
                 let and_token: Token![&] = input.parse()?;
-                let raw: Option<raw> = input.parse()?;
+                let raw: Option<raw> = if input.peek(raw)
+                    && (input.peek2(Token![mut]) || input.peek2(Token![const]))
+                {
+                    Some(input.parse()?)
+                } else {
+                    None
+                };
                 let mutability: Option<Token![mut]> = input.parse()?;
                 if raw.is_some() && mutability.is_none() {
-                    input.parse::<Option<Token![const]>>()?;
+                    input.parse::<Token![const]>()?;
                 }
                 let expr = Box::new(unary_expr(input, allow_struct)?);
                 if raw.is_some() {

--- a/tests/test_stmt.rs
+++ b/tests/test_stmt.rs
@@ -1,0 +1,44 @@
+#[macro_use]
+mod macros;
+
+use syn::Stmt;
+
+#[test]
+fn test_raw_operator() {
+    let stmt = syn::parse_str::<Stmt>("let _ = &raw const x;").unwrap();
+
+    snapshot!(stmt, @r###"
+    Local(Local {
+        pat: Pat::Wild,
+        init: Some(Verbatim(`& raw const x`)),
+    })
+    "###);
+}
+
+#[test]
+fn test_raw_variable() {
+    let stmt = syn::parse_str::<Stmt>("let _ = &raw;").unwrap();
+
+    snapshot!(stmt, @r###"
+    Local(Local {
+        pat: Pat::Wild,
+        init: Some(Expr::Reference {
+            expr: Expr::Path {
+                path: Path {
+                    segments: [
+                        PathSegment {
+                            ident: "raw",
+                            arguments: None,
+                        },
+                    ],
+                },
+            },
+        }),
+    })
+    "###);
+}
+
+#[test]
+fn test_raw_invalid() {
+    assert!(syn::parse_str::<Stmt>("let _ = &raw x;").is_err());
+}


### PR DESCRIPTION
Fixes #773. The parsing of `&raw` as a raw reference operator should only kick in if `raw` is followed by `const` or `mut`.