### PR TITLE
Parse top level const/static without value

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -72,11 +72,6 @@ pub fn base_dir_filter(entry: &DirEntry) -> bool {
         // https://github.com/dtolnay/syn/issues/762
         "test/ui/parser/foreign-static-syntactic-pass.rs" |
 
-        // TODO: top level const/static without value: `const X: u8;`
-        // https://github.com/dtolnay/syn/issues/764
-        "test/ui/parser/item-free-const-no-body-syntactic-pass.rs" |
-        "test/ui/parser/item-free-static-no-body-syntactic-pass.rs" |
-
         // TODO: mut receiver in fn pointer type: `fn(mut self)`
         // https://github.com/dtolnay/syn/issues/765
         "test/ui/parser/self-param-syntactic-pass.rs" |


### PR DESCRIPTION
It cannot be parsed as `Item{Const, Struct}` because `eq_token` and `expr` fields are not `Option`, so it parsed as `Item::Verbatim` [like `&raw [const|mut]` syntax](https://github.com/dtolnay/syn/blob/011b9dfc2d04bb1f2aee1b43e2bd88a9a067a568/src/expr.rs#L1495-L1497).

Closes #764