### PR TITLE
Fix instruction for running benchmarks

### DIFF
--- a/benches/file.rs
+++ b/benches/file.rs
@@ -1,4 +1,4 @@
-// $ cargo bench --features full --bench file
+// $ cargo bench --features full,test --bench file
 
 #![feature(rustc_private, test)]
 #![recursion_limit = "1024"]

--- a/benches/rust.rs
+++ b/benches/rust.rs
@@ -1,7 +1,7 @@
-// $ cargo bench --features full --bench rust
+// $ cargo bench --features full,test --bench rust
 //
 // Syn only, useful for profiling:
-// $ RUSTFLAGS='--cfg syn_only' cargo build --release --features full --bench rust
+// $ RUSTFLAGS='--cfg syn_only' cargo build --release --features full,test --bench rust
 
 #![cfg_attr(not(syn_only), feature(rustc_private))]
 #![recursion_limit = "1024"]


### PR DESCRIPTION
Without this, it just hits the error message added in #798.

```console
$ cargo bench …
   Compiling syn-test-suite v0.0.0

ERROR:  use --all-features
  Syn's test suite normally only works with all-features enabled.
  Run again with `--all-features`, or run with `--features test`
  to bypass this check.

error: could not compile `syn-test-suite`
warning: build failed, waiting for other jobs to finish...
```