### PR TITLE
Improve lookahead documentation

### DIFF
--- a/src/lookahead.rs
+++ b/src/lookahead.rs
@@ -18,6 +18,9 @@ use std::cell::RefCell;
 /// [`ParseStream::peek`]: crate::parse::ParseBuffer::peek
 /// [`ParseStream::lookahead1`]: crate::parse::ParseBuffer::lookahead1
 ///
+/// Please be aware that advancing the source stream with parse() will not advance 
+/// the lookahead object.
+///
 /// # Example
 ///
 /// ```
@@ -136,7 +139,7 @@ impl<'a> Lookahead1<'a> {
 /// Types that can be parsed by looking at just one token.
 ///
 /// Use [`ParseStream::peek`] to peek one of these types in a parse stream
-/// without consuming it from the stream.
+/// without consuming it from the stream. 
 ///
 /// This trait is sealed and cannot be implemented for types outside of Syn.
 ///


### PR DESCRIPTION
Given that a colleague also was not able to spot my mistake on its own I know three people which missed the this issue.
It might be obvious for those with a better understanding so please feel free to reject (or reword) this proposal :)

https://discord.com/channels/273534239310479360/512792629516173323/960864849305432095