### PR TITLE
Add all examples into top-level workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,4 +72,17 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 features = ["full", "visit", "visit-mut", "fold", "extra-traits"]
 
 [workspace]
-members = ["dev", "json", "tests/crates", "tests/features"]
+members = [
+    "dev",
+    "examples/dump-syntax",
+    "examples/heapsize/example",
+    "examples/heapsize/heapsize",
+    "examples/heapsize/heapsize_derive",
+    "examples/lazy-static/example",
+    "examples/lazy-static/lazy-static",
+    "examples/trace-var/example",
+    "examples/trace-var/trace-var",
+    "json",
+    "tests/crates",
+    "tests/features",
+]

--- a/examples/dump-syntax/Cargo.toml
+++ b/examples/dump-syntax/Cargo.toml
@@ -13,5 +13,3 @@ proc-macro2 = { version = "1.0", features = ["span-locations"] }
 path = "../.."
 default-features = false
 features = ["parsing", "full", "extra-traits"]
-
-[workspace]

--- a/examples/heapsize/Cargo.toml
+++ b/examples/heapsize/Cargo.toml
@@ -1,2 +1,0 @@
-[workspace]
-members = ["example", "heapsize", "heapsize_derive"]

--- a/examples/lazy-static/Cargo.toml
+++ b/examples/lazy-static/Cargo.toml
@@ -1,2 +1,0 @@
-[workspace]
-members = ["example", "lazy-static"]

--- a/examples/lazy-static/example/Cargo.toml
+++ b/examples/lazy-static/example/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "example"
+name = "lazy-static-example"
 version = "0.0.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"

--- a/examples/trace-var/Cargo.toml
+++ b/examples/trace-var/Cargo.toml
@@ -1,2 +1,0 @@
-[workspace]
-members = ["example", "trace-var"]

--- a/examples/trace-var/example/Cargo.toml
+++ b/examples/trace-var/example/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "example"
+name = "trace-var-example"
 version = "0.0.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"


### PR DESCRIPTION
IIRC the reason it was not set up this way originally was that the examples used a newer edition than what was supported by the top-level crate. This made `cargo generate-lockfile` fail.