### PR TITLE
Handle multiple nested `None`-delimited groups

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -201,13 +201,14 @@ impl<'a> Cursor<'a> {
         Cursor::create(self.ptr.offset(1), self.scope)
     }
 
-    /// If the cursor is looking at a `None`-delimited group, move it to look at
+    /// While the cursor is looking at a `None`-delimited group, move it to look at
     /// the first token inside instead. If the group is empty, this will move
     /// the cursor past the `None`-delimited group.
     ///
-    /// WARNING: This mutates its argument.
+    /// WARNING: This mutates its argument, stopping when it finds something
+    /// other than a `None`-delimited group.
     fn ignore_none(&mut self) {
-        if let Entry::Group(group, buf) = self.entry() {
+        while let Entry::Group(group, buf) = self.entry() {
             if group.delimiter() == Delimiter::None {
                 // NOTE: We call `Cursor::create` here to make sure that
                 // situations where we should immediately exit the span after
@@ -215,6 +216,8 @@ impl<'a> Cursor<'a> {
                 unsafe {
                     *self = Cursor::create(&buf.data[0], self.scope);
                 }
+            } else {
+                break;
             }
         }
     }

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -1,5 +1,9 @@
-use proc_macro2::{Span, TokenStream, TokenTree};
+#[macro_use]
+mod macros;
+
+use proc_macro2::{Delimiter, Group, Literal, Span, TokenStream, TokenTree};
 use quote::ToTokens;
+use std::iter::FromIterator;
 use std::str::FromStr;
 use syn::{Lit, LitFloat, LitInt};
 
@@ -228,4 +232,17 @@ fn suffix() {
     assert_eq!(get_suffix("1_i32"), "i32");
     assert_eq!(get_suffix("1.0f32"), "f32");
     assert_eq!(get_suffix("1.0_f32"), "f32");
+}
+
+#[test]
+fn test_deep_group_empty() {
+    let tokens = TokenStream::from_iter(vec![TokenTree::Group(Group::new(
+        Delimiter::None,
+        TokenStream::from_iter(vec![TokenTree::Group(Group::new(
+            Delimiter::None,
+            TokenStream::from_iter(vec![TokenTree::Literal(Literal::string("hi"))]),
+        ))]),
+    ))]);
+
+    snapshot!(tokens as Lit, @r#""hi""# );
 }


### PR DESCRIPTION
When rust-lang/rust#72388 re-lands, we may accumulate several 'layers'
of `None`-delimited groups. This commit ensures that we 'unwrap' all of
the layers, allowing consumers to avoid needing to handle these cases.