### PR TITLE
Fix static async closure keyword order

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -403,8 +403,8 @@ ast_struct! {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprClosure #full {
         pub attrs: Vec<Attribute>,
-        pub asyncness: Option<Token![async]>,
         pub movability: Option<Token![static]>,
+        pub asyncness: Option<Token![async]>,
         pub capture: Option<Token![move]>,
         pub or1_token: Token![|],
         pub inputs: Punctuated<Pat, Token![,]>,
@@ -2397,12 +2397,8 @@ pub(crate) mod parsing {
 
     #[cfg(feature = "full")]
     fn expr_closure(input: ParseStream, allow_struct: AllowStruct) -> Result<ExprClosure> {
+        let movability: Option<Token![static]> = input.parse()?;
         let asyncness: Option<Token![async]> = input.parse()?;
-        let movability: Option<Token![static]> = if asyncness.is_none() {
-            input.parse()?
-        } else {
-            None
-        };
         let capture: Option<Token![move]> = input.parse()?;
         let or1_token: Token![|] = input.parse()?;
 
@@ -2440,8 +2436,8 @@ pub(crate) mod parsing {
 
         Ok(ExprClosure {
             attrs: Vec::new(),
-            asyncness,
             movability,
+            asyncness,
             capture,
             or1_token,
             inputs,
@@ -3223,8 +3219,8 @@ pub(crate) mod printing {
     impl ToTokens for ExprClosure {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             outer_attrs_to_tokens(&self.attrs, tokens);
-            self.asyncness.to_tokens(tokens);
             self.movability.to_tokens(tokens);
+            self.asyncness.to_tokens(tokens);
             self.capture.to_tokens(tokens);
             self.or1_token.to_tokens(tokens);
             self.inputs.to_tokens(tokens);

--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -412,8 +412,8 @@ impl Clone for ExprClosure {
     fn clone(&self) -> Self {
         ExprClosure {
             attrs: self.attrs.clone(),
-            asyncness: self.asyncness.clone(),
             movability: self.movability.clone(),
+            asyncness: self.asyncness.clone(),
             capture: self.capture.clone(),
             or1_token: self.or1_token.clone(),
             inputs: self.inputs.clone(),

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -726,8 +726,8 @@ impl Debug for ExprClosure {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("ExprClosure");
         formatter.field("attrs", &self.attrs);
-        formatter.field("asyncness", &self.asyncness);
         formatter.field("movability", &self.movability);
+        formatter.field("asyncness", &self.asyncness);
         formatter.field("capture", &self.capture);
         formatter.field("or1_token", &self.or1_token);
         formatter.field("inputs", &self.inputs);

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -422,8 +422,8 @@ impl Eq for ExprClosure {}
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for ExprClosure {
     fn eq(&self, other: &Self) -> bool {
-        self.attrs == other.attrs && self.asyncness == other.asyncness
-            && self.movability == other.movability && self.capture == other.capture
+        self.attrs == other.attrs && self.movability == other.movability
+            && self.asyncness == other.asyncness && self.capture == other.capture
             && self.inputs == other.inputs && self.output == other.output
             && self.body == other.body
     }

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -1269,9 +1269,9 @@ where
 {
     ExprClosure {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        asyncness: (node.asyncness).map(|it| Token![async](tokens_helper(f, &it.span))),
         movability: (node.movability)
             .map(|it| Token![static](tokens_helper(f, &it.span))),
+        asyncness: (node.asyncness).map(|it| Token![async](tokens_helper(f, &it.span))),
         capture: (node.capture).map(|it| Token![move](tokens_helper(f, &it.span))),
         or1_token: Token![|](tokens_helper(f, &node.or1_token.spans)),
         inputs: FoldHelper::lift(node.inputs, |it| f.fold_pat(it)),

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -641,8 +641,8 @@ impl Hash for ExprClosure {
         H: Hasher,
     {
         self.attrs.hash(state);
-        self.asyncness.hash(state);
         self.movability.hash(state);
+        self.asyncness.hash(state);
         self.capture.hash(state);
         self.inputs.hash(state);
         self.output.hash(state);

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -1373,10 +1373,10 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    if let Some(it) = &node.asyncness {
+    if let Some(it) = &node.movability {
         tokens_helper(v, &it.span);
     }
-    if let Some(it) = &node.movability {
+    if let Some(it) = &node.asyncness {
         tokens_helper(v, &it.span);
     }
     if let Some(it) = &node.capture {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -1374,10 +1374,10 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    if let Some(it) = &mut node.asyncness {
+    if let Some(it) = &mut node.movability {
         tokens_helper(v, &mut it.span);
     }
-    if let Some(it) = &mut node.movability {
+    if let Some(it) = &mut node.asyncness {
         tokens_helper(v, &mut it.span);
     }
     if let Some(it) = &mut node.capture {

--- a/syn.json
+++ b/syn.json
@@ -1087,14 +1087,14 @@
             "syn": "Attribute"
           }
         },
-        "asyncness": {
-          "option": {
-            "token": "Async"
-          }
-        },
         "movability": {
           "option": {
             "token": "Static"
+          }
+        },
+        "asyncness": {
+          "option": {
+            "token": "Async"
           }
         },
         "capture": {

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -591,18 +591,6 @@ impl Debug for Lite<syn::Expr> {
                 if !_val.attrs.is_empty() {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
-                if let Some(val) = &_val.asyncness {
-                    #[derive(RefCast)]
-                    #[repr(transparent)]
-                    struct Print(syn::token::Async);
-                    impl Debug for Print {
-                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                            formatter.write_str("Some")?;
-                            Ok(())
-                        }
-                    }
-                    formatter.field("asyncness", Print::ref_cast(val));
-                }
                 if let Some(val) = &_val.movability {
                     #[derive(RefCast)]
                     #[repr(transparent)]
@@ -614,6 +602,18 @@ impl Debug for Lite<syn::Expr> {
                         }
                     }
                     formatter.field("movability", Print::ref_cast(val));
+                }
+                if let Some(val) = &_val.asyncness {
+                    #[derive(RefCast)]
+                    #[repr(transparent)]
+                    struct Print(syn::token::Async);
+                    impl Debug for Print {
+                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str("Some")?;
+                            Ok(())
+                        }
+                    }
+                    formatter.field("asyncness", Print::ref_cast(val));
                 }
                 if let Some(val) = &_val.capture {
                     #[derive(RefCast)]
@@ -1294,18 +1294,6 @@ impl Debug for Lite<syn::ExprClosure> {
         if !_val.attrs.is_empty() {
             formatter.field("attrs", Lite(&_val.attrs));
         }
-        if let Some(val) = &_val.asyncness {
-            #[derive(RefCast)]
-            #[repr(transparent)]
-            struct Print(syn::token::Async);
-            impl Debug for Print {
-                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("Some")?;
-                    Ok(())
-                }
-            }
-            formatter.field("asyncness", Print::ref_cast(val));
-        }
         if let Some(val) = &_val.movability {
             #[derive(RefCast)]
             #[repr(transparent)]
@@ -1317,6 +1305,18 @@ impl Debug for Lite<syn::ExprClosure> {
                 }
             }
             formatter.field("movability", Print::ref_cast(val));
+        }
+        if let Some(val) = &_val.asyncness {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::token::Async);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    Ok(())
+                }
+            }
+            formatter.field("asyncness", Print::ref_cast(val));
         }
         if let Some(val) = &_val.capture {
             #[derive(RefCast)]

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -22,10 +22,6 @@ static EXCLUDE: &[&str] = &[
     "src/test/ui/rfc-2497-if-let-chains/issue-90722.rs",
     "src/test/ui/rfc-2497-if-let-chains/then-else-blocks.rs",
 
-    // TODO: static async closure keyword order
-    "src/tools/rustfmt/tests/source/async_block.rs",
-    "src/tools/rustfmt/tests/target/async_block.rs",
-
     // TODO: impl ~const T {}
     // https://github.com/dtolnay/syn/issues/1051
     "src/test/ui/rfc-2632-const-trait-impl/syntax.rs",


### PR DESCRIPTION
Uncovered by the new tests from https://github.com/rust-lang/rustfmt/pull/5150.