### PR TITLE
Delete field reserved for unstable &raw reference syntax

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,7 +1,5 @@
 use super::*;
 use crate::punctuated::Punctuated;
-#[cfg(feature = "full")]
-use crate::reserved::Reserved;
 use proc_macro2::{Span, TokenStream};
 #[cfg(feature = "printing")]
 use quote::IdentFragment;
@@ -630,7 +628,6 @@ ast_struct! {
     pub struct ExprReference #full {
         pub attrs: Vec<Attribute>,
         pub and_token: Token![&],
-        pub raw: Reserved,
         pub mutability: Option<Token![mut]>,
         pub expr: Box<Expr>,
     }
@@ -1523,7 +1520,6 @@ pub(crate) mod parsing {
                 Ok(Expr::Reference(ExprReference {
                     attrs,
                     and_token,
-                    raw: Reserved::default(),
                     mutability,
                     expr,
                 }))
@@ -2385,7 +2381,6 @@ pub(crate) mod parsing {
             Ok(ExprReference {
                 attrs: Vec::new(),
                 and_token: input.parse()?,
-                raw: Reserved::default(),
                 mutability: input.parse()?,
                 expr: Box::new(unary_expr(input, allow_struct)?),
             })

--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -612,7 +612,6 @@ impl Clone for ExprReference {
         ExprReference {
             attrs: self.attrs.clone(),
             and_token: self.and_token.clone(),
-            raw: self.raw.clone(),
             mutability: self.mutability.clone(),
             expr: self.expr.clone(),
         }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -926,7 +926,6 @@ impl Debug for ExprReference {
         let mut formatter = formatter.debug_struct("ExprReference");
         formatter.field("attrs", &self.attrs);
         formatter.field("and_token", &self.and_token);
-        formatter.field("raw", &self.raw);
         formatter.field("mutability", &self.mutability);
         formatter.field("expr", &self.expr);
         formatter.finish()

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -1474,7 +1474,6 @@ where
     ExprReference {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         and_token: Token![&](tokens_helper(f, &node.and_token.spans)),
-        raw: node.raw,
         mutability: (node.mutability).map(|it| Token![mut](tokens_helper(f, &it.span))),
         expr: Box::new(f.fold_expr(*node.expr)),
     }

--- a/syn.json
+++ b/syn.json
@@ -1566,9 +1566,6 @@
         "and_token": {
           "token": "And"
         },
-        "raw": {
-          "syn": "Reserved"
-        },
         "mutability": {
           "option": {
             "token": "Mut"


### PR DESCRIPTION
Closes #678. That syntax no longer seems on track for stabilization.