### PR TITLE
Preserve span of LexError on conversion to syn::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro"]
 test = ["syn-test-suite/all-features"]
 
 [dependencies]
-proc-macro2 = { version = "1.0.23", default-features = false }
+proc-macro2 = { version = "1.0.26", default-features = false }
 quote = { version = "1.0", optional = true, default-features = false }
 unicode-xid = "0.2"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -349,7 +349,7 @@ impl std::error::Error for Error {}
 
 impl From<LexError> for Error {
     fn from(err: LexError) -> Self {
-        Error::new(Span::call_site(), format!("{:?}", err))
+        Error::new(err.span(), "lex error")
     }
 }
 


### PR DESCRIPTION
Lex error spans were added to proc-macro2 in https://github.com/alexcrichton/proc-macro2/pull/283.