### PR TITLE
Bypass a round trip through TokenBuffer in LitStr::parse

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -224,7 +224,7 @@ impl LitStr {
 
         // Parse string literal into a token stream with every span equal to the
         // original literal's span.
-        let mut tokens = crate::parse_str(&self.value())?;
+        let mut tokens = TokenStream::from_str(&self.value())?;
         tokens = respan_token_stream(tokens, self.span());
 
         parser.parse2(tokens)


### PR DESCRIPTION
`crate::parse_str::<TokenStream>` is gonna turn &amp;str into TokenStream into TokenBuffer into TokenStream. Only the first conversion is needed in this context.