### PR TITLE
De-duplicate the generated code for `surround`

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -433,18 +433,14 @@ mod printing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for FieldsNamed {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.brace_token.surround(tokens, |tokens| {
-                self.named.to_tokens(tokens);
-            });
+            self.brace_token.surround_tokens(tokens, &self.named);
         }
     }
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for FieldsUnnamed {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.paren_token.surround(tokens, |tokens| {
-                self.unnamed.to_tokens(tokens);
-            });
+            self.paren_token.surround_tokens(tokens, &self.unnamed);
         }
     }
 

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -260,9 +260,7 @@ mod printing {
                 },
                 Data::Enum(data) => {
                     self.generics.where_clause.to_tokens(tokens);
-                    data.brace_token.surround(tokens, |tokens| {
-                        data.variants.to_tokens(tokens);
-                    });
+                    data.brace_token.surround_tokens(tokens, &data.variants);
                 }
                 Data::Union(data) => {
                     self.generics.where_clause.to_tokens(tokens);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2721,9 +2721,7 @@ pub(crate) mod printing {
     #[cfg(feature = "full")]
     fn wrap_bare_struct(tokens: &mut TokenStream, e: &Expr) {
         if let Expr::Struct(_) = *e {
-            token::Paren::default().surround(tokens, |tokens| {
-                e.to_tokens(tokens);
-            });
+            token::Paren::default().surround_tokens(tokens, e);
         } else {
             e.to_tokens(tokens);
         }
@@ -2772,9 +2770,7 @@ pub(crate) mod printing {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             outer_attrs_to_tokens(&self.attrs, tokens);
             self.func.to_tokens(tokens);
-            self.paren_token.surround(tokens, |tokens| {
-                self.args.to_tokens(tokens);
-            })
+            self.paren_token.surround_tokens(tokens, &self.args);
         }
     }
 
@@ -2787,9 +2783,7 @@ pub(crate) mod printing {
             self.dot_token.to_tokens(tokens);
             self.method.to_tokens(tokens);
             self.turbofish.to_tokens(tokens);
-            self.paren_token.surround(tokens, |tokens| {
-                self.args.to_tokens(tokens);
-            });
+            self.paren_token.surround_tokens(tokens, &self.args);
         }
     }
 
@@ -2892,9 +2886,7 @@ pub(crate) mod printing {
                     else_.to_tokens(tokens);
                 }
                 _ => {
-                    token::Brace::default().surround(tokens, |tokens| {
-                        else_.to_tokens(tokens);
-                    });
+                    token::Brace::default().surround_tokens(tokens, else_);
                 }
             }
         }
@@ -3132,9 +3124,7 @@ pub(crate) mod printing {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             outer_attrs_to_tokens(&self.attrs, tokens);
             self.expr.to_tokens(tokens);
-            self.bracket_token.surround(tokens, |tokens| {
-                self.index.to_tokens(tokens);
-            });
+            self.bracket_token.surround_tokens(tokens, &self.index);
         }
     }
 
@@ -3249,9 +3239,7 @@ pub(crate) mod printing {
     impl ToTokens for ExprGroup {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             outer_attrs_to_tokens(&self.attrs, tokens);
-            self.group_token.surround(tokens, |tokens| {
-                self.expr.to_tokens(tokens);
-            });
+            self.group_token.surround_tokens(tokens, &self.expr);
         }
     }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -2912,9 +2912,7 @@ mod printing {
             self.ident.to_tokens(tokens);
             self.generics.to_tokens(tokens);
             self.generics.where_clause.to_tokens(tokens);
-            self.brace_token.surround(tokens, |tokens| {
-                self.variants.to_tokens(tokens);
-            });
+            self.brace_token.surround_tokens(tokens, &self.variants);
         }
     }
 
@@ -3025,13 +3023,13 @@ mod printing {
             self.ident.to_tokens(tokens);
             match &self.mac.delimiter {
                 MacroDelimiter::Paren(paren) => {
-                    paren.surround(tokens, |tokens| self.mac.tokens.to_tokens(tokens));
+                    paren.surround_tokens(tokens, &self.mac.tokens);
                 }
                 MacroDelimiter::Brace(brace) => {
-                    brace.surround(tokens, |tokens| self.mac.tokens.to_tokens(tokens));
+                    brace.surround_tokens(tokens, &self.mac.tokens);
                 }
                 MacroDelimiter::Bracket(bracket) => {
-                    bracket.surround(tokens, |tokens| self.mac.tokens.to_tokens(tokens));
+                    bracket.surround_tokens(tokens, &self.mac.tokens);
                 }
             }
             self.semi_token.to_tokens(tokens);
@@ -3084,9 +3082,7 @@ mod printing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for UseGroup {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.brace_token.surround(tokens, |tokens| {
-                self.items.to_tokens(tokens);
-            });
+            self.brace_token.surround_tokens(tokens, &self.items);
         }
     }
 

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -205,13 +205,13 @@ mod printing {
             self.bang_token.to_tokens(tokens);
             match &self.delimiter {
                 MacroDelimiter::Paren(paren) => {
-                    paren.surround(tokens, |tokens| self.tokens.to_tokens(tokens));
+                    paren.surround_tokens(tokens, &self.tokens);
                 }
                 MacroDelimiter::Brace(brace) => {
-                    brace.surround(tokens, |tokens| self.tokens.to_tokens(tokens));
+                    brace.surround_tokens(tokens, &self.tokens);
                 }
                 MacroDelimiter::Bracket(bracket) => {
-                    bracket.surround(tokens, |tokens| self.tokens.to_tokens(tokens));
+                    bracket.surround_tokens(tokens, &self.tokens);
                 }
             }
         }

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -837,9 +837,7 @@ mod printing {
     impl ToTokens for PatTuple {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             tokens.append_all(self.attrs.outer());
-            self.paren_token.surround(tokens, |tokens| {
-                self.elems.to_tokens(tokens);
-            });
+            self.paren_token.surround_tokens(tokens, &self.elems);
         }
     }
 
@@ -895,9 +893,7 @@ mod printing {
     impl ToTokens for PatSlice {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             tokens.append_all(self.attrs.outer());
-            self.bracket_token.surround(tokens, |tokens| {
-                self.elems.to_tokens(tokens);
-            });
+            self.bracket_token.surround_tokens(tokens, &self.elems);
         }
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -653,9 +653,7 @@ mod printing {
 
                     // ERROR CORRECTION: Add braces to make sure that the
                     // generated code is valid.
-                    _ => token::Brace::default().surround(tokens, |tokens| {
-                        e.to_tokens(tokens);
-                    }),
+                    _ => token::Brace::default().surround_tokens(tokens, e),
                 },
             }
         }
@@ -739,9 +737,7 @@ mod printing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for ParenthesizedGenericArguments {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.paren_token.surround(tokens, |tokens| {
-                self.inputs.to_tokens(tokens);
-            });
+            self.paren_token.surround_tokens(tokens, &self.inputs);
             self.output.to_tokens(tokens);
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -549,8 +549,7 @@ macro_rules! define_delimiters {
                 }
 
                 #[cfg(feature = "printing")]
-                #[doc(hidden)]
-                pub fn surround_tokens<T>(&self, tokens: &mut TokenStream, to_tokens: &T)
+                pub(crate) fn surround_tokens<T>(&self, tokens: &mut TokenStream, to_tokens: &T)
                 where
                     T: ToTokens,
                 {

--- a/src/token.rs
+++ b/src/token.rs
@@ -545,6 +545,14 @@ macro_rules! define_delimiters {
                 {
                     printing::delim($token, self.span, tokens, f);
                 }
+
+                #[cfg(feature = "printing")]
+                pub fn surround_tokens<T>(&self, tokens: &mut TokenStream, to_tokens: &T)
+                where
+                    T: ToTokens,
+                {
+                    printing::delim($token, self.span, tokens, |tokens| to_tokens.to_tokens(tokens));
+                }
             }
 
             #[cfg(feature = "parsing")]

--- a/src/token.rs
+++ b/src/token.rs
@@ -1028,7 +1028,10 @@ pub mod printing {
 
     impl<'a> Drop for DelimGuard<'a> {
         fn drop(&mut self) {
-            let mut g = Group::new(self.delim, std::mem::take(&mut self.inner));
+            let mut g = Group::new(
+                self.delim,
+                std::mem::replace(&mut self.inner, Default::default()),
+            );
             g.set_span(self.span);
             self.tokens.append(g);
         }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -1068,9 +1068,7 @@ mod printing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for TypeSlice {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.bracket_token.surround(tokens, |tokens| {
-                self.elem.to_tokens(tokens);
-            });
+            self.bracket_token.surround_tokens(tokens, &self.elem);
         }
     }
 
@@ -1140,9 +1138,7 @@ mod printing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for TypeTuple {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.paren_token.surround(tokens, |tokens| {
-                self.elems.to_tokens(tokens);
-            });
+            self.paren_token.surround_tokens(tokens, &self.elems);
         }
     }
 
@@ -1172,18 +1168,14 @@ mod printing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for TypeGroup {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.group_token.surround(tokens, |tokens| {
-                self.elem.to_tokens(tokens);
-            });
+            self.group_token.surround_tokens(tokens, &self.elem);
         }
     }
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for TypeParen {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.paren_token.surround(tokens, |tokens| {
-                self.elem.to_tokens(tokens);
-            });
+            self.paren_token.surround_tokens(tokens, &self.elem);
         }
     }
 


### PR DESCRIPTION
Reduces the output of "llvm lines" by ~1%