### PR TITLE
Tolerate the standard library reusing ThreadIds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,10 @@ fn main() {
         None => return,
     };
 
+    if compiler.minor < 34 {
+        println!("cargo:rustc-cfg=syn_no_atomic_u64");
+    }
+
     if compiler.minor < 36 {
         println!("cargo:rustc-cfg=syn_omit_await_from_token_macro");
     }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,6 +1,11 @@
 use std::fmt::{self, Debug};
-use std::num::NonZeroU64;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
+
+#[cfg(not(syn_no_atomic_u64))]
+use std::{num::NonZeroU64 as NonZeroThreadId, sync::atomic::AtomicU64 as AtomicThreadId};
+
+#[cfg(syn_no_atomic_u64)]
+use std::{num::NonZeroUsize as NonZeroThreadId, sync::atomic::AtomicUsize as AtomicThreadId};
 
 /// ThreadBound is a Sync-maker and Send-maker that allows accessing a value
 /// of type T only from the original thread on which the ThreadBound was
@@ -42,16 +47,30 @@ impl<T: Debug> Debug for ThreadBound<T> {
 }
 
 #[derive(Copy, Clone, PartialEq)]
-struct ThreadId(NonZeroU64);
+struct ThreadId(NonZeroThreadId);
 
 impl ThreadId {
     fn current() -> Self {
-        static NEXT_THREAD_ID: AtomicU64 = AtomicU64::new(1);
+        static NEXT_THREAD_ID: AtomicThreadId = AtomicThreadId::new(1);
 
         thread_local! {
             static THIS_THREAD_ID: ThreadId = {
-                let current = NEXT_THREAD_ID.fetch_add(1, Ordering::Relaxed);
-                ThreadId(unsafe { NonZeroU64::new_unchecked(current) })
+                #[cfg(not(syn_no_atomic_u64))]
+                {
+                    let current = NEXT_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+                    ThreadId(unsafe { NonZeroThreadId::new_unchecked(current) })
+                }
+                #[cfg(syn_no_atomic_u64)]
+                {
+                    let mut current = NEXT_THREAD_ID.load(Ordering::Relaxed);
+                    loop {
+                        let next = current.checked_add(1).expect("ThreadId overflow");
+                        match NEXT_THREAD_ID.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
+                            Ok(current) => break ThreadId(unsafe { NonZeroThreadId::new_unchecked(current) }),
+                            Err(update) => current = update,
+                        }
+                    }
+                }
             };
         }
 


### PR DESCRIPTION
Allegedly, under some team members' interpretation of https://doc.rust-lang.org/1.57.0/std/thread/struct.ThreadId.html, the wording *"A ThreadId has a unique value for each thread that creates one"* is ambiguous as to whether two different threads in the same process might have the same "unique value" for their `ThreadId`, as long as the two threads do not exist at the same time.

Failure mode:

- Create a syn::Error with Span on thread 1
- Pass the error over to thread 2
- Thread 1 ends
- Create thread 3, which gets assigned the same `ThreadId` as thread 1
- Pass the error over to thread 3
- Read its Span, which accesses thread_local span table from dead thread 1

https://github.com/rust-lang/rust/pull/84083