### PR TITLE
Parse suffix on byte string, byte, and char literals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro"]
 test = ["syn-test-suite/all-features"]
 
 [dependencies]
-proc-macro2 = { version = "1.0.7", default-features = false }
+proc-macro2 = { version = "1.0.13", default-features = false }
 quote = { version = "1.0", optional = true, default-features = false }
 unicode-xid = "0.2"
 

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -340,6 +340,10 @@ impl LitByteStr {
     pub fn set_span(&mut self, span: Span) {
         self.repr.token.set_span(span)
     }
+
+    pub fn suffix(&self) -> &str {
+        &self.repr.suffix
+    }
 }
 
 impl LitByte {
@@ -365,6 +369,10 @@ impl LitByte {
     pub fn set_span(&mut self, span: Span) {
         self.repr.token.set_span(span)
     }
+
+    pub fn suffix(&self) -> &str {
+        &self.repr.suffix
+    }
 }
 
 impl LitChar {
@@ -389,6 +397,10 @@ impl LitChar {
 
     pub fn set_span(&mut self, span: Span) {
         self.repr.token.set_span(span)
+    }
+
+    pub fn suffix(&self) -> &str {
+        &self.repr.suffix
     }
 }
 

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -207,7 +207,8 @@ impl LitStr {
     }
 
     pub fn value(&self) -> String {
-        let (value, _) = value::parse_lit_str(&self.repr.token.to_string());
+        let repr = self.repr.token.to_string();
+        let (value, _suffix) = value::parse_lit_str(&repr);
         String::from(value)
     }
 
@@ -1079,15 +1080,13 @@ mod value {
             pounds += 1;
         }
         assert_eq!(byte(s, pounds), b'"');
-        assert_eq!(byte(s, s.len() - pounds - 1), b'"');
-        for end in s[s.len() - pounds..].bytes() {
+        let close = s.rfind('"').unwrap();
+        for end in s[close + 1..close + 1 + pounds].bytes() {
             assert_eq!(end, b'#');
         }
 
-        let content = s[pounds + 1..s.len() - pounds - 1]
-            .to_owned()
-            .into_boxed_str();
-        let suffix = Box::<str>::default(); // todo
+        let content = s[pounds + 1..close].to_owned().into_boxed_str();
+        let suffix = s[close + 1 + pounds..].to_owned().into_boxed_str();
         (content, suffix)
     }
 

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -200,9 +200,9 @@ fn suffix() {
         let lit = syn::parse_str::<Lit>(token).unwrap();
         match lit {
             Lit::Str(lit) => lit.suffix().to_owned(),
-            //Lit::ByteStr(lit) => lit.suffix().to_owned(),
-            //Lit::Byte(lit) => lit.suffix().to_owned(),
-            //Lit::Char(lit) => lit.suffix().to_owned(),
+            Lit::ByteStr(lit) => lit.suffix().to_owned(),
+            Lit::Byte(lit) => lit.suffix().to_owned(),
+            Lit::Char(lit) => lit.suffix().to_owned(),
             _ => unimplemented!(),
         }
     }

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -44,6 +44,9 @@ fn strings() {
         "contains\nnewlinesescaped newlines",
     );
     test_string("r\"raw\nstring\\\nhere\"", "raw\nstring\\\nhere");
+    test_string("\"...\"q", "...");
+    test_string("r\"...\"q", "...");
+    test_string("r##\"...\"##q", "...");
 }
 
 #[test]

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -126,6 +126,7 @@ fn chars() {
     test_char("'\\''", '\'');
     test_char("'\"'", '"');
     test_char("'\\u{1F415}'", '\u{1F415}');
+    test_char("'a'q", 'a');
 }
 
 #[test]

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -100,6 +100,7 @@ fn bytes() {
     test_byte("b'\\t'", b'\t');
     test_byte("b'\\''", b'\'');
     test_byte("b'\"'", b'"');
+    test_byte("b'a'q", b'a');
 }
 
 #[test]

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -193,3 +193,25 @@ fn negative() {
     assert_eq!("-1.5f32", LitFloat::new("-1.5f32", span).to_string());
     assert_eq!("-1.5f64", LitFloat::new("-1.5f64", span).to_string());
 }
+
+#[test]
+fn suffix() {
+    fn get_suffix(token: &str) -> String {
+        let lit = syn::parse_str::<Lit>(token).unwrap();
+        match lit {
+            Lit::Str(lit) => lit.suffix().to_owned(),
+            //Lit::ByteStr(lit) => lit.suffix().to_owned(),
+            //Lit::Byte(lit) => lit.suffix().to_owned(),
+            //Lit::Char(lit) => lit.suffix().to_owned(),
+            _ => unimplemented!(),
+        }
+    }
+
+    assert_eq!(get_suffix("\"\"s"), "s");
+    assert_eq!(get_suffix("r\"\"r"), "r");
+    assert_eq!(get_suffix("b\"\"b"), "b");
+    assert_eq!(get_suffix("br\"\"br"), "br");
+    assert_eq!(get_suffix("r#\"\"#r"), "r");
+    assert_eq!(get_suffix("'c'c"), "c");
+    assert_eq!(get_suffix("b'b'b"), "b");
+}

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -76,6 +76,9 @@ fn byte_strings() {
         b"contains\nnewlinesescaped newlines",
     );
     test_byte_string("br\"raw\nstring\\\nhere\"", b"raw\nstring\\\nhere");
+    test_byte_string("b\"...\"q", b"...");
+    test_byte_string("br\"...\"q", b"...");
+    test_byte_string("br##\"...\"##q", b"...");
 }
 
 #[test]


### PR DESCRIPTION
e.g. `br#"..."#suffix`, `b'?'suffix`, `'?'suffix`

Rust lexical grammar is nuts but this matches the behavior of libproc_macro.