### PR TITLE
Add Lifetime span getter and setter

### DIFF
--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -57,6 +57,17 @@ impl Lifetime {
             ident: Ident::new(&symbol[1..], span),
         }
     }
+
+    pub fn span(&self) -> Span {
+        self.apostrophe
+            .join(self.ident.span())
+            .unwrap_or(self.apostrophe)
+    }
+
+    pub fn set_span(&mut self, span: Span) {
+        self.apostrophe = span;
+        self.ident.set_span(span);
+    }
 }
 
 impl Display for Lifetime {


### PR DESCRIPTION
This matches the `span` and `set_span` accessors we provide on all the various `Lit` variant types.

Lifetimes are ordinarily treated as a single token. Only the proc macro API splits them into `'` punctuation and ident. Consequently the span of those two things is normally identical, except in pathological case when manually constructed from within a proc macro with differing spans. Thus, requiring macros to decide whether to write `lifetime.apostrophe.span` or `lifetime.ident.span()` for that span makes the code misleading. The new accessors reflect the fact that really there is only one span involved.

For example rustc parsers `'a` as the following TokenStream, in which byte range `95..97` covers both characters of the entire `'a` token.

```console
TokenStream [
    Punct {
        ch: '\'',
        spacing: Joint,
        span: #0 bytes(95..97),
    },
    Ident {
        ident: "asdf",
        span: #0 bytes(95..97),
    },
]
```