### PR TITLE
Refactor inner attribute parsing

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -501,8 +501,6 @@ pub mod parsing {
     use super::*;
     use crate::ext::IdentExt;
     use crate::parse::{Parse, ParseStream, Result};
-    #[cfg(feature = "full")]
-    use crate::private;
 
     pub fn parse_inner(input: ParseStream, attrs: &mut Vec<Attribute>) -> Result<()> {
         while input.peek(Token![#]) && input.peek2(Token![!]) {
@@ -531,15 +529,6 @@ pub mod parsing {
             path: content.call(Path::parse_mod_style)?,
             tokens: content.parse()?,
         })
-    }
-
-    #[cfg(feature = "full")]
-    impl private {
-        pub(crate) fn attrs(outer: Vec<Attribute>, inner: Vec<Attribute>) -> Vec<Attribute> {
-            let mut attrs = outer;
-            attrs.extend(inner);
-            attrs
-        }
     }
 
     // Like Path::parse_mod_style but accepts keywords in the path.

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -250,9 +250,7 @@ impl Attribute {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_inner(input: ParseStream) -> Result<Vec<Self>> {
         let mut attrs = Vec::new();
-        while input.peek(Token![#]) && input.peek2(Token![!]) {
-            attrs.push(input.call(parsing::single_parse_inner)?);
-        }
+        parsing::parse_inner(input, &mut attrs)?;
         Ok(attrs)
     }
 }
@@ -505,6 +503,13 @@ pub mod parsing {
     use crate::parse::{Parse, ParseStream, Result};
     #[cfg(feature = "full")]
     use crate::private;
+
+    pub fn parse_inner(input: ParseStream, attrs: &mut Vec<Attribute>) -> Result<()> {
+        while input.peek(Token![#]) && input.peek2(Token![!]) {
+            attrs.push(input.call(parsing::single_parse_inner)?);
+        }
+        Ok(())
+    }
 
     pub fn single_parse_inner(input: ParseStream) -> Result<Attribute> {
         let content;

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2141,7 +2141,7 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ExprForLoop {
         fn parse(input: ParseStream) -> Result<Self> {
-            let outer_attrs = input.call(Attribute::parse_outer)?;
+            let mut attrs = input.call(Attribute::parse_outer)?;
             let label: Option<Label> = input.parse()?;
             let for_token: Token![for] = input.parse()?;
 
@@ -2152,11 +2152,11 @@ pub(crate) mod parsing {
 
             let content;
             let brace_token = braced!(content in input);
-            let inner_attrs = content.call(Attribute::parse_inner)?;
+            attr::parsing::parse_inner(&content, &mut attrs)?;
             let stmts = content.call(Block::parse_within)?;
 
             Ok(ExprForLoop {
-                attrs: private::attrs(outer_attrs, inner_attrs),
+                attrs,
                 label,
                 for_token,
                 pat,
@@ -2171,17 +2171,17 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ExprLoop {
         fn parse(input: ParseStream) -> Result<Self> {
-            let outer_attrs = input.call(Attribute::parse_outer)?;
+            let mut attrs = input.call(Attribute::parse_outer)?;
             let label: Option<Label> = input.parse()?;
             let loop_token: Token![loop] = input.parse()?;
 
             let content;
             let brace_token = braced!(content in input);
-            let inner_attrs = content.call(Attribute::parse_inner)?;
+            attr::parsing::parse_inner(&content, &mut attrs)?;
             let stmts = content.call(Block::parse_within)?;
 
             Ok(ExprLoop {
-                attrs: private::attrs(outer_attrs, inner_attrs),
+                attrs,
                 label,
                 loop_token,
                 body: Block { brace_token, stmts },
@@ -2193,13 +2193,13 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ExprMatch {
         fn parse(input: ParseStream) -> Result<Self> {
-            let outer_attrs = input.call(Attribute::parse_outer)?;
+            let mut attrs = input.call(Attribute::parse_outer)?;
             let match_token: Token![match] = input.parse()?;
             let expr = Expr::parse_without_eager_brace(input)?;
 
             let content;
             let brace_token = braced!(content in input);
-            let inner_attrs = content.call(Attribute::parse_inner)?;
+            attr::parsing::parse_inner(&content, &mut attrs)?;
 
             let mut arms = Vec::new();
             while !content.is_empty() {
@@ -2207,7 +2207,7 @@ pub(crate) mod parsing {
             }
 
             Ok(ExprMatch {
-                attrs: private::attrs(outer_attrs, inner_attrs),
+                attrs,
                 match_token,
                 expr: Box::new(expr),
                 brace_token,
@@ -2487,18 +2487,18 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ExprWhile {
         fn parse(input: ParseStream) -> Result<Self> {
-            let outer_attrs = input.call(Attribute::parse_outer)?;
+            let mut attrs = input.call(Attribute::parse_outer)?;
             let label: Option<Label> = input.parse()?;
             let while_token: Token![while] = input.parse()?;
             let cond = Expr::parse_without_eager_brace(input)?;
 
             let content;
             let brace_token = braced!(content in input);
-            let inner_attrs = content.call(Attribute::parse_inner)?;
+            attr::parsing::parse_inner(&content, &mut attrs)?;
             let stmts = content.call(Block::parse_within)?;
 
             Ok(ExprWhile {
-                attrs: private::attrs(outer_attrs, inner_attrs),
+                attrs,
                 label,
                 while_token,
                 cond: Box::new(cond),
@@ -2627,13 +2627,12 @@ pub(crate) mod parsing {
     #[cfg(feature = "full")]
     fn expr_struct_helper(
         input: ParseStream,
-        outer_attrs: Vec<Attribute>,
+        mut attrs: Vec<Attribute>,
         path: Path,
     ) -> Result<ExprStruct> {
         let content;
         let brace_token = braced!(content in input);
-        let inner_attrs = content.call(Attribute::parse_inner)?;
-        let attrs = private::attrs(outer_attrs, inner_attrs);
+        attr::parsing::parse_inner(&content, &mut attrs)?;
 
         let mut fields = Punctuated::new();
         while !content.is_empty() {
@@ -2706,16 +2705,16 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ExprBlock {
         fn parse(input: ParseStream) -> Result<Self> {
-            let outer_attrs = input.call(Attribute::parse_outer)?;
+            let mut attrs = input.call(Attribute::parse_outer)?;
             let label: Option<Label> = input.parse()?;
 
             let content;
             let brace_token = braced!(content in input);
-            let inner_attrs = content.call(Attribute::parse_inner)?;
+            attr::parsing::parse_inner(&content, &mut attrs)?;
             let stmts = content.call(Block::parse_within)?;
 
             Ok(ExprBlock {
-                attrs: private::attrs(outer_attrs, inner_attrs),
+                attrs,
                 label,
                 block: Block { brace_token, stmts },
             })

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1524,7 +1524,7 @@ pub(crate) mod parsing {
     // <atom> ? ...
     #[cfg(feature = "full")]
     fn trailer_expr(
-        outer_attrs: Vec<Attribute>,
+        mut attrs: Vec<Attribute>,
         input: ParseStream,
         allow_struct: AllowStruct,
     ) -> Result<Expr> {
@@ -1532,7 +1532,7 @@ pub(crate) mod parsing {
         let mut e = trailer_helper(input, atom)?;
 
         let inner_attrs = e.replace_attrs(Vec::new());
-        let attrs = private::attrs(outer_attrs, inner_attrs);
+        attrs.extend(inner_attrs);
         e.replace_attrs(attrs);
         Ok(e)
     }


### PR DESCRIPTION
Appending inner attrs onto an existing attributes vector, instead of into a separate vector which the caller is responsible for combining together, is more amenable for an upcoming refactor -- it's more convenient to pass `&mut attrs` as an argument to various helpers, rather than trying to pass back inner attrs as a tuple element in return position, which is always clumsy.

```rust
// easy
let thing = parse_thing(input, x, y, attrs)?;

// clumsy
let (thing, inner_attrs) = parse_thing(input, x, y)?;
attrs.extend(inner_attrs);
```

The rustc parser follows the same strategy, such as in https://github.com/rust-lang/rust/blob/b849326744a8eec939e592f0ab13bff85cc865d3/compiler/rustc_parse/src/parser/item.rs#L33-L48.