### PR TITLE
Parse leading vert in nested patterns

### DIFF
--- a/src/pat.rs
+++ b/src/pat.rs
@@ -523,7 +523,7 @@ pub mod parsing {
                 attrs,
                 member,
                 colon_token: input.parse()?,
-                pat: Box::new(multi_pat(input)?),
+                pat: Box::new(multi_pat_with_leading_vert(input)?),
             });
         }
 
@@ -602,7 +602,7 @@ pub mod parsing {
 
         let mut elems = Punctuated::new();
         while !content.is_empty() {
-            let value = multi_pat(&content)?;
+            let value = multi_pat_with_leading_vert(&content)?;
             elems.push_value(value);
             if content.is_empty() {
                 break;
@@ -701,7 +701,7 @@ pub mod parsing {
 
         let mut elems = Punctuated::new();
         while !content.is_empty() {
-            let value = multi_pat(&content)?;
+            let value = multi_pat_with_leading_vert(&content)?;
             elems.push_value(value);
             if content.is_empty() {
                 break;

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -27,10 +27,6 @@ static EXCLUDE: &[&str] = &[
     "src/test/ui/const-generics/defaults/pretty-printing-ast.rs",
     "src/test/ui/const-generics/min_const_generics/type_and_const_defaults.rs",
 
-    // TODO: leading vert in or-pattern
-    // https://github.com/dtolnay/syn/issues/982
-    "src/test/ui/or-patterns/or-patterns-syntactic-pass.rs",
-
     // TODO: static with omitted type
     // https://github.com/dtolnay/syn/issues/983
     // TODO: placeholder type in type parameter position

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -31,14 +31,14 @@ fn test_leading_vert() {
     syn::parse_str::<Item>("fn fun2(|| A: E) {}").unwrap_err();
 
     syn::parse_str::<Stmt>("let | () = ();").unwrap();
-    syn::parse_str::<Stmt>("let (| A): E;").unwrap_err();
+    syn::parse_str::<Stmt>("let (| A): E;").unwrap();
     syn::parse_str::<Stmt>("let (|| A): (E);").unwrap_err();
-    syn::parse_str::<Stmt>("let (| A,): (E,);").unwrap_err();
-    syn::parse_str::<Stmt>("let [| A]: [E; 1];").unwrap_err();
+    syn::parse_str::<Stmt>("let (| A,): (E,);").unwrap();
+    syn::parse_str::<Stmt>("let [| A]: [E; 1];").unwrap();
     syn::parse_str::<Stmt>("let [|| A]: [E; 1];").unwrap_err();
-    syn::parse_str::<Stmt>("let TS(| A): TS;").unwrap_err();
+    syn::parse_str::<Stmt>("let TS(| A): TS;").unwrap();
     syn::parse_str::<Stmt>("let TS(|| A): TS;").unwrap_err();
-    syn::parse_str::<Stmt>("let NS { f: | A }: NS;").unwrap_err();
+    syn::parse_str::<Stmt>("let NS { f: | A }: NS;").unwrap();
     syn::parse_str::<Stmt>("let NS { f: || A }: NS;").unwrap_err();
 }
 


### PR DESCRIPTION
Closes #982. This matches the upstream rustc parser change in https://github.com/rust-lang/rust/pull/81869.