### PR TITLE
Delete unneeded From conversion from parse_quote

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -1,6 +1,5 @@
 pub use std::clone::Clone;
 pub use std::cmp::{Eq, PartialEq};
-pub use std::convert::From;
 pub use std::default::Default;
 pub use std::fmt::{self, Debug, Formatter};
 pub use std::hash::{Hash, Hasher};

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -73,11 +73,7 @@
 #[macro_export]
 macro_rules! parse_quote {
     ($($tt:tt)*) => {
-        $crate::parse_quote::parse(
-            $crate::__private::From::from(
-                $crate::__private::quote::quote!($($tt)*)
-            )
-        )
+        $crate::parse_quote::parse($crate::__private::quote::quote!($($tt)*))
     };
 }
 


### PR DESCRIPTION
The origin of this was 7d6a7b8979ae517ab4ec0dca3173c21c9f456ca8 which was written against quote 0.4, in which the return type of `quote!` was different from `TokenStream`. Now that `quote!` simply produces `TokenStream` there is no longer a need for a conversion there.