### PR TITLE
Parse type parameter defaults on impl blocks

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -2469,7 +2469,8 @@ pub mod parsing {
                 || (input.peek2(Ident) || input.peek2(Lifetime))
                     && (input.peek3(Token![:])
                         || input.peek3(Token![,])
-                        || input.peek3(Token![>]))
+                        || input.peek3(Token![>])
+                        || input.peek3(Token![=]))
                 || input.peek2(Token![const]));
         let mut generics: Generics = if has_generics {
             input.parse()?

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -275,3 +275,27 @@ fn test_impl_visibility() {
 
     snapshot!(tokens as Item, @"Verbatim(`pub default unsafe impl union { }`)");
 }
+
+#[test]
+fn test_impl_type_parameter_defaults() {
+    #[cfg(any())]
+    impl<T = ()> () {}
+    let tokens = quote! {
+        impl<T = ()> () {}
+    };
+    snapshot!(tokens as Item, @r###"
+    Item::Impl {
+        generics: Generics {
+            lt_token: Some,
+            params: [
+                Type(TypeParam {
+                    ident: "T",
+                    eq_token: Some,
+                    default: Some(Type::Tuple),
+                }),
+            ],
+            gt_token: Some,
+        },
+        self_ty: Type::Tuple,
+    }"###);
+}


### PR DESCRIPTION
rustc syntactically accepts this.

```rust
#[cfg(any())]
impl<T = ()> () {}
```

[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=5f585898bde387b258cecc57558e9aa9)