### PR TITLE
Parse as float even with `e` and numeric exponent separated by `_`

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -1359,10 +1359,13 @@ mod value {
                 // NOTE: Looking at a floating point literal, we don't want to
                 // consider these integers.
                 b'.' if base == 10 => return None,
-                b'e' | b'E' if base == 10 => match byte(s, 1) {
-                    b'-' | b'+' | b'0'..=b'9' => return None,
-                    _ => break,
-                },
+                b'e' | b'E' if base == 10 => {
+                    let rest = s[1..].trim_start_matches('_');
+                    match byte(rest, 0) {
+                        b'-' | b'+' | b'0'..=b'9' => return None,
+                        _ => break,
+                    }
+                }
                 _ => break,
             };
 

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -195,6 +195,7 @@ fn floats() {
     test_float("1.0__3e-12", 1.03e-12, "");
     test_float("1.03e+12", 1.03e12, "");
     test_float("9e99e99", 9e99, "e99");
+    test_float("1e_0", 1.0, "");
 }
 
 #[test]


### PR DESCRIPTION
Previously, we'd parse `1e0` as a float but `1e_0` as an integer `1` with suffix `e_0`. This PR fixes it to parse as float, matching the behavior of libproc_macro.