### PR TITLE
Preserve attributes on let-else stmt

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -50,7 +50,7 @@ ast_struct! {
 pub mod parsing {
     use super::*;
     use crate::parse::discouraged::Speculative;
-    use crate::parse::{Parse, ParseStream, Result};
+    use crate::parse::{Parse, ParseBuffer, ParseStream, Result};
     use proc_macro2::TokenStream;
 
     impl Block {
@@ -152,6 +152,7 @@ pub mod parsing {
     }
 
     fn parse_stmt(input: ParseStream, allow_nosemi: bool) -> Result<Stmt> {
+        let begin = input.fork();
         let mut attrs = input.call(Attribute::parse_outer)?;
 
         // brace-style macros; paren and bracket macros get parsed as
@@ -169,7 +170,7 @@ pub mod parsing {
         }
 
         if input.peek(Token![let]) {
-            stmt_local(input, attrs)
+            stmt_local(input, attrs, begin)
         } else if input.peek(Token![pub])
             || input.peek(Token![crate]) && !input.peek2(Token![::])
             || input.peek(Token![extern])
@@ -222,9 +223,7 @@ pub mod parsing {
         })))
     }
 
-    fn stmt_local(input: ParseStream, attrs: Vec<Attribute>) -> Result<Stmt> {
-        let begin = input.fork();
-
+    fn stmt_local(input: ParseStream, attrs: Vec<Attribute>, begin: ParseBuffer) -> Result<Stmt> {
         let let_token: Token![let] = input.parse()?;
 
         let mut pat: Pat = pat::parsing::multi_pat_with_leading_vert(input)?;

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -14,9 +14,6 @@ const REVISION: &str = "e100ec5bc7cd768ec17d75448b29c9ab4a39272b";
 
 #[rustfmt::skip]
 static EXCLUDE: &[&str] = &[
-    // TODO: attributes on let-else stmt
-    "src/test/ui/let-else/let-else-allow-unused.rs",
-
     // TODO: impl ~const T {}
     // https://github.com/dtolnay/syn/issues/1051
     "src/test/ui/rfc-2632-const-trait-impl/syntax.rs",


### PR DESCRIPTION
Previously the stmt attributes on something like:

```rust
#[allow(unused)]
let Some(chaenomeles) = value else { return };
```

would just be lost during parsing.