### PR TITLE
Type unit

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -67,7 +67,7 @@ ast_enum_of_structs! {
         Tuple(TypeTuple),
 
         /// The unit type: `()`
-        Unit,
+        Unit(TypeUnit),
 
         /// Tokens in type position not interpreted by Syn.
         Verbatim(TokenStream),
@@ -240,6 +240,16 @@ ast_struct! {
     pub struct TypeTuple {
         pub paren_token: token::Paren,
         pub elems: Punctuated<Type, Token![,]>,
+    }
+}
+
+ast_struct! {
+    /// A unit type: `()`.
+    ///
+    /// *This type is available only if Syn is built with the `"derive"` or
+    /// `"full"` feature.*
+    pub struct TypeUnit {
+        pub paren_token: token::Paren,
     }
 }
 
@@ -463,7 +473,9 @@ pub mod parsing {
             let content;
             let paren_token = parenthesized!(content in input);
             if content.is_empty() {
-                return Ok(Type::Unit);
+                return Ok(Type::Unit(TypeUnit {
+                    paren_token,
+                }));
             }
             if content.peek(Lifetime) {
                 return Ok(Type::Paren(TypeParen {
@@ -1078,6 +1090,12 @@ mod printing {
 
     use crate::attr::FilterAttrs;
     use crate::print::TokensOrDefault;
+
+    impl ToTokens for TypeUnit {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            self.paren_token.surround(tokens, |_| {});
+        }
+    }
 
     impl ToTokens for TypeSlice {
         fn to_tokens(&self, tokens: &mut TokenStream) {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -66,6 +66,9 @@ ast_enum_of_structs! {
         /// A tuple type: `(A, B, C, String)`.
         Tuple(TypeTuple),
 
+        /// The unit type: `()`
+        Unit,
+
         /// Tokens in type position not interpreted by Syn.
         Verbatim(TokenStream),
 
@@ -332,6 +335,9 @@ impl Hash for Type {
                 hash.write_u8(13);
                 ty.hash(hash);
             }
+            Type::Unit => {
+                hash.write_u8(15);
+            }
             Type::Verbatim(ty) => {
                 hash.write_u8(14);
                 TokenStreamHelper(ty).hash(hash);
@@ -457,10 +463,7 @@ pub mod parsing {
             let content;
             let paren_token = parenthesized!(content in input);
             if content.is_empty() {
-                return Ok(Type::Tuple(TypeTuple {
-                    paren_token,
-                    elems: Punctuated::new(),
-                }));
+                return Ok(Type::Unit);
             }
             if content.peek(Lifetime) {
                 return Ok(Type::Paren(TypeParen {

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -5038,6 +5038,9 @@ impl Debug for Lite<syn::Type> {
                 }
                 formatter.finish()
             }
+            syn::Type::Unit => {
+                formatter.debug_struct("Type::Unit").finish()
+            }
             syn::Type::Verbatim(_val) => {
                 formatter.write_str("Verbatim")?;
                 formatter.write_str("(`")?;

--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -165,7 +165,7 @@ fn test_union() {
                         vis: Inherited,
                         ident: Some("uninit"),
                         colon_token: Some,
-                        ty: Type::Tuple,
+                        ty: Type::Unit,
                     },
                     Field {
                         vis: Inherited,

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -56,7 +56,7 @@ fn test_split_for_impl() {
                         }),
                     ],
                     eq_token: Some,
-                    default: Some(Type::Tuple),
+                    default: Some(Type::Unit),
                 }),
             ],
             gt_token: Some,


### PR DESCRIPTION
Hello! I am new to rust, so please let me know if there is a different answer to my question. I am trying to build a match with an arm for functions with no return signature or functions that return unit, and was finding it somewhat difficult to do so. Previously, `()` in a type position would be parsed as `Type::Tuple` with empty `elems`, like so:

```
Tuple(TypeTuple { paren_token: Paren, elems: [] })
```

But with this change I believe I can express my pattern like this (with `#![feature(box_patterns)]`):

```
match ret {
    ReturnType::Default | ReturnType::Type(_, box Type::Unit(..)) => ...
}
```

Is it worth it? Well, that's for you to decide :)