### PR TITLE
Serialize where token even if where clause is empty

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -1300,10 +1300,8 @@ mod printing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for WhereClause {
         fn to_tokens(&self, tokens: &mut TokenStream) {
-            if !self.predicates.is_empty() {
-                self.where_token.to_tokens(tokens);
-                self.predicates.to_tokens(tokens);
-            }
+            self.where_token.to_tokens(tokens);
+            self.predicates.to_tokens(tokens);
         }
     }
 


### PR DESCRIPTION
If where predicates are not pushed to the `WhereClause` but are just emitted as tokens, it's a bit unfortunate if the `where` token is not emitted when turning the `WhereClause` into tokens, even though there is a `WhereClause`. Currently, `WhereClause` does not emit any tokens if there are not predicates. In my opinion, it would be a bit more intuitive if the `where` token is emitted anyways.


A simplified example of a use case:
```rust
fn generate_where_clause(generics: &mut syn::Generics) -> proc_macro2::TokenStream {
    let predicates = &mut generics.make_where_clause().predicates;

    if !predicates.empty_or_trailing() {
        predicates.push_punct(syn::token::Comma::default());
    }

    quote::quote! { T: Trait }
}

let mut generics: syn::Generics = _;
let custom_where_clause = generate_where_clause(&mut generics);
let (_, _, where_clause) = generics.split_for_impl();

quote! {
    impl<T> Trait for Struct<T> #where_clause #custom_where_clause {}
}
```