### PR TITLE
Make codegen runnable from any directory

### DIFF
--- a/codegen/src/clone.rs
+++ b/codegen/src/clone.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn_codegen::{Data, Definitions, Node, Type};
 
-const CLONE_SRC: &str = "../src/gen/clone.rs";
+const CLONE_SRC: &str = "src/gen/clone.rs";
 
 fn expand_impl_body(defs: &Definitions, node: &Node) -> TokenStream {
     let type_name = &node.ident;

--- a/codegen/src/debug.rs
+++ b/codegen/src/debug.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn_codegen::{Data, Definitions, Node, Type};
 
-const DEBUG_SRC: &str = "../src/gen/debug.rs";
+const DEBUG_SRC: &str = "src/gen/debug.rs";
 
 fn expand_impl_body(defs: &Definitions, node: &Node) -> TokenStream {
     let type_name = &node.ident;

--- a/codegen/src/eq.rs
+++ b/codegen/src/eq.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn_codegen::{Data, Definitions, Node, Type};
 
-const EQ_SRC: &str = "../src/gen/eq.rs";
+const EQ_SRC: &str = "src/gen/eq.rs";
 
 fn always_eq(field_type: &Type) -> bool {
     match field_type {

--- a/codegen/src/file.rs
+++ b/codegen/src/file.rs
@@ -1,10 +1,11 @@
+use crate::workspace_path;
 use anyhow::Result;
 use proc_macro2::TokenStream;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 
-pub fn write(path: impl AsRef<Path>, content: TokenStream) -> Result<()> {
+pub fn write(relative_to_workspace_root: impl AsRef<Path>, content: TokenStream) -> Result<()> {
     let mut formatted = Vec::new();
     writeln!(
         formatted,
@@ -17,7 +18,8 @@ pub fn write(path: impl AsRef<Path>, content: TokenStream) -> Result<()> {
     let pretty = prettyplease::unparse(&syntax_tree);
     write!(formatted, "{}", pretty)?;
 
-    if path.as_ref().is_file() && fs::read(&path)? == formatted {
+    let path = workspace_path::get(relative_to_workspace_root);
+    if path.is_file() && fs::read(&path)? == formatted {
         return Ok(());
     }
 

--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -5,7 +5,7 @@ use quote::{format_ident, quote};
 use syn::Index;
 use syn_codegen::{Data, Definitions, Features, Node, Type};
 
-const FOLD_SRC: &str = "../src/gen/fold.rs";
+const FOLD_SRC: &str = "src/gen/fold.rs";
 
 fn simple_visit(item: &str, name: &TokenStream) -> TokenStream {
     let ident = gen::under_name(item);

--- a/codegen/src/hash.rs
+++ b/codegen/src/hash.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn_codegen::{Data, Definitions, Node, Type};
 
-const HASH_SRC: &str = "../src/gen/hash.rs";
+const HASH_SRC: &str = "src/gen/hash.rs";
 
 fn skip(field_type: &Type) -> bool {
     match field_type {

--- a/codegen/src/json.rs
+++ b/codegen/src/json.rs
@@ -1,6 +1,6 @@
+use crate::workspace_path;
 use anyhow::Result;
 use std::fs;
-use std::path::Path;
 use syn_codegen::Definitions;
 
 pub fn generate(defs: &Definitions) -> Result<()> {
@@ -10,8 +10,7 @@ pub fn generate(defs: &Definitions) -> Result<()> {
     let check: Definitions = serde_json::from_str(&j)?;
     assert_eq!(*defs, check);
 
-    let codegen_root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let json_path = codegen_root.join("../syn.json");
+    let json_path = workspace_path::get("syn.json");
     fs::write(json_path, j)?;
 
     Ok(())

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -28,6 +28,7 @@ mod snapshot;
 mod version;
 mod visit;
 mod visit_mut;
+mod workspace_path;
 
 fn main() -> anyhow::Result<()> {
     color_backtrace::install();

--- a/codegen/src/snapshot.rs
+++ b/codegen/src/snapshot.rs
@@ -5,7 +5,7 @@ use quote::{format_ident, quote};
 use syn::Index;
 use syn_codegen::{Data, Definitions, Node, Type};
 
-const TESTS_DEBUG_SRC: &str = "../tests/debug/gen.rs";
+const TESTS_DEBUG_SRC: &str = "tests/debug/gen.rs";
 
 fn rust_type(ty: &Type) -> TokenStream {
     match ty {

--- a/codegen/src/version.rs
+++ b/codegen/src/version.rs
@@ -1,12 +1,11 @@
+use crate::workspace_path;
 use anyhow::Result;
 use semver::Version;
 use serde::Deserialize;
 use std::fs;
-use std::path::Path;
 
 pub fn get() -> Result<Version> {
-    let codegen_root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let syn_cargo_toml = codegen_root.join("../Cargo.toml");
+    let syn_cargo_toml = workspace_path::get("Cargo.toml");
     let manifest = fs::read_to_string(syn_cargo_toml)?;
     let parsed: Manifest = toml::from_str(&manifest)?;
     Ok(parsed.package.version)

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -6,7 +6,7 @@ use quote::{format_ident, quote};
 use syn::Index;
 use syn_codegen::{Data, Definitions, Features, Node, Type};
 
-const VISIT_SRC: &str = "../src/gen/visit.rs";
+const VISIT_SRC: &str = "src/gen/visit.rs";
 
 fn simple_visit(item: &str, name: &Operand) -> TokenStream {
     let ident = gen::under_name(item);

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -6,7 +6,7 @@ use quote::{format_ident, quote};
 use syn::Index;
 use syn_codegen::{Data, Definitions, Features, Node, Type};
 
-const VISIT_MUT_SRC: &str = "../src/gen/visit_mut.rs";
+const VISIT_MUT_SRC: &str = "src/gen/visit_mut.rs";
 
 fn simple_visit(item: &str, name: &Operand) -> TokenStream {
     let ident = gen::under_name(item);

--- a/codegen/src/workspace_path.rs
+++ b/codegen/src/workspace_path.rs
@@ -1,0 +1,8 @@
+use std::path::{Path, PathBuf};
+
+pub fn get(relative_to_workspace_root: impl AsRef<Path>) -> PathBuf {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    assert!(path.pop());
+    path.push(relative_to_workspace_root);
+    path
+}


### PR DESCRIPTION
Previously this would fail with _"Error: No such file or directory (os error 2)"_ if run as `cargo run --manifest-path codegen/Cargo.toml`.
