### PR TITLE
Rely on rustdoc to resolve Punctuated<T, P> to an intra doc link

### DIFF
--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -58,7 +58,6 @@
 ///   `P` with optional trailing punctuation
 /// - [`Vec<Stmt>`] — parses the same as `Block::parse_within`
 ///
-/// [`Punctuated<T, P>`]: crate::punctuated::Punctuated
 /// [`Vec<Stmt>`]: Block::parse_within
 ///
 /// # Panics
@@ -66,9 +65,6 @@
 /// Panics if the tokens fail to parse as the expected syntax tree type. The
 /// caller is responsible for ensuring that the input tokens are syntactically
 /// valid.
-//
-// TODO: allow Punctuated to be inferred as intra doc link, currently blocked on
-// https://github.com/rust-lang/rust/issues/62834
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "parsing", feature = "printing"))))]
 #[macro_export]
 macro_rules! parse_quote {


### PR DESCRIPTION
The rustdoc bug was fixed by https://github.com/rust-lang/rust/pull/76934.

## Before:

![Screenshot from 2021-12-25 19-05-09](https://user-images.githubusercontent.com/1940490/147397932-ed8e5a8b-c7cb-406c-ac33-71ad175b530c.png)

## After:

![Screenshot from 2021-12-25 19-05-32](https://user-images.githubusercontent.com/1940490/147397934-544b9880-3985-4217-bf95-1fac55f268f5.png)