### PR TITLE
Remove parsing of extern:: paths

### DIFF
--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -72,7 +72,6 @@ pub trait Speculative {
     ///             || input.peek(Token![self])
     ///             || input.peek(Token![Self])
     ///             || input.peek(Token![crate])
-    ///             || input.peek(Token![extern])
     ///         {
     ///             let ident = input.call(Ident::parse_any)?;
     ///             return Ok(PathSegment::from(ident));

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1717,7 +1717,6 @@ pub(crate) mod parsing {
             || input.peek(Token![self])
             || input.peek(Token![Self])
             || input.peek(Token![super])
-            || input.peek(Token![extern])
             || input.peek(Token![crate])
         {
             path_or_macro_or_struct(input, allow_struct)
@@ -1789,7 +1788,6 @@ pub(crate) mod parsing {
             || input.peek(Token![self])
             || input.peek(Token![Self])
             || input.peek(Token![super])
-            || input.peek(Token![extern])
             || input.peek(Token![crate])
         {
             input.parse().map(Expr::Path)

--- a/src/item.rs
+++ b/src/item.rs
@@ -1306,7 +1306,6 @@ pub mod parsing {
                 && (lookahead.peek(Ident)
                     || lookahead.peek(Token![self])
                     || lookahead.peek(Token![super])
-                    || lookahead.peek(Token![extern])
                     || lookahead.peek(Token![crate])
                     || lookahead.peek(Token![::]))
             {
@@ -1494,7 +1493,6 @@ pub mod parsing {
                 || lookahead.peek(Token![self])
                 || lookahead.peek(Token![super])
                 || lookahead.peek(Token![crate])
-                || lookahead.peek(Token![extern])
             {
                 let ident = input.call(Ident::parse_any)?;
                 if input.peek(Token![::]) {
@@ -1929,7 +1927,6 @@ pub mod parsing {
                 && (lookahead.peek(Ident)
                     || lookahead.peek(Token![self])
                     || lookahead.peek(Token![super])
-                    || lookahead.peek(Token![extern])
                     || lookahead.peek(Token![crate])
                     || lookahead.peek(Token![::]))
             {
@@ -2393,7 +2390,6 @@ pub mod parsing {
             } else if lookahead.peek(Ident)
                 || lookahead.peek(Token![self])
                 || lookahead.peek(Token![super])
-                || lookahead.peek(Token![extern])
                 || lookahead.peek(Token![crate])
                 || lookahead.peek(Token![::])
             {
@@ -2694,7 +2690,6 @@ pub mod parsing {
                 && (lookahead.peek(Ident)
                     || lookahead.peek(Token![self])
                     || lookahead.peek(Token![super])
-                    || lookahead.peek(Token![extern])
                     || lookahead.peek(Token![crate])
                     || lookahead.peek(Token![::]))
             {

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -415,7 +415,6 @@ pub mod parsing {
                 || lookahead.peek(Token![<])
                 || input.peek(Token![Self])
                 || input.peek(Token![super])
-                || input.peek(Token![extern])
                 || input.peek(Token![crate])
             {
                 pat_path_or_macro_or_struct_or_range(input)
@@ -746,7 +745,6 @@ pub mod parsing {
             || lookahead.peek(Token![self])
             || lookahead.peek(Token![Self])
             || lookahead.peek(Token![super])
-            || lookahead.peek(Token![extern])
             || lookahead.peek(Token![crate])
         {
             Expr::Path(input.parse()?)

--- a/src/path.rs
+++ b/src/path.rs
@@ -291,11 +291,7 @@ pub mod parsing {
 
     impl PathSegment {
         fn parse_helper(input: ParseStream, expr_style: bool) -> Result<Self> {
-            if input.peek(Token![super])
-                || input.peek(Token![self])
-                || input.peek(Token![crate])
-                || input.peek(Token![extern])
-            {
+            if input.peek(Token![super]) || input.peek(Token![self]) || input.peek(Token![crate]) {
                 let ident = input.call(Ident::parse_any)?;
                 return Ok(PathSegment::from(ident));
             }
@@ -400,7 +396,6 @@ pub mod parsing {
                             && !input.peek(Token![self])
                             && !input.peek(Token![Self])
                             && !input.peek(Token![crate])
-                            && !input.peek(Token![extern])
                         {
                             break;
                         }

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -163,7 +163,7 @@ pub mod parsing {
             stmt_local(input, attrs).map(Stmt::Local)
         } else if input.peek(Token![pub])
             || input.peek(Token![crate]) && !input.peek2(Token![::])
-            || input.peek(Token![extern]) && !input.peek2(Token![::])
+            || input.peek(Token![extern])
             || input.peek(Token![use])
             || input.peek(Token![static]) && (input.peek2(Token![mut]) || input.peek2(Ident))
             || input.peek(Token![const])

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -554,7 +554,7 @@ pub mod parsing {
             }))
         } else if lookahead.peek(Token![fn])
             || lookahead.peek(Token![unsafe])
-            || lookahead.peek(Token![extern]) && !input.peek2(Token![::])
+            || lookahead.peek(Token![extern])
         {
             let allow_mut_self = true;
             if let Some(mut bare_fn) = parse_bare_fn(input, allow_mut_self)? {
@@ -568,7 +568,6 @@ pub mod parsing {
             || input.peek(Token![self])
             || input.peek(Token![Self])
             || input.peek(Token![crate])
-            || input.peek(Token![extern])
             || lookahead.peek(Token![::])
             || lookahead.peek(Token![<])
         {


### PR DESCRIPTION
This unstable feature was removed from rustc in https://github.com/rust-lang/rust/pull/57572.