### PR TITLE
Report no precedence for `:` binary operator in non-full mode

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1422,7 +1422,9 @@ pub(crate) mod parsing {
             Precedence::Assign
         } else if input.peek(Token![..]) {
             Precedence::Range
-        } else if input.peek(Token![as]) || input.peek(Token![:]) && !input.peek(Token![::]) {
+        } else if input.peek(Token![as])
+            || cfg!(feature = "full") && input.peek(Token![:]) && !input.peek(Token![::])
+        {
             Precedence::Cast
         } else {
             Precedence::Any


### PR DESCRIPTION
Fixes #978.