### PR TITLE
Parse ForeignItem `type` with generics and bounds

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -81,10 +81,6 @@ pub fn base_dir_filter(entry: &DirEntry) -> bool {
         // https://github.com/dtolnay/syn/issues/762
         "test/ui/parser/foreign-static-syntactic-pass.rs" |
 
-        // TODO: extern type with bound: `extern { type A: Ord; }`
-        // https://github.com/dtolnay/syn/issues/763
-        "test/ui/parser/foreign-ty-syntactic-pass.rs" |
-
         // TODO: top level const/static without value: `const X: u8;`
         // https://github.com/dtolnay/syn/issues/764
         "test/ui/parser/item-free-const-no-body-syntactic-pass.rs" |


### PR DESCRIPTION
As tested by https://github.com/rust-lang/rust/blob/1836e3b42a5b2f37fd79104eedbe8f48a5afdee6/src/test/ui/parser/foreign-ty-syntactic-pass.rs.

```rust
extern "C" {
    type A: Ord;
    type A<'a> where 'a: 'static;
    type A<T: Ord> where T: 'static;
    type A = u8;
    type A<'a: 'static, T: Ord + 'static>: Eq + PartialEq where T: 'static + Copy = Vec<u8>;
}
```

Closes #763. Required for https://github.com/dtolnay/cxx/issues/99.