### PR TITLE
Fix impl parsing with None-delimited grouped path

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -2372,15 +2372,26 @@ pub mod parsing {
             None
         };
 
-        let first_ty: Type = input.parse()?;
+        let mut first_ty: Type = input.parse()?;
         let self_ty: Type;
         let trait_;
 
         let is_impl_for = input.peek(Token![for]);
         if is_impl_for {
             let for_token: Token![for] = input.parse()?;
-            if let Type::Path(TypePath { qself: None, path }) = first_ty {
-                trait_ = Some((polarity, path, for_token));
+            let mut first_ty_ref = &first_ty;
+            while let Type::Group(ty) = first_ty_ref {
+                first_ty_ref = &ty.elem;
+            }
+            if let Type::Path(_) = first_ty_ref {
+                while let Type::Group(ty) = first_ty {
+                    first_ty = *ty.elem;
+                }
+                if let Type::Path(TypePath { qself: None, path }) = first_ty {
+                    trait_ = Some((polarity, path, for_token));
+                } else {
+                    unreachable!()
+                }
             } else {
                 trait_ = None;
             }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -118,3 +118,44 @@ fn test_negative_impl() {
     }
     "###);
 }
+
+#[test]
+fn test_macro_variable_impl() {
+    // mimics the token stream corresponding to `impl $trait for $ty {}`
+    let tokens = TokenStream::from_iter(vec![
+        TokenTree::Ident(Ident::new("impl", Span::call_site())),
+        TokenTree::Group(Group::new(Delimiter::None, quote!(Trait))),
+        TokenTree::Ident(Ident::new("for", Span::call_site())),
+        TokenTree::Group(Group::new(Delimiter::None, quote!(Type))),
+        TokenTree::Group(Group::new(Delimiter::Brace, TokenStream::new())),
+    ]);
+
+    snapshot!(tokens as Item, @r###"
+    Item::Impl {
+        generics: Generics,
+        trait_: Some((
+            None,
+            Path {
+                segments: [
+                    PathSegment {
+                        ident: "Trait",
+                        arguments: None,
+                    },
+                ],
+            },
+        )),
+        self_ty: Type::Group {
+            elem: Type::Path {
+                path: Path {
+                    segments: [
+                        PathSegment {
+                            ident: "Type",
+                            arguments: None,
+                        },
+                    ],
+                },
+            },
+        },
+    }
+    "###);
+}


### PR DESCRIPTION
Fixes #941.

This was broken by #936.