### PR TITLE
Restrict PartialOrd comparison to only tokens in the same buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,7 @@
     clippy::bool_to_int_with_if,
     clippy::cast_lossless,
     clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
     clippy::cast_ptr_alignment,
     clippy::default_trait_access,
     clippy::doc_markdown,

--- a/src/verbatim.rs
+++ b/src/verbatim.rs
@@ -1,15 +1,18 @@
 use crate::parse::{ParseBuffer, ParseStream};
 use proc_macro2::{Delimiter, TokenStream};
+use std::cmp::Ordering;
 use std::iter;
 
 pub fn between<'a>(begin: ParseBuffer<'a>, end: ParseStream<'a>) -> TokenStream {
     let end = end.cursor();
     let mut cursor = begin.cursor();
+    assert!(crate::buffer::same_buffer(end, cursor));
+
     let mut tokens = TokenStream::new();
     while cursor != end {
         let (tt, next) = cursor.token_tree().unwrap();
 
-        if end < next {
+        if crate::buffer::cmp_assuming_same_buffer(end, next) == Ordering::Less {
             // A syntax node can cross the boundary of a None-delimited group
             // due to such groups being transparent to the parser in most cases.
             // Any time this occurs the group is known to be semantically


### PR DESCRIPTION
How does this look @CAD97? I was hesitant about directly exposing a pointer comparison across unrelated allocations.

```rust
use syn::buffer::TokenBuffer;
let a = TokenBuffer::new2("...".parse().unwrap());
let b = TokenBuffer::new2("...".parse().unwrap());
println!("{:?}", a.begin().partial_cmp(&b.begin()));
```