### PR TITLE
Fix panic on comma after `mut self` in bare fn type

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -740,7 +740,10 @@ pub mod parsing {
                         break;
                     }
 
-                    inputs.push_punct(args.parse()?);
+                    let comma = args.parse()?;
+                    if !has_mut_self {
+                        inputs.push_punct(comma);
+                    }
                 }
 
                 inputs

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -9,6 +9,7 @@ use syn::Type;
 #[test]
 fn test_mut_self() {
     syn::parse_str::<Type>("fn(mut self)").unwrap();
+    syn::parse_str::<Type>("fn(mut self,)").unwrap();
     syn::parse_str::<Type>("fn(mut self: ())").unwrap();
     syn::parse_str::<Type>("fn(mut self: ...)").unwrap_err();
     syn::parse_str::<Type>("fn(mut self: mut self)").unwrap_err();


### PR DESCRIPTION
Fixes #1147.