### PR TITLE
Add baseline benchmark to distinguish TokenStream::clone from syn::parse2

### DIFF
--- a/benches/file.rs
+++ b/benches/file.rs
@@ -22,10 +22,20 @@ use test::Bencher;
 
 const FILE: &str = "tests/rust/library/core/src/str/mod.rs";
 
-#[bench]
-fn parse_file(b: &mut Bencher) {
+fn get_tokens() -> TokenStream {
     repo::clone_rust();
     let content = fs::read_to_string(FILE).unwrap();
-    let tokens = TokenStream::from_str(&content).unwrap();
+    TokenStream::from_str(&content).unwrap()
+}
+
+#[bench]
+fn baseline(b: &mut Bencher) {
+    let tokens = get_tokens();
+    b.iter(|| drop(tokens.clone()));
+}
+
+#[bench]
+fn parse_file(b: &mut Bencher) {
+    let tokens = get_tokens();
     b.iter(|| syn::parse2::<syn::File>(tokens.clone()));
 }


### PR DESCRIPTION
The only way libproc_macro currently exposes to iterate a TokenStream is by value, i.e. there is no `impl IntoIterator for &TokenStream`. So a syn benchmark can't do anything without a clone and drop of the TokenStream on every iteration. This PR adds a benchmark that measures just the clone and drop, so that we can subtract and tell how long only the syn::parse2 is taking.

```console
test baseline   ... bench:     655,804 ns/iter (+/- 54,279)
test parse_file ... bench:   5,625,961 ns/iter (+/- 372,480)
```