### PR TITLE
Tolerate leading colons in paths inside a braced use item

### DIFF
--- a/tests/regression/issue1143.rs
+++ b/tests/regression/issue1143.rs
@@ -1,0 +1,35 @@
+#[test]
+fn issue1143() {
+    // Can *tolerate* a braced `use` item which has `::`-lead paths inside it
+    let _: syn::File = syn::parse_quote! {
+        #[cfg(foo)]
+        pub(crate) use {
+            ::fs::FsPool,
+            ::std::fs,
+        };
+
+        #[cfg(foo)]
+        fn bar() -> Result<()> {
+            let pool = FsPool::default();
+            let file =
+                fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)?
+            ;
+            let pooled_file = pool.write(file);
+            // …
+        }
+    };
+    // without affecting the classic parsing logic.
+    let _: syn::ItemUse = syn::parse_quote! {
+        #[cfg(codegen)]
+        use {
+            proc_macro2::{TokenStream as TokenStream2},
+            quote::quote,
+            syn::*,
+        };
+    };
+    let _: syn::ItemUse = syn::parse_quote! {
+        use ::fs::FsPool;
+    };
+}


### PR DESCRIPTION
but this does not really *parse* them in the AST, since it would be a subtle
and complex thing to do without breaking the 1.0 semver, thus not worth the trouble.

Tackles https://github.com/dtolnay/syn/issues/1143 (see that issue for more info/context about this PR).