### PR TITLE
Error earlier on unexpected token in struct expr

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2463,7 +2463,7 @@ pub(crate) mod parsing {
             }
 
             fields.push(content.parse()?);
-            if !content.peek(Token![,]) {
+            if content.is_empty() {
                 break;
             }
             let punct: Token![,] = content.parse()?;

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -551,7 +551,7 @@ pub mod parsing {
         while !content.is_empty() && !content.peek(Token![..]) {
             let value = content.call(field_pat)?;
             fields.push_value(value);
-            if !content.peek(Token![,]) {
+            if content.is_empty() {
                 break;
             }
             let punct: Token![,] = content.parse()?;


### PR DESCRIPTION
Previously we would only report errors inside of a struct expression or struct pattern's braces after subsequent tokens parsed successfully, otherwise preferring any error in the subsequent tokens.

Before:

```console
error: expected expression
 --> dev/main.rs:5:30
  |
5 | let _ = Struct { a: b, c; }; ,
  |                              ^
```

After:

```console
error: expected `,`
 --> dev/main.rs:5:25
  |
5 | let _ = Struct { a: b, c; }; ,
  |                         ^
```

Closes #817.