### PR TITLE
Add a caveat to PatIdent's description

### DIFF
--- a/src/pat.rs
+++ b/src/pat.rs
@@ -96,6 +96,8 @@ ast_struct! {
 
 ast_struct! {
     /// A pattern that binds a new variable: `ref mut binding @ SUBPATTERN`.
+    /// It may also be a unit struct or struct variant (e.g. `None`), or a
+    /// constant; these cannot be distinguished syntactically.
     ///
     /// *This type is available if Syn is built with the `"full"` feature.*
     pub struct PatIdent {


### PR DESCRIPTION
This bit me a little: something like `None` or `MY_CONST` parse as a `PatIdent` but doesn't bind a variable as claimed.