### PR TITLE
Raise rayon thread pool stack size

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use rayon::ThreadPoolBuilder;
 use std::env;
 
 pub mod eq;
@@ -11,4 +12,12 @@ pub fn abort_after() -> usize {
         Ok(s) => s.parse().expect("failed to parse ABORT_AFTER_FAILURE"),
         Err(_) => usize::max_value(),
     }
+}
+
+/// Configure Rayon threadpool.
+pub fn rayon_init() {
+    ThreadPoolBuilder::new()
+        .stack_size(10 * 1024 * 1024)
+        .build_global()
+        .unwrap();
 }

--- a/tests/test_precedence.rs
+++ b/tests/test_precedence.rs
@@ -85,6 +85,7 @@ fn test_simple_precedence() {
 /// Test expressions from rustc, like in `test_round_trip`.
 #[test]
 fn test_rustc_precedence() {
+    common::rayon_init();
     repo::clone_rust();
     let abort_after = common::abort_after();
     if abort_after == 0 {

--- a/tests/test_round_trip.rs
+++ b/tests/test_round_trip.rs
@@ -40,6 +40,7 @@ use common::eq::SpanlessEq;
 
 #[test]
 fn test_round_trip() {
+    common::rayon_init();
     repo::clone_rust();
     let abort_after = common::abort_after();
     if abort_after == 0 {


### PR DESCRIPTION
This prevents stack overflows in the test suite when run in debug mode on some platforms on some of the deeply nested rustc test cases.

6 MB is enough on my machine but I included a safety margin.

In release mode we need much less stack space; 1.5 MB is enough, which is below the default size.