### PR TITLE
Accept traits with parenthesized path arguments in impls

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -2598,7 +2598,11 @@ pub mod parsing {
         let trait_ = (|| -> Option<_> {
             let ahead = input.fork();
             let polarity: Option<Token![!]> = ahead.parse().ok()?;
-            let path: Path = ahead.parse().ok()?;
+            let mut path: Path = ahead.parse().ok()?;
+            if path.segments.last().unwrap().arguments.is_empty() && ahead.peek(token::Paren) {
+                let parenthesized = PathArguments::Parenthesized(ahead.parse().ok()?);
+                path.segments.last_mut().unwrap().arguments = parenthesized;
+            }
             let for_token: Token![for] = ahead.parse().ok()?;
             input.advance_to(&ahead);
             Some((polarity, path, for_token))


### PR DESCRIPTION
This lets `ItemImpl`s, i.e. `impl Trait for Type {}`, include parenthesized path arguments on `Trait`. An example would be `impl FnOnce() for X {}`.

This is in line with `rustc` which parses successfully, but bails later with "associated type bindings are not allowed here".