### PR TITLE
Parse Expr::Struct containing None-delimited ident name

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1691,7 +1691,11 @@ pub(crate) mod parsing {
     // interactions, as they are fully contained.
     #[cfg(feature = "full")]
     fn atom_expr(input: ParseStream, allow_struct: AllowStruct) -> Result<Expr> {
-        if input.peek(token::Group) && !input.peek2(Token![::]) && !input.peek2(Token![!]) {
+        if input.peek(token::Group)
+            && !input.peek2(Token![::])
+            && !input.peek2(Token![!])
+            && !input.peek2(token::Brace)
+        {
             input.call(expr_group).map(Expr::Group)
         } else if input.peek(Lit) {
             input.parse().map(Expr::Lit)

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -142,3 +142,25 @@ fn test_macro_variable_macro() {
     }
     "###);
 }
+
+#[test]
+fn test_macro_variable_struct() {
+    // mimics the token stream corresponding to `$struct {}`
+    let tokens = TokenStream::from_iter(vec![
+        TokenTree::Group(Group::new(Delimiter::None, quote! { S })),
+        TokenTree::Group(Group::new(Delimiter::Brace, TokenStream::new())),
+    ]);
+
+    snapshot!(tokens as Expr, @r###"
+    Expr::Struct {
+        path: Path {
+            segments: [
+                PathSegment {
+                    ident: "S",
+                    arguments: None,
+                },
+            ],
+        },
+    }
+    "###);
+}


### PR DESCRIPTION
This would happen in the expression `$struct {...}` where $struct:ident.