### PR TITLE
Extend<Pair<&..>> and Pairs::cloned supports for Punctuated

### DIFF
--- a/src/gen_helper.rs
+++ b/src/gen_helper.rs
@@ -21,7 +21,7 @@ pub mod fold {
         }
     }
 
-    impl<T, U> FoldHelper for Punctuated<T, U> {
+    impl<T, U: Default> FoldHelper for Punctuated<T, U> {
         type Item = T;
         fn lift<F>(self, mut f: F) -> Self
         where

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -455,7 +455,7 @@ where
     }
 }
 
-impl<T, P> FromIterator<Pair<T, P>> for Punctuated<T, P> {
+impl<T, P: Default> FromIterator<Pair<T, P>> for Punctuated<T, P> {
     fn from_iter<I: IntoIterator<Item = Pair<T, P>>>(i: I) -> Self {
         let mut ret = Punctuated::new();
         ret.extend(i);
@@ -463,12 +463,14 @@ impl<T, P> FromIterator<Pair<T, P>> for Punctuated<T, P> {
     }
 }
 
-impl<T, P> Extend<Pair<T, P>> for Punctuated<T, P> {
+impl<T, P> Extend<Pair<T, P>> for Punctuated<T, P>
+where
+    P: Default,
+{
     fn extend<I: IntoIterator<Item = Pair<T, P>>>(&mut self, i: I) {
-        assert!(
-            self.empty_or_trailing(),
-            "Punctuated::extend: Punctuated is not empty or does not have a trailing punctuation",
-        );
+        if !self.empty_or_trailing() {
+            self.push_punct(Default::default());
+        }
 
         let mut nomore = false;
         for pair in i {


### PR DESCRIPTION
This is designed to make it easy to extend a `Punctuated` from an iterator over another `Punctuated`:

1. Auto-insert extra punctuation if extend-target does not have trailing comma. This is a breaking change due to the extra `Default` bound, so I may need to remove it.
2. Support extension from reference types.
3. Support `cloned` over a `Pairs` iterator.

The last two are redundant with each other, from the POV of the motivation.