### PR TITLE
Fix parse of `tuple.0. 0`

### DIFF
--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -52,53 +52,69 @@ fn test_await() {
 
 #[test]
 fn test_tuple_multi_index() {
-    let input = "tuple.0.0";
-    snapshot!(input as Expr, @r###"
-    Expr::Field {
-        base: Expr::Field {
-            base: Expr::Path {
-                path: Path {
-                    segments: [
-                        PathSegment {
-                            ident: "tuple",
-                            arguments: None,
-                        },
-                    ],
+    for &input in &[
+        "tuple.0.0",
+        "tuple .0.0",
+        "tuple. 0.0",
+        "tuple.0 .0",
+        "tuple.0. 0",
+        "tuple . 0 . 0",
+    ] {
+        snapshot!(input as Expr, @r###"
+        Expr::Field {
+            base: Expr::Field {
+                base: Expr::Path {
+                    path: Path {
+                        segments: [
+                            PathSegment {
+                                ident: "tuple",
+                                arguments: None,
+                            },
+                        ],
+                    },
                 },
+                member: Unnamed(Index {
+                    index: 0,
+                }),
             },
             member: Unnamed(Index {
                 index: 0,
             }),
-        },
-        member: Unnamed(Index {
-            index: 0,
-        }),
+        }
+        "###);
     }
-    "###);
 
-    let tokens = quote!(tuple.0.0);
-    snapshot!(tokens as Expr, @r###"
-    Expr::Field {
-        base: Expr::Field {
-            base: Expr::Path {
-                path: Path {
-                    segments: [
-                        PathSegment {
-                            ident: "tuple",
-                            arguments: None,
-                        },
-                    ],
+    for tokens in vec![
+        quote!(tuple.0.0),
+        quote!(tuple .0.0),
+        quote!(tuple. 0.0),
+        quote!(tuple.0 .0),
+        quote!(tuple.0. 0),
+        quote!(tuple . 0 . 0),
+    ] {
+        snapshot!(tokens as Expr, @r###"
+        Expr::Field {
+            base: Expr::Field {
+                base: Expr::Path {
+                    path: Path {
+                        segments: [
+                            PathSegment {
+                                ident: "tuple",
+                                arguments: None,
+                            },
+                        ],
+                    },
                 },
+                member: Unnamed(Index {
+                    index: 0,
+                }),
             },
             member: Unnamed(Index {
                 index: 0,
             }),
-        },
-        member: Unnamed(Index {
-            index: 0,
-        }),
+        }
+        "###);
     }
-    "###);
 }
 
 #[test]

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -50,6 +50,7 @@ fn test_await() {
     "###);
 }
 
+#[rustfmt::skip]
 #[test]
 fn test_tuple_multi_index() {
     for &input in &[


### PR DESCRIPTION
Previously `tuple.0. 0` would fail with:

```console
error: unexpected end of input, expected literal
 --> dev/main.rs:5:19
  |
5 |     let _ = tuple.0. 0;
  |                   ^^
```

because we had done `split('.')` on the `0.` float literal token expecting to parse an integer index from both sides.