### PR TITLE
Parse visibility on impl blocks

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -2458,6 +2458,7 @@ pub mod parsing {
 
     fn parse_impl(input: ParseStream, allow_verbatim_impl: bool) -> Result<Option<ItemImpl>> {
         let mut attrs = input.call(Attribute::parse_outer)?;
+        let has_visibility = allow_verbatim_impl && input.parse::<Visibility>()?.is_some();
         let defaultness: Option<Token![default]> = input.parse()?;
         let unsafety: Option<Token![unsafe]> = input.parse()?;
         let impl_token: Token![impl] = input.parse()?;
@@ -2541,7 +2542,7 @@ pub mod parsing {
             items.push(content.parse()?);
         }
 
-        if is_const_impl || is_impl_for && trait_.is_none() {
+        if has_visibility || is_const_impl || is_impl_for && trait_.is_none() {
             Ok(None)
         } else {
             Ok(Some(ItemImpl {

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -266,3 +266,12 @@ fn test_type_empty_bounds() {
     }
     "###);
 }
+
+#[test]
+fn test_impl_visibility() {
+    let tokens = quote! {
+        pub default unsafe impl union {}
+    };
+
+    snapshot!(tokens as Item, @"Verbatim(`pub default unsafe impl union { }`)");
+}


### PR DESCRIPTION
Rustc's parser allows them.

```rust
#[cfg(any())]
pub impl _ {}

#[cfg(any())]
crate impl crate for crate {}
```