### PR TITLE
Collect an Iterator<Item = syn::Result<T>> into syn::Result<FromIterator<T>> whilst combining collected syn::Errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -843,7 +843,7 @@ mod rustdoc_workaround {
 ////////////////////////////////////////////////////////////////////////////////
 
 mod error;
-pub use crate::error::{Error, Result};
+pub use crate::error::{Error, Result, ResultIterCombineSynErrors};
 
 /// Parse tokens of source code into the chosen syntax tree node.
 ///


### PR DESCRIPTION
Been using this trait a lot recently, would be great if it were part of syn itself :)