### PR TITLE
Set src/gen to be considered generated by linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/gen/** linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src/gen/** linguist-generated
+tests/debug/gen.rs linguist-generated


### PR DESCRIPTION
This will render the files collapsed by default in diffs.

<br>

![Screenshot from 2021-09-21 20-33-09](https://user-images.githubusercontent.com/1940490/134279346-e5ee5915-975d-4940-98e9-0ed92a340ce3.png)
