### PR TITLE
Parse macro call expr with None-delimited path

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1691,7 +1691,7 @@ pub(crate) mod parsing {
     // interactions, as they are fully contained.
     #[cfg(feature = "full")]
     fn atom_expr(input: ParseStream, allow_struct: AllowStruct) -> Result<Expr> {
-        if input.peek(token::Group) && !input.peek2(Token![::]) {
+        if input.peek(token::Group) && !input.peek2(Token![::]) && !input.peek2(Token![!]) {
             input.call(expr_group).map(Expr::Group)
         } else if input.peek(Lit) {
             input.parse().map(Expr::Lit)

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -115,3 +115,30 @@ fn test_macro_variable_func() {
     }
     "###);
 }
+
+#[test]
+fn test_macro_variable_macro() {
+    // mimics the token stream corresponding to `$macro!()`
+    let tokens = TokenStream::from_iter(vec![
+        TokenTree::Group(Group::new(Delimiter::None, quote! { m })),
+        TokenTree::Punct(Punct::new('!', Spacing::Alone)),
+        TokenTree::Group(Group::new(Delimiter::Parenthesis, TokenStream::new())),
+    ]);
+
+    snapshot!(tokens as Expr, @r###"
+    Expr::Macro {
+        mac: Macro {
+            path: Path {
+                segments: [
+                    PathSegment {
+                        ident: "m",
+                        arguments: None,
+                    },
+                ],
+            },
+            delimiter: Paren,
+            tokens: TokenStream(``),
+        },
+    }
+    "###);
+}


### PR DESCRIPTION
This would happen in the expression `$macro!()` where $macro:ident.

Fixes https://crater-reports.s3.amazonaws.com/pr-72622/master%237726070fa755f660b5da3f82f46e07d9c6866f69/reg/fourier-0.1.0/log.txt.