### PR TITLE
Parse parenthesized path arguments with disambiguator

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -844,8 +844,12 @@ pub mod parsing {
             let lifetimes: Option<BoundLifetimes> = input.parse()?;
 
             let mut path: Path = input.parse()?;
-            if path.segments.last().unwrap().arguments.is_empty() && input.peek(token::Paren) {
-                let parenthesized = PathArguments::Parenthesized(input.parse()?);
+            if path.segments.last().unwrap().arguments.is_empty()
+                && (input.peek(token::Paren) || input.peek(Token![::]) && input.peek3(token::Paren))
+            {
+                input.parse::<Option<Token![::]>>()?;
+                let args: ParenthesizedGenericArguments = input.parse()?;
+                let parenthesized = PathArguments::Parenthesized(args);
                 path.segments.last_mut().unwrap().arguments = parenthesized;
             }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -589,7 +589,7 @@ pub mod parsing {
             path: &mut Self,
             expr_style: bool,
         ) -> Result<()> {
-            while input.peek(Token![::]) {
+            while input.peek(Token![::]) && !input.peek3(token::Paren) {
                 let punct: Token![::] = input.parse()?;
                 path.segments.push_punct(punct);
                 let value = PathSegment::parse_helper(input, expr_style)?;

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -821,7 +821,10 @@ pub mod parsing {
         fn parse(input: ParseStream) -> Result<Self> {
             let (qself, mut path) = path::parsing::qpath(input, false)?;
 
-            if path.segments.last().unwrap().arguments.is_empty() && input.peek(token::Paren) {
+            if path.segments.last().unwrap().arguments.is_empty()
+                && (input.peek(token::Paren) || input.peek(Token![::]) && input.peek3(token::Paren))
+            {
+                input.parse::<Option<Token![::]>>()?;
                 let args: ParenthesizedGenericArguments = input.parse()?;
                 let parenthesized = PathArguments::Parenthesized(args);
                 path.segments.last_mut().unwrap().arguments = parenthesized;

--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -102,3 +102,25 @@ fn print_incomplete_qpath() {
     "###);
     assert!(ty.path.segments.pop().is_none());
 }
+
+#[test]
+fn parse_parenthesized_path_arguments_with_disambiguator() {
+    #[rustfmt::skip]
+    let tokens = quote!(FnOnce::() -> !);
+    snapshot!(tokens as Type, @r###"
+    Type::Path {
+        path: Path {
+            segments: [
+                PathSegment {
+                    ident: "FnOnce",
+                    arguments: PathArguments::Parenthesized {
+                        output: Type(
+                            Type::Never,
+                        ),
+                    },
+                },
+            ],
+        },
+    }
+    "###);
+}


### PR DESCRIPTION
Closes #1096.