### PR TITLE
Fix panic_fmt warning

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -1280,7 +1280,7 @@ mod value {
 
     fn backslash_u(mut s: &str) -> (char, &str) {
         if byte(s, 0) != b'{' {
-            panic!("expected {{ after \\u");
+            panic!("{}", "expected { after \\u");
         }
         s = &s[1..];
 


### PR DESCRIPTION
```console
$ cargo check
warning: panic message contains braces
    --> src/lit.rs:1283:30
     |
1283 |             panic!("expected {{ after \\u");
     |                              ^^
     |
     = note: `#[warn(panic_fmt)]` on by default
     = note: this message is not used as a format string, but will be in a future Rust edition
help: add a "{}" format string to use the message literally
     |
1283 |             panic!("{}", "expected {{ after \\u");
     |                    ^^^^^
```

FYI: the current one is printed as `expected {{ after \u`: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=45ed815fdfa7a54d42bdaa70a4659674