### PR TITLE
Prevent actions duplication on noop merge commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,13 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
+  pre_ci:
+    uses: ./.github/workflows/pre_ci.yml
+
   test:
     name: Tests
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -25,6 +30,8 @@ jobs:
 
   build:
     name: ${{matrix.name || format('Rust {0}', matrix.rust)}}
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
     runs-on: ${{matrix.os || 'ubuntu'}}-latest
     strategy:
       fail-fast: false
@@ -72,6 +79,8 @@ jobs:
 
   examples:
     name: Examples
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -84,6 +93,8 @@ jobs:
 
   docs:
     name: Docs
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: --cfg=doc_cfg -Dbroken_intra_doc_links
@@ -96,6 +107,8 @@ jobs:
 
   codegen:
     name: Codegen
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -106,6 +119,8 @@ jobs:
 
   msrv:
     name: Minimal versions
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -116,6 +131,8 @@ jobs:
 
   fuzz:
     name: Fuzz
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -126,6 +143,8 @@ jobs:
 
   miri:
     name: Miri
+    needs: pre_ci
+    if: needs.pre_ci.outputs.continue
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/pre_ci.yml
+++ b/.github/workflows/pre_ci.yml
@@ -1,0 +1,47 @@
+# TODO: Move this to a dtolnay/skip-duplicate-actions reusable action.
+#
+# When a branch is used to open a PR in the branch's own repository, GitHub will
+# trigger 'on: push' workflows against the head commit of the PR, and trigger
+# 'on: pull_request' workflows against a merge commit between the head commit
+# and the PR's base branch (typically master).
+#
+# Often times those 2 sets of jobs end up running against identical trees. This
+# is the case if there have been no commits on the base branch since when the
+# PR's head branch was forked from the base branch.
+#
+# The code below detects this common scenario and provides a way to bypass CI
+# from running redundantly on the merge commit.
+
+name: pre_ci
+
+on:
+  workflow_call:
+    outputs:
+      continue:
+        value: ${{jobs.pre_ci.outputs.continue}}
+
+jobs:
+  pre_ci:
+    runs-on: ubuntu-latest
+    outputs:
+      continue: ${{steps.decision.outputs.continue}}
+
+    steps:
+      - id: is_local_pull_request
+        run: echo value=true >> $GITHUB_OUTPUT
+        if: github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+        if: steps.is_local_pull_request.outputs.value
+
+      - id: is_noop_merge
+        run: if git diff HEAD^2 --quiet; then echo value=true >> $GITHUB_OUTPUT; fi
+        if: steps.is_local_pull_request.outputs.value
+
+      - id: decision
+        run: echo continue=true >> $GITHUB_OUTPUT
+        if: |
+          !steps.is_local_pull_request.outputs.value || !steps.is_noop_merge.outputs.value


### PR DESCRIPTION
When a branch is used to open a PR in the branch's own repository, GitHub will trigger `on: push` workflows against the head commit of the PR, and `on: pull_request` workflows against a merge commit between the head commit
and the PR's base branch (typically master).

Often times those 2 sets of jobs end up running against identical trees. This is the case if there have been no commits on the base branch since when the PR's head branch was forked from the base branch.

This PR adds a workflow to detect this common scenario and provides a way to bypass CI from running redundantly on the merge commit.