### PR TITLE
Parse Type::Path containing None-delimited group segment

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -430,7 +430,7 @@ pub mod parsing {
     }
 
     fn ambig_ty(input: ParseStream, allow_plus: bool) -> Result<Type> {
-        if input.peek(token::Group) && !input.peek2(Token![::]) {
+        if input.peek(token::Group) && !input.peek2(Token![::]) && !input.peek2(Token![<]) {
             return input.parse().map(Type::Group);
         }
 

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -1,3 +1,9 @@
+#[macro_use]
+mod macros;
+
+use proc_macro2::{Delimiter, Group, Ident, Punct, Spacing, Span, TokenStream, TokenTree};
+use quote::quote;
+use std::iter::FromIterator;
 use syn::Type;
 
 #[test]
@@ -7,4 +13,41 @@ fn test_mut_self() {
     syn::parse_str::<Type>("fn(mut self: ...)").unwrap_err();
     syn::parse_str::<Type>("fn(mut self: mut self)").unwrap_err();
     syn::parse_str::<Type>("fn(mut self::T)").unwrap_err();
+}
+
+#[test]
+fn test_macro_variable_type() {
+    // mimics the token stream corresponding to `$ty<T>`
+    let tokens = TokenStream::from_iter(vec![
+        TokenTree::Group(Group::new(Delimiter::None, quote! { ty })),
+        TokenTree::Punct(Punct::new('<', Spacing::Alone)),
+        TokenTree::Ident(Ident::new("T", Span::call_site())),
+        TokenTree::Punct(Punct::new('>', Spacing::Alone)),
+    ]);
+
+    snapshot!(tokens as Type, @r###"
+    Type::Path {
+        path: Path {
+            segments: [
+                PathSegment {
+                    ident: "ty",
+                    arguments: PathArguments::AngleBracketed {
+                        args: [
+                            Type(Type::Path {
+                                path: Path {
+                                    segments: [
+                                        PathSegment {
+                                            ident: "T",
+                                            arguments: None,
+                                        },
+                                    ],
+                                },
+                            }),
+                        ],
+                    },
+                },
+            ],
+        },
+    }
+    "###);
 }


### PR DESCRIPTION
This would happen in the type `$ty<T>` or `$ty<'a>` where $ty:ty.

Fixes https://crater-reports.s3.amazonaws.com/pr-72622/master%237726070fa755f660b5da3f82f46e07d9c6866f69/reg/gc-sequence-0.2.0/log.txt.