### PR TITLE
Make PathArguments::is_none() public

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -89,9 +89,8 @@ impl PathArguments {
         }
     }
 
-    #[cfg(feature = "parsing")]
-    fn is_none(&self) -> bool {
-        match *self {
+    pub fn is_none(&self) -> bool {
+        match self {
             PathArguments::None => true,
             PathArguments::AngleBracketed(_) | PathArguments::Parenthesized(_) => false,
         }


### PR DESCRIPTION
I've found this to be at least as often useful as `is_empty` is.