### PR TITLE
Use 'FromStr for Literal' instead of TokenStream workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro"]
 test = ["syn-test-suite/all-features"]
 
 [dependencies]
-proc-macro2 = { version = "1.0.26", default-features = false }
+proc-macro2 = { version = "1.0.27", default-features = false }
 quote = { version = "1.0", optional = true, default-features = false }
 unicode-xid = "0.2"
 

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -925,7 +925,6 @@ mod printing {
 mod value {
     use super::*;
     use crate::bigint::BigInt;
-    use proc_macro2::TokenStream;
     use std::char;
     use std::ops::{Index, RangeFrom};
 
@@ -1564,11 +1563,7 @@ mod value {
                 digits.parse().ok().map(Literal::i64_unsuffixed)
             }
         } else {
-            let stream = repr.parse::<TokenStream>().unwrap();
-            match stream.into_iter().next().unwrap() {
-                TokenTree::Literal(l) => Some(l),
-                _ => unreachable!(),
-            }
+            Some(repr.parse::<Literal>().unwrap())
         }
     }
 }


### PR DESCRIPTION
This picks up https://github.com/dtolnay/proc-macro2/pull/286 from proc-macro2 1.0.27. Proc-macro2 takes care of the necessary workaround on old compilers, or forwards to `FromStr for proc_macro::Literal` where available.