### PR TITLE
Fix parsing of path type wrapped in a `None`-delimited group

### DIFF
--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -51,3 +51,55 @@ fn test_macro_variable_type() {
     }
     "###);
 }
+
+#[test]
+fn test_group_angle_brackets() {
+    // mimics the token stream corresponding to `$ty<T>`
+    let tokens = TokenStream::from_iter(vec![
+        TokenTree::Ident(Ident::new("Option", Span::call_site())),
+        TokenTree::Punct(Punct::new('<', Spacing::Alone)),
+        TokenTree::Group(Group::new(Delimiter::None, quote! { Vec<u8> })),
+        TokenTree::Punct(Punct::new('>', Spacing::Alone)),
+    ]);
+
+    snapshot!(tokens as Type, @r###"
+    Type::Path {
+        path: Path {
+            segments: [
+                PathSegment {
+                    ident: "Option",
+                    arguments: PathArguments::AngleBracketed {
+                        args: [
+                            Type(Type::Group {
+                                elem: Type::Path {
+                                    path: Path {
+                                        segments: [
+                                            PathSegment {
+                                                ident: "Vec",
+                                                arguments: PathArguments::AngleBracketed {
+                                                    args: [
+                                                        Type(Type::Path {
+                                                            path: Path {
+                                                                segments: [
+                                                                    PathSegment {
+                                                                        ident: "u8",
+                                                                        arguments: None,
+                                                                    },
+                                                                ],
+                                                            },
+                                                        }),
+                                                    ],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                            }),
+                        ],
+                    },
+                },
+            ],
+        },
+    }
+    "###);
+}


### PR DESCRIPTION
Previously, `peek2` was used to check for `::` or `<` following a
`None`-delimited group. However, `peek2` will look *inside* a
`None`-delimited group, so this code would treat input like
`{{ Vec<u8> }}` as having an angle bracket *after* the `None`-delimited
group.

We now consume the `None`-delimited group by parsing it, and then use
`peek` to check for tokens that occur *after* the `None`-delimited
group.