### PR TITLE
Implement `PartialOrd` for `Cursor`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -14,7 +14,7 @@
 use crate::proc_macro as pm;
 use crate::Lifetime;
 use proc_macro2::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
-use std::marker::PhantomData;
+use std::{cmp::Ordering, marker::PhantomData};
 
 /// Internal type which is used instead of `TokenTree` to represent a token tree
 /// within a `TokenBuffer`.
@@ -348,8 +348,16 @@ impl<'a> Eq for Cursor<'a> {}
 impl<'a> PartialEq for Cursor<'a> {
     fn eq(&self, other: &Self) -> bool {
         let Cursor { ptr, scope, marker } = self;
-        let _ = marker;
-        *ptr == other.ptr && *scope == other.scope
+        let _ = (scope, marker);
+        *ptr == other.ptr
+    }
+}
+
+impl<'a> PartialOrd for Cursor<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let Cursor { ptr, scope, marker } = self;
+        let _ = (scope, marker);
+        ptr.partial_cmp(&other.ptr)
     }
 }
 

--- a/src/verbatim.rs
+++ b/src/verbatim.rs
@@ -1,5 +1,5 @@
 use crate::parse::{ParseBuffer, ParseStream};
-use proc_macro2::TokenStream;
+use proc_macro2::{Delimiter, TokenStream};
 use std::iter;
 
 pub fn between<'a>(begin: ParseBuffer<'a>, end: ParseStream<'a>) -> TokenStream {
@@ -8,6 +8,22 @@ pub fn between<'a>(begin: ParseBuffer<'a>, end: ParseStream<'a>) -> TokenStream 
     let mut tokens = TokenStream::new();
     while cursor != end {
         let (tt, next) = cursor.token_tree().unwrap();
+
+        if next > end {
+            // In some edge cases, a syntax node can actually cross the border
+            // of a None-delimited group, due to such groups being transparent
+            // to the parser in most cases. In the cases that this can occur,
+            // the presence of the group is known to be semantically irrelevant,
+            // so we should just ignore the presence of the group. (Issue #1235)
+            if let Some((inside, _span, after)) = cursor.group(Delimiter::None) {
+                assert!(next == after);
+                cursor = inside;
+                continue;
+            } else {
+                panic!("verbatim end must not be inside a delimited group");
+            }
+        }
+
         tokens.extend(iter::once(tt));
         cursor = next;
     }

--- a/tests/regression/issue1235.rs
+++ b/tests/regression/issue1235.rs
@@ -1,0 +1,32 @@
+use proc_macro2::{Delimiter, Group};
+use quote::quote;
+
+#[test]
+fn main() {
+    // Okay. Rustc allows top-level `static` with no value syntactically, but
+    // not semantically. Syn parses as Item::Verbatim.
+    let tokens = quote!(
+        pub static FOO: usize;
+        pub static BAR: usize;
+    );
+    let file = syn::parse2::<syn::File>(tokens).unwrap();
+    println!("{:#?}", file);
+
+    // Okay.
+    let inner = Group::new(
+        Delimiter::None,
+        quote!(static FOO: usize = 0; pub static BAR: usize = 0),
+    );
+    let tokens = quote!(pub #inner;);
+    let file = syn::parse2::<syn::File>(tokens).unwrap();
+    println!("{:#?}", file);
+
+    // Parser crash.
+    let inner = Group::new(
+        Delimiter::None,
+        quote!(static FOO: usize; pub static BAR: usize),
+    );
+    let tokens = quote!(pub #inner;);
+    let file = syn::parse2::<syn::File>(tokens).unwrap();
+    println!("{:#?}", file);
+}


### PR DESCRIPTION
New version of #1196 now that #1223 has changed token buffers to a flat layout, making the comparison trivial to implement.

As additional motivation and since it was first discovered in #1196, fixes #1235. The issue has nothing to do with `eq` comparing the scope pointer; in fact, the involved pointers actually have the same scope. Properly fixing the issue requires the ability to compare cursors in order to detect the case where the verbatim end is inside of a `None`-delimited group we previously would have stepped over.

I removed the check for scope equality here, as it is much more useful to be able to be able to compare cursors which don't necessarily have the same scope end (e.g. to determine which of multiple speculative parses got the furthest). Additionally, we actually now rely on comparing two cursors at the same location with different scopes in `verbatim::between` treating them as equal, as we explicitly enter the `None`-delimited group which the end cursor implicitly entered.

If exposing this is undesirable, we can reintroduce the scope check to `Cursor` comparison (treating cursors not with the same scope as unordered and nonequal) and introduce a `Cursor::position(&self) -> impl Ord` which can be used to order cursor's position ignoring the scope. (This would also provide a nice place to document how cursors are ordered.)

I'm happy to implement + document that alternative approach if it's desired, but since just dropping the scope-matters in comparison is simpler, I'm providing this solution first.