### PR TITLE
Fix loss of punctuation spans on TypeTuple parse

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -435,9 +435,13 @@ pub mod parsing {
                         let mut elems = Punctuated::new();
                         elems.push_value(first);
                         elems.push_punct(content.parse()?);
-                        let rest: Punctuated<Type, Token![,]> =
-                            content.parse_terminated(Parse::parse)?;
-                        elems.extend(rest);
+                        while !content.is_empty() {
+                            elems.push_value(content.parse()?);
+                            if content.is_empty() {
+                                break;
+                            }
+                            elems.push_punct(content.parse()?);
+                        }
                         elems
                     },
                 }));
@@ -770,9 +774,13 @@ pub mod parsing {
                     let mut elems = Punctuated::new();
                     elems.push_value(first);
                     elems.push_punct(content.parse()?);
-                    let rest: Punctuated<Type, Token![,]> =
-                        content.parse_terminated(Parse::parse)?;
-                    elems.extend(rest);
+                    while !content.is_empty() {
+                        elems.push_value(content.parse()?);
+                        if content.is_empty() {
+                            break;
+                        }
+                        elems.push_punct(content.parse()?);
+                    }
                     elems
                 },
             })


### PR DESCRIPTION
The original implementation was going through Punctuated's impl IntoIterator\<Item = T\> followed by Extend\<T\>, which throws away the old punctuation tokens P and creates brand new Default ones, losing the spans.

Fixes #959.