### PR TITLE
Remove workaround for mod@crate::parse rustdoc links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -813,14 +813,6 @@ mod print;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// https://github.com/rust-lang/rust/issues/62830
-#[cfg(feature = "parsing")]
-mod rustdoc_workaround {
-    pub use crate::parse::{self as parse_module};
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
 mod error;
 pub use crate::error::{Error, Result};
 

--- a/src/parse_macro_input.rs
+++ b/src/parse_macro_input.rs
@@ -4,7 +4,7 @@
 /// Refer to the [`parse` module] documentation for more details about parsing
 /// in Syn.
 ///
-/// [`parse` module]: parse/index.html
+/// [`parse` module]: mod@crate::parse
 ///
 /// <br>
 ///
@@ -51,7 +51,7 @@
 /// This macro can also be used with the [`Parser` trait] for types that have
 /// multiple ways that they can be parsed.
 ///
-/// [`Parser` trait]: parse/trait.Parser.html
+/// [`Parser` trait]: crate::parse::Parser
 ///
 /// ```
 /// # extern crate proc_macro;
@@ -103,9 +103,6 @@
 /// #     proc_macro::TokenStream::new()
 /// # }
 /// ```
-//
-// TODO: change the parse module link to an intra rustdoc link, currently
-// blocked on https://github.com/rust-lang/rust/issues/62830
 #[macro_export]
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "parsing", feature = "proc-macro"))))]
 macro_rules! parse_macro_input {

--- a/src/parse_macro_input.rs
+++ b/src/parse_macro_input.rs
@@ -4,7 +4,7 @@
 /// Refer to the [`parse` module] documentation for more details about parsing
 /// in Syn.
 ///
-/// [`parse` module]: crate::rustdoc_workaround::parse_module
+/// [`parse` module]: parse/index.html
 ///
 /// <br>
 ///
@@ -51,7 +51,7 @@
 /// This macro can also be used with the [`Parser` trait] for types that have
 /// multiple ways that they can be parsed.
 ///
-/// [`Parser` trait]: crate::rustdoc_workaround::parse_module::Parser
+/// [`Parser` trait]: parse/trait.Parser.html
 ///
 /// ```
 /// # extern crate proc_macro;
@@ -103,6 +103,9 @@
 /// #     proc_macro::TokenStream::new()
 /// # }
 /// ```
+//
+// TODO: change the parse module link to an intra rustdoc link, currently
+// blocked on https://github.com/rust-lang/rust/issues/62830
 #[macro_export]
 #[cfg_attr(doc_cfg, doc(cfg(all(feature = "parsing", feature = "proc-macro"))))]
 macro_rules! parse_macro_input {


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/62830 has been fixed.