### PR TITLE
Reject for<'a> dyn Trait

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -412,6 +412,7 @@ pub mod parsing {
                 && !lookahead.peek(Token![self])
                 && !lookahead.peek(Token![Self])
                 && !lookahead.peek(Token![crate])
+                || input.peek(Token![dyn])
             {
                 return Err(lookahead.error());
             }
@@ -540,15 +541,7 @@ pub mod parsing {
             || lookahead.peek(Token![<])
         {
             if input.peek(Token![dyn]) {
-                let mut trait_object: TypeTraitObject = input.parse()?;
-                if lifetimes.is_some() {
-                    match trait_object.bounds.iter_mut().next().unwrap() {
-                        TypeParamBound::Trait(trait_bound) => {
-                            trait_bound.lifetimes = lifetimes;
-                        }
-                        TypeParamBound::Lifetime(_) => unreachable!(),
-                    }
-                }
+                let trait_object: TypeTraitObject = input.parse()?;
                 return Ok(Type::TraitObject(trait_object));
             }
 


### PR DESCRIPTION
This is not valid syntax in Rust.

```console
error: expected identifier, found keyword `dyn`
 --> src/main.rs:1:18
  |
1 | type T = for<'a> dyn Trait;
  |                  ^^^ expected identifier, found keyword

error: expected one of `(`, `+`, `::`, `;`, or `<`, found `Trait`
 --> src/main.rs:1:22
  |
1 | type T = for<'a> dyn Trait;
  |                      ^^^^^ expected one of `(`, `+`, `::`, `;`, or `<`
```

Fixes #1041.