### PR TITLE
Parse const blocks in pattern position

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -12,9 +12,8 @@ const REVISION: &str = "9d78d1d02761b906038ba4d54c5f3427f920f5fb";
 
 #[rustfmt::skip]
 static EXCLUDE: &[&str] = &[
-    // TODO: const block in pattern position (#921)
+    // TODO: const block in range patterns (#921)
     "src/test/ui/inline-const/const-match-pat-range.rs",
-    "src/test/ui/inline-const/const-match-pat.rs",
 
     // Compile-fail expr parameter in const generic position: f::<1 + 2>()
     "src/test/ui/const-generics/closing-args-token.rs",


### PR DESCRIPTION
Part of #921. The remaining work on const blocks is use in range patterns, since those follow a different parse. In pat outside of ranges, const block will parse to `Pat::Verbatim`. In ranges, the range bounds are represented as Expr in the syntax tree so we'd need to parse to `Pat::Range` containing the const block range bounds as `Expr::Verbatim`.