### PR TITLE
Remove support for inner attributes on non-block expressions

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -246,12 +246,11 @@ pub mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for Variant {
         fn parse(input: ParseStream) -> Result<Self> {
-            let mut attrs = input.call(Attribute::parse_outer)?;
+            let attrs = input.call(Attribute::parse_outer)?;
             let _visibility: Visibility = input.parse()?;
             let ident: Ident = input.parse()?;
             let fields = if input.peek(token::Brace) {
-                let fields = parse_braced(input, &mut attrs)?;
-                Fields::Named(fields)
+                Fields::Named(input.parse()?)
             } else if input.peek(token::Paren) {
                 Fields::Unnamed(input.parse()?)
             } else {
@@ -293,17 +292,6 @@ pub mod parsing {
                 unnamed: content.parse_terminated(Field::parse_unnamed)?,
             })
         }
-    }
-
-    pub(crate) fn parse_braced(
-        input: ParseStream,
-        attrs: &mut Vec<Attribute>,
-    ) -> Result<FieldsNamed> {
-        let content;
-        let brace_token = braced!(content in input);
-        attr::parsing::parse_inner(&content, attrs)?;
-        let named = content.parse_terminated(Field::parse_named)?;
-        Ok(FieldsNamed { brace_token, named })
     }
 
     impl Field {

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -95,7 +95,7 @@ pub mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for DeriveInput {
         fn parse(input: ParseStream) -> Result<Self> {
-            let mut attrs = input.call(Attribute::parse_outer)?;
+            let attrs = input.call(Attribute::parse_outer)?;
             let vis = input.parse::<Visibility>()?;
 
             let lookahead = input.lookahead1();
@@ -103,7 +103,7 @@ pub mod parsing {
                 let struct_token = input.parse::<Token![struct]>()?;
                 let ident = input.parse::<Ident>()?;
                 let generics = input.parse::<Generics>()?;
-                let (where_clause, fields, semi) = data_struct(input, &mut attrs)?;
+                let (where_clause, fields, semi) = data_struct(input)?;
                 Ok(DeriveInput {
                     attrs,
                     vis,
@@ -122,7 +122,7 @@ pub mod parsing {
                 let enum_token = input.parse::<Token![enum]>()?;
                 let ident = input.parse::<Ident>()?;
                 let generics = input.parse::<Generics>()?;
-                let (where_clause, brace, variants) = data_enum(input, &mut attrs)?;
+                let (where_clause, brace, variants) = data_enum(input)?;
                 Ok(DeriveInput {
                     attrs,
                     vis,
@@ -141,7 +141,7 @@ pub mod parsing {
                 let union_token = input.parse::<Token![union]>()?;
                 let ident = input.parse::<Ident>()?;
                 let generics = input.parse::<Generics>()?;
-                let (where_clause, fields) = data_union(input, &mut attrs)?;
+                let (where_clause, fields) = data_union(input)?;
                 Ok(DeriveInput {
                     attrs,
                     vis,
@@ -163,7 +163,6 @@ pub mod parsing {
 
     pub fn data_struct(
         input: ParseStream,
-        attrs: &mut Vec<Attribute>,
     ) -> Result<(Option<WhereClause>, Fields, Option<Token![;]>)> {
         let mut lookahead = input.lookahead1();
         let mut where_clause = None;
@@ -188,7 +187,7 @@ pub mod parsing {
                 Err(lookahead.error())
             }
         } else if lookahead.peek(token::Brace) {
-            let fields = data::parsing::parse_braced(input, attrs)?;
+            let fields = input.parse()?;
             Ok((where_clause, Fields::Named(fields), None))
         } else if lookahead.peek(Token![;]) {
             let semi = input.parse()?;
@@ -200,7 +199,6 @@ pub mod parsing {
 
     pub fn data_enum(
         input: ParseStream,
-        attrs: &mut Vec<Attribute>,
     ) -> Result<(
         Option<WhereClause>,
         token::Brace,
@@ -210,18 +208,14 @@ pub mod parsing {
 
         let content;
         let brace = braced!(content in input);
-        attr::parsing::parse_inner(&content, attrs)?;
         let variants = content.parse_terminated(Variant::parse)?;
 
         Ok((where_clause, brace, variants))
     }
 
-    pub fn data_union(
-        input: ParseStream,
-        attrs: &mut Vec<Attribute>,
-    ) -> Result<(Option<WhereClause>, FieldsNamed)> {
+    pub fn data_union(input: ParseStream) -> Result<(Option<WhereClause>, FieldsNamed)> {
         let where_clause = input.parse()?;
-        let fields = data::parsing::parse_braced(input, attrs)?;
+        let fields = input.parse()?;
         Ok((where_clause, fields))
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -1987,13 +1987,12 @@ pub mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ItemStruct {
         fn parse(input: ParseStream) -> Result<Self> {
-            let mut attrs = input.call(Attribute::parse_outer)?;
+            let attrs = input.call(Attribute::parse_outer)?;
             let vis = input.parse::<Visibility>()?;
             let struct_token = input.parse::<Token![struct]>()?;
             let ident = input.parse::<Ident>()?;
             let generics = input.parse::<Generics>()?;
-            let (where_clause, fields, semi_token) =
-                derive::parsing::data_struct(input, &mut attrs)?;
+            let (where_clause, fields, semi_token) = derive::parsing::data_struct(input)?;
             Ok(ItemStruct {
                 attrs,
                 vis,
@@ -2012,13 +2011,12 @@ pub mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ItemEnum {
         fn parse(input: ParseStream) -> Result<Self> {
-            let mut attrs = input.call(Attribute::parse_outer)?;
+            let attrs = input.call(Attribute::parse_outer)?;
             let vis = input.parse::<Visibility>()?;
             let enum_token = input.parse::<Token![enum]>()?;
             let ident = input.parse::<Ident>()?;
             let generics = input.parse::<Generics>()?;
-            let (where_clause, brace_token, variants) =
-                derive::parsing::data_enum(input, &mut attrs)?;
+            let (where_clause, brace_token, variants) = derive::parsing::data_enum(input)?;
             Ok(ItemEnum {
                 attrs,
                 vis,
@@ -2037,12 +2035,12 @@ pub mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ItemUnion {
         fn parse(input: ParseStream) -> Result<Self> {
-            let mut attrs = input.call(Attribute::parse_outer)?;
+            let attrs = input.call(Attribute::parse_outer)?;
             let vis = input.parse::<Visibility>()?;
             let union_token = input.parse::<Token![union]>()?;
             let ident = input.parse::<Ident>()?;
             let generics = input.parse::<Generics>()?;
-            let (where_clause, fields) = derive::parsing::data_union(input, &mut attrs)?;
+            let (where_clause, fields) = derive::parsing::data_union(input)?;
             Ok(ItemUnion {
                 attrs,
                 vis,


### PR DESCRIPTION
This mirrors https://github.com/rust-lang/rust/pull/83312, which removed support for this syntax from rustc.