### PR TITLE
Remove extern crate proc_macro from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,6 @@ proc-macro = true
 ```
 
 ```rust
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};

--- a/dev/parse.rs
+++ b/dev/parse.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::File;

--- a/examples/heapsize/heapsize_derive/src/lib.rs
+++ b/examples/heapsize/heapsize_derive/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;

--- a/examples/lazy-static/lazy-static/src/lib.rs
+++ b/examples/lazy-static/lazy-static/src/lib.rs
@@ -1,9 +1,7 @@
 #![recursion_limit = "128"]
 #![feature(proc_macro_diagnostic)]
 
-extern crate proc_macro;
-use self::proc_macro::TokenStream;
-
+use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;

--- a/examples/trace-var/trace-var/src/lib.rs
+++ b/examples/trace-var/trace-var/src/lib.rs
@@ -1,6 +1,4 @@
-extern crate proc_macro;
-use self::proc_macro::TokenStream;
-
+use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use std::collections::HashSet as Set;
 use syn::fold::{self, Fold};

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -470,8 +470,8 @@ ast_enum_of_structs! {
 /// as type `AttributeArgs`.
 ///
 /// ```
-/// extern crate proc_macro;
-///
+/// # extern crate proc_macro;
+/// #
 /// use proc_macro::TokenStream;
 /// use syn::{parse_macro_input, AttributeArgs, ItemFn};
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,8 +31,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// conversion to `compile_error!` automatically.
 ///
 /// ```
-/// extern crate proc_macro;
-///
+/// # extern crate proc_macro;
+/// #
 /// use proc_macro::TokenStream;
 /// use syn::{parse_macro_input, AttributeArgs, ItemFn};
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@
 //! ```
 //!
 //! ```
-//! extern crate proc_macro;
-//!
+//! # extern crate proc_macro;
+//! #
 //! use proc_macro::TokenStream;
 //! use quote::quote;
 //! use syn::{parse_macro_input, DeriveInput};
@@ -820,8 +820,8 @@ pub use crate::error::{Error, Result};
 /// # Examples
 ///
 /// ```
-/// extern crate proc_macro;
-///
+/// # extern crate proc_macro;
+/// #
 /// use proc_macro::TokenStream;
 /// use quote::quote;
 /// use syn::DeriveInput;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -26,8 +26,8 @@
 //! [`parse_macro_input!`]: ../macro.parse_macro_input.html
 //!
 //! ```
-//! extern crate proc_macro;
-//!
+//! # extern crate proc_macro;
+//! #
 //! use proc_macro::TokenStream;
 //! use syn::{braced, parse_macro_input, token, Field, Ident, Result, Token};
 //! use syn::parse::{Parse, ParseStream};
@@ -153,8 +153,8 @@
 //! [`Parser`]: trait.Parser.html
 //!
 //! ```
-//! extern crate proc_macro;
-//!
+//! # extern crate proc_macro;
+//! #
 //! use proc_macro::TokenStream;
 //! use syn::parse::Parser;
 //! use syn::punctuated::Punctuated;
@@ -1217,8 +1217,8 @@ pub(crate) fn parse_stream<F: Parser>(f: F, input: ParseStream) -> Result<F::Out
 /// provided any attribute args.
 ///
 /// ```
-/// extern crate proc_macro;
-///
+/// # extern crate proc_macro;
+/// #
 /// use proc_macro::TokenStream;
 /// use syn::parse_macro_input;
 /// use syn::parse::Nothing;

--- a/src/parse_macro_input.rs
+++ b/src/parse_macro_input.rs
@@ -16,8 +16,8 @@
 /// #\[proc_macro_attribute\] attribute.
 ///
 /// ```
-/// extern crate proc_macro;
-///
+/// # extern crate proc_macro;
+/// #
 /// use proc_macro::TokenStream;
 /// use syn::{parse_macro_input, Result};
 /// use syn::parse::{Parse, ParseStream};


### PR DESCRIPTION
This is no longer required inside of proc-macro crates as of Rust 1.42.
https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#use-proc_macrotokenstream-now-works