### PR TITLE
Pull in proc-macro2 1.0.46 for byte order mark fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro"]
 test = ["syn-test-suite/all-features"]
 
 [dependencies]
-proc-macro2 = { version = "1.0.39", default-features = false }
+proc-macro2 = { version = "1.0.46", default-features = false }
 quote = { version = "1.0", optional = true, default-features = false }
 unicode-ident = "1.0"
 


### PR DESCRIPTION
See https://github.com/dtolnay/proc-macro2/issues/353.

Without this, our benchmarks fail against the current contents of the rust-lang/rust repo.

```console
$ cargo test --release --bench rust --features full,test
871050 lines in 12914 files
read_from_disk:     elapsed=0.170s
tokenstream_parse:  FAIL tests/rust/src/test/ui/json/json-bom-plus-crlf-multifile-aux.rs
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `12913`,
 right: `12914`', benches/rust.rs:122:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```