### PR TITLE
Add `bail!` for easy erroring in parsers

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -15,6 +15,8 @@ pub use proc_macro2::{Span, TokenStream as TokenStream2};
 
 pub use crate::span::IntoSpans;
 
+pub use crate::error::{BailSpan, BailSpanFallback};
+
 #[cfg(all(
     not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "wasi"))),
     feature = "proc-macro"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2232,7 +2232,7 @@ pub(crate) mod parsing {
                             match expr {
                                 Expr::$variant(inner) => return Ok(inner),
                                 Expr::Group(next) => expr = *next.expr,
-                                _ => return Err(Error::new_spanned(expr, $msg)),
+                                _ => bail!(expr, $msg),
                             }
                         }
                     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -1606,16 +1606,13 @@ pub mod parsing {
                 let mut arg: FnArg = input.parse()?;
                 match &mut arg {
                     FnArg::Receiver(receiver) if has_receiver => {
-                        return Err(Error::new(
+                        bail!(
                             receiver.self_token.span,
-                            "unexpected second method receiver",
-                        ));
+                            "unexpected second method receiver"
+                        );
                     }
                     FnArg::Receiver(receiver) if !args.is_empty() => {
-                        return Err(Error::new(
-                            receiver.self_token.span,
-                            "unexpected method receiver",
-                        ));
+                        bail!(receiver.self_token.span, "unexpected method receiver");
                     }
                     FnArg::Receiver(receiver) => {
                         has_receiver = true;
@@ -2516,9 +2513,9 @@ pub mod parsing {
                 }
             } else if !allow_verbatim_impl {
                 #[cfg(feature = "printing")]
-                return Err(Error::new_spanned(first_ty_ref, "expected trait path"));
+                bail!(first_ty_ref, "expected trait path");
                 #[cfg(not(feature = "printing"))]
-                return Err(Error::new(first_ty_span, "expected trait path"));
+                bail!(first_ty_span, "expected trait path");
             } else {
                 trait_ = None;
             }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -205,6 +205,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
 
+pub use crate::bail;
 pub use crate::error::{Error, Result};
 pub use crate::lookahead::{Lookahead1, Peek};
 


### PR DESCRIPTION
I find myself very frequently writing code of the form:

```rust
return Err(parse::Error::new_spanned(
    item,
    format_args!("An error message: {}", s),
));
```

I think it would be very nice to have a macro to write this shorter:

```rust
bail!(item, "An error message: {}", s);
```