### PR TITLE
Remove deprecated description method from Error impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -309,11 +309,7 @@ impl Clone for ErrorMessage {
     }
 }
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        "parse error"
-    }
-}
+impl std::error::Error for Error {}
 
 impl From<LexError> for Error {
     fn from(err: LexError) -> Self {


### PR DESCRIPTION
This trait method has been soft deprecated in libstd since 1.27.0 and hard deprecated since 1.42.0. Nothing should be using it and it's not able to return a meaningful message anyway. If anything, our message is less useful than the trait's default impl's message.