### PR TITLE
Document completion check on syn::parse2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -880,6 +880,9 @@ pub fn parse<T: parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T> {
 
 /// Parse a proc-macro2 token stream into the chosen syntax tree node.
 ///
+/// This function will check that the input is fully parsed. If there are
+/// any unparsed tokens at the end of the stream, an error is returned.
+///
 /// This function parses a `proc_macro2::TokenStream` which is commonly useful
 /// when the input comes from a node of the Syn syntax tree, for example the
 /// body tokens of a [`Macro`] node. When in a procedural macro parsing the


### PR DESCRIPTION
The free-standing `parse2`'s documentation doesn't mention that it can error even if the underlying `Parse::parse` succeeds.  
[This tripped me up a bit.](https://github.com/Tamschi/call2-for-syn/issues/1)

This pull request copies the relevant phrase from `Parser::parse2`'s documentation.