### PR TITLE
Preserve ordering of associated type constraints relative to types

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -756,11 +756,8 @@ pub(crate) mod printing {
             self.colon2_token.to_tokens(tokens);
             self.lt_token.to_tokens(tokens);
 
-            // Print lifetimes before types and consts, all before bindings,
-            // regardless of their order in self.args.
-            //
-            // TODO: ordering rules for const arguments vs type arguments have
-            // not been settled yet. https://github.com/rust-lang/rust/issues/44580
+            // Print lifetimes before types/consts/bindings, regardless of their
+            // order in self.args.
             let mut trailing_or_empty = true;
             for param in self.args.pairs() {
                 match **param.value() {
@@ -776,30 +773,17 @@ pub(crate) mod printing {
             }
             for param in self.args.pairs() {
                 match **param.value() {
-                    GenericArgument::Type(_) | GenericArgument::Const(_) => {
-                        if !trailing_or_empty {
-                            <Token![,]>::default().to_tokens(tokens);
-                        }
-                        param.to_tokens(tokens);
-                        trailing_or_empty = param.punct().is_some();
-                    }
-                    GenericArgument::Lifetime(_)
+                    GenericArgument::Type(_)
                     | GenericArgument::Binding(_)
-                    | GenericArgument::Constraint(_) => {}
-                }
-            }
-            for param in self.args.pairs() {
-                match **param.value() {
-                    GenericArgument::Binding(_) | GenericArgument::Constraint(_) => {
+                    | GenericArgument::Constraint(_)
+                    | GenericArgument::Const(_) => {
                         if !trailing_or_empty {
                             <Token![,]>::default().to_tokens(tokens);
                         }
                         param.to_tokens(tokens);
                         trailing_or_empty = param.punct().is_some();
                     }
-                    GenericArgument::Lifetime(_)
-                    | GenericArgument::Type(_)
-                    | GenericArgument::Const(_) => {}
+                    GenericArgument::Lifetime(_) => {}
                 }
             }
 

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -14,9 +14,6 @@ const REVISION: &str = "98ad6a5519651af36e246c0335c964dd52c554ba";
 
 #[rustfmt::skip]
 static EXCLUDE_FILES: &[&str] = &[
-    // TODO: generic associated type constraint inside trait bound
-    "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0138_associated_type_bounds.rs",
-
     // TODO: negative literal for const generic parameter default value
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0200_const_param_default_literal.rs",
 


### PR DESCRIPTION
Rustc appears to have settled on no ordering restriction beyond lifetimes going first.