### PR TITLE
Invert TypeTraitObject exit condition to match TypeImplTrait

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -885,7 +885,12 @@ pub mod parsing {
                                 break;
                             }
                             bounds.push_punct(input.parse()?);
-                            if input.peek(Token![>]) || input.is_empty() {
+                            if !(input.peek(Ident::peek_any)
+                                || input.peek(Token![::])
+                                || input.peek(Token![?])
+                                || input.peek(Lifetime)
+                                || input.peek(token::Paren))
+                            {
                                 break;
                             }
                         }


### PR DESCRIPTION
This closes an inconsistency between #1077 and #1074. The implementation from #1074 (`TypeImplTrait`) is the correct termination condition. For example the following would fail to parse prior to this PR:

```rust
fn main() {
    let _: (dyn ToString + ,);
}
```

After this PR it parses successfully, matching `rustc` which accepts this program since 1.18.0.