### PR TITLE
Permit empty trait bounds after colon on type item

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1179,14 +1179,14 @@ pub mod parsing {
             let mut bounds = Punctuated::new();
             if colon_token.is_some() {
                 loop {
+                    if input.peek(Token![where]) || input.peek(Token![=]) || input.peek(Token![;]) {
+                        break;
+                    }
                     bounds.push_value(input.parse::<TypeParamBound>()?);
                     if input.peek(Token![where]) || input.peek(Token![=]) || input.peek(Token![;]) {
                         break;
                     }
                     bounds.push_punct(input.parse::<Token![+]>()?);
-                    if input.peek(Token![where]) || input.peek(Token![=]) || input.peek(Token![;]) {
-                        break;
-                    }
                 }
             }
             generics.where_clause = input.parse()?;

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -241,3 +241,28 @@ fn test_supertraits() {
     }
     "###);
 }
+
+#[test]
+fn test_type_empty_bounds() {
+    #[rustfmt::skip]
+    let tokens = quote! {
+        trait Foo {
+            type Bar: ;
+        }
+    };
+
+    snapshot!(tokens as ItemTrait, @r###"
+    ItemTrait {
+        vis: Inherited,
+        ident: "Foo",
+        generics: Generics,
+        items: [
+            TraitItem::Type {
+                ident: "Bar",
+                generics: Generics,
+                colon_token: Some,
+            },
+        ],
+    }
+    "###);
+}


### PR DESCRIPTION
Fixes #974.