### PR TITLE
Explicitly mention Expr::* variants require "full"

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -15,7 +15,7 @@ ast_enum_of_structs! {
     /// A Rust expression.
     ///
     /// *This type is available if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
+    /// feature, but most of the variants are not available unless "full" is enabled.*
     ///
     /// # Syntax tree enums
     ///


### PR DESCRIPTION
The most variants are not available unless syn is build with "full", which sometimes leads to [confusing situations](https://github.com/TeXitoi/structopt/issues/354)