### PR TITLE
Support full let-else statement parsing

### DIFF
--- a/examples/trace-var/trace-var/src/lib.rs
+++ b/examples/trace-var/trace-var/src/lib.rs
@@ -84,7 +84,7 @@ impl Args {
     ///     let VAR = { let VAR = INIT; println!("VAR = {:?}", VAR); VAR };
     fn let_and_print(&mut self, local: Local) -> Stmt {
         let Local { pat, init, .. } = local;
-        let init = self.fold_expr(*init.unwrap().1);
+        let init = self.fold_expr(*init.unwrap().expr);
         let ident = match pat {
             Pat::Ident(ref p) => &p.ident,
             _ => unreachable!(),

--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1356,6 +1356,17 @@ impl Clone for Local {
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for LocalInitializer {
+    fn clone(&self) -> Self {
+        LocalInitializer {
+            eq_token: self.eq_token.clone(),
+            expr: self.expr.clone(),
+            else_block: self.else_block.clone(),
+        }
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
 impl Clone for Macro {

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1866,6 +1866,17 @@ impl Debug for Local {
         formatter.finish()
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for LocalInitializer {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("LocalInitializer");
+        formatter.field("eq_token", &self.eq_token);
+        formatter.field("expr", &self.expr);
+        formatter.field("else_block", &self.else_block);
+        formatter.finish()
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Debug for Macro {

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1287,6 +1287,16 @@ impl PartialEq for Local {
         self.attrs == other.attrs && self.pat == other.pat && self.init == other.init
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for LocalInitializer {}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for LocalInitializer {
+    fn eq(&self, other: &Self) -> bool {
+        self.expr == other.expr && self.else_block == other.else_block
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Eq for Macro {}

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1734,6 +1734,17 @@ impl Hash for Local {
         self.init.hash(state);
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for LocalInitializer {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.expr.hash(state);
+        self.else_block.hash(state);
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Hash for Macro {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,7 +463,7 @@ pub mod spanned;
 #[cfg(feature = "full")]
 mod stmt;
 #[cfg(feature = "full")]
-pub use crate::stmt::{Block, Local, Stmt};
+pub use crate::stmt::{Block, Local, LocalInitializer, Stmt};
 
 mod thread;
 

--- a/syn.json
+++ b/syn.json
@@ -3417,20 +3417,43 @@
         },
         "init": {
           "option": {
-            "tuple": [
-              {
-                "token": "Eq"
-              },
-              {
-                "box": {
-                  "syn": "Expr"
-                }
-              }
-            ]
+            "syn": "LocalInitializer"
           }
         },
         "semi_token": {
           "token": "Semi"
+        }
+      }
+    },
+    {
+      "ident": "LocalInitializer",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "eq_token": {
+          "token": "Eq"
+        },
+        "expr": {
+          "box": {
+            "syn": "Expr"
+          }
+        },
+        "else_block": {
+          "option": {
+            "tuple": [
+              {
+                "token": "Else"
+              },
+              {
+                "box": {
+                  "syn": "ExprBlock"
+                }
+              }
+            ]
+          }
         }
       }
     },

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -3501,7 +3501,31 @@ impl Debug for Lite<syn::Local> {
         if let Some(val) = &_val.init {
             #[derive(RefCast)]
             #[repr(transparent)]
-            struct Print((syn::token::Eq, Box<syn::Expr>));
+            struct Print(syn::LocalInitializer);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some")?;
+                    let _val = &self.0;
+                    formatter.write_str("(")?;
+                    Debug::fmt(Lite(_val), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("init", Print::ref_cast(val));
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::LocalInitializer> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("LocalInitializer");
+        formatter.field("expr", Lite(&_val.expr));
+        if let Some(val) = &_val.else_block {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::Else, Box<syn::ExprBlock>));
             impl Debug for Print {
                 fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                     formatter.write_str("Some")?;
@@ -3512,7 +3536,7 @@ impl Debug for Lite<syn::Local> {
                     Ok(())
                 }
             }
-            formatter.field("init", Print::ref_cast(val));
+            formatter.field("else_block", Print::ref_cast(val));
         }
         formatter.finish()
     }


### PR DESCRIPTION
Currently let-else statements are parsed as `ExprVerbatim` (i.e. they are not parsed internally).

*let-else* statements are in beta now, so they will most probably appear in stable in November. Therefore, I think, now is the right moment for adding full parsing implementation.

This PR adds such parsing implementation to syn.
Fixes: https://github.com/dtolnay/syn/issues/1159