### PR TITLE
Parse simple literal const generic path args even without "full"

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -241,12 +241,15 @@ pub mod parsing {
                 if input.peek(Ident) && input.peek2(Token![:]) && !input.peek2(Token![::]) {
                     return Ok(GenericArgument::Constraint(input.parse()?));
                 }
+            }
 
-                if input.peek(Lit) {
-                    let lit = input.parse()?;
-                    return Ok(GenericArgument::Const(Expr::Lit(lit)));
-                }
+            if input.peek(Lit) {
+                let lit = input.parse()?;
+                return Ok(GenericArgument::Const(Expr::Lit(lit)));
+            }
 
+            #[cfg(feature = "full")]
+            {
                 if input.peek(token::Brace) {
                     let block = input.call(expr::parsing::expr_block)?;
                     return Ok(GenericArgument::Const(Expr::Block(block)));


### PR DESCRIPTION
This allows e.g. the following DeriveInput to parse even without the `"full"` feature enabled. This is going to make increasingly common appearance with the stabilization of min_const generics in Rust 1.51 (https://github.com/rust-lang/rust/pull/79135).

```rust
pub struct S {
    array: Array<10>,
}
```