### PR TITLE
Parse extern static with value

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1754,7 +1754,31 @@ pub mod parsing {
             let mut item = if lookahead.peek(Token![fn]) {
                 input.parse().map(ForeignItem::Fn)
             } else if lookahead.peek(Token![static]) {
-                input.parse().map(ForeignItem::Static)
+                let vis = input.parse()?;
+                let static_token = input.parse()?;
+                let mutability = input.parse()?;
+                let ident = input.parse()?;
+                let colon_token = input.parse()?;
+                let ty = input.parse()?;
+
+                if input.peek(Token![=]) {
+                    input.parse::<Token![=]>()?;
+                    input.parse::<Expr>()?;
+                    input.parse::<Token![;]>()?;
+
+                    Ok(ForeignItem::Verbatim(verbatim::between(begin, input)))
+                } else {
+                    Ok(ForeignItem::Static(ForeignItemStatic {
+                        attrs: Vec::new(),
+                        vis,
+                        static_token,
+                        mutability,
+                        ident,
+                        colon_token,
+                        ty,
+                        semi_token: input.parse()?,
+                    }))
+                }
             } else if lookahead.peek(Token![type]) {
                 parse_flexible_foreign_item_type(begin, input)
             } else if vis.is_inherited()

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -68,10 +68,6 @@ pub fn base_dir_filter(entry: &DirEntry) -> bool {
         "test/ui/parser/fn-body-optional-syntactic-pass.rs" |
         "test/ui/parser/fn-header-syntactic-pass.rs" |
 
-        // TODO: extern static with value: `extern { static X: u8 = 0; }`
-        // https://github.com/dtolnay/syn/issues/762
-        "test/ui/parser/foreign-static-syntactic-pass.rs" |
-
         // TODO: top level const/static without value: `const X: u8;`
         // https://github.com/dtolnay/syn/issues/764
         "test/ui/parser/item-free-const-no-body-syntactic-pass.rs" |


### PR DESCRIPTION
It cannot be parsed as `ForeignItemStatic` , so it parsed as `ForeignItem::Verbatim` like `&raw [const|mut]` syntax.

Closes #762