### PR TITLE
Advance test suite past the let-chains PR

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -10,10 +10,20 @@ use std::path::Path;
 use tar::Archive;
 use walkdir::DirEntry;
 
-const REVISION: &str = "e100ec5bc7cd768ec17d75448b29c9ab4a39272b";
+const REVISION: &str = "5e57faa78aa7661c6000204591558f6665f11abc";
 
 #[rustfmt::skip]
 static EXCLUDE: &[&str] = &[
+    // TODO
+    "src/test/ui/expr/if/attrs/let-chains-attr.rs",
+    "src/test/ui/mir/mir_let_chains_drop_order.rs",
+    "src/test/ui/rfc-2497-if-let-chains/ast-lowering-does-not-wrap-let-chains.rs",
+    "src/test/ui/rfc-2497-if-let-chains/irrefutable-lets.rs",
+    "src/test/ui/rfc-2497-if-let-chains/issue-90722.rs",
+    "src/test/ui/rfc-2497-if-let-chains/then-else-blocks.rs",
+    "src/tools/rustfmt/tests/source/async_block.rs",
+    "src/tools/rustfmt/tests/target/async_block.rs",
+
     // TODO: impl ~const T {}
     // https://github.com/dtolnay/syn/issues/1051
     "src/test/ui/rfc-2632-const-trait-impl/syntax.rs",

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -14,13 +14,15 @@ const REVISION: &str = "5e57faa78aa7661c6000204591558f6665f11abc";
 
 #[rustfmt::skip]
 static EXCLUDE: &[&str] = &[
-    // TODO
+    // TODO: let chains
     "src/test/ui/expr/if/attrs/let-chains-attr.rs",
     "src/test/ui/mir/mir_let_chains_drop_order.rs",
     "src/test/ui/rfc-2497-if-let-chains/ast-lowering-does-not-wrap-let-chains.rs",
     "src/test/ui/rfc-2497-if-let-chains/irrefutable-lets.rs",
     "src/test/ui/rfc-2497-if-let-chains/issue-90722.rs",
     "src/test/ui/rfc-2497-if-let-chains/then-else-blocks.rs",
+
+    // TODO: static async closure keyword order
     "src/tools/rustfmt/tests/source/async_block.rs",
     "src/tools/rustfmt/tests/target/async_block.rs",
 


### PR DESCRIPTION
#1125. This picks up the new tests from https://github.com/rust-lang/rust/pull/88642.