### PR TITLE
Move documentation testing to doc CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustc-dev
-      - run: cargo test --all-features --release
+      - run: cargo test --all-features --release --tests
 
   build:
     name: ${{matrix.name || format('Rust {0}', matrix.rust)}}
@@ -82,6 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo test --all-features --doc
       - run: cargo doc --all-features
 
   codegen:


### PR DESCRIPTION
This cuts about 18 seconds from our longest running job, by not building doc tests in the same job as the main test suite.