### PR TITLE
Parse const generics on methods with feature(full)

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2000,7 +2000,16 @@ pub(crate) mod parsing {
 
     #[cfg(feature = "full")]
     fn generic_method_argument(input: ParseStream) -> Result<GenericMethodArgument> {
-        // TODO parse const generics as well
+        if input.peek(Lit) {
+            let lit = input.parse()?;
+            return Ok(GenericMethodArgument::Const(Expr::Lit(lit)));
+        }
+
+        if input.peek(token::Brace) {
+            let block = input.call(expr::parsing::expr_block)?;
+            return Ok(GenericMethodArgument::Const(Expr::Block(block)));
+        }
+
         input.parse().map(GenericMethodArgument::Type)
     }
 


### PR DESCRIPTION
I must admit I have not extensively tested this, but the code is simple enough and taken from the support for const generics on types so I have a lot of confidence in this.