### PR TITLE
Don't break negative literal const generic args with parenthesization

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -12,10 +12,6 @@ const REVISION: &str = "50171c310cd15e1b2d3723766ce64e2e4d6696fc";
 
 #[rustfmt::skip]
 static EXCLUDE: &[&str] = &[
-    // TODO: negative literal in const generic arg
-    // f::<-1>()
-    "src/test/debuginfo/function-names.rs",
-
     // TODO: unnamed fields, anonymous structs/unions
     // struct S { _: union { i: i32 } }
     // https://github.com/dtolnay/syn/issues/1048


### PR DESCRIPTION
Previously this would break test_precedence on something like `f::<-1>()` by parenthesizing to `f::<-(1)>()`, which is invalid syntax.