### PR TITLE
Refactor printing of delimiter tokens

### DIFF
--- a/src/mac.rs
+++ b/src/mac.rs
@@ -198,22 +198,26 @@ mod printing {
     use proc_macro2::TokenStream;
     use quote::ToTokens;
 
+    impl MacroDelimiter {
+        pub(crate) fn surround<F>(&self, tokens: &mut TokenStream, f: F)
+        where
+            F: FnOnce(&mut TokenStream),
+        {
+            match self {
+                MacroDelimiter::Paren(paren) => paren.surround(tokens, f),
+                MacroDelimiter::Brace(brace) => brace.surround(tokens, f),
+                MacroDelimiter::Bracket(bracket) => bracket.surround(tokens, f),
+            }
+        }
+    }
+
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
     impl ToTokens for Macro {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             self.path.to_tokens(tokens);
             self.bang_token.to_tokens(tokens);
-            match &self.delimiter {
-                MacroDelimiter::Paren(paren) => {
-                    paren.surround(tokens, |tokens| self.tokens.to_tokens(tokens));
-                }
-                MacroDelimiter::Brace(brace) => {
-                    brace.surround(tokens, |tokens| self.tokens.to_tokens(tokens));
-                }
-                MacroDelimiter::Bracket(bracket) => {
-                    bracket.surround(tokens, |tokens| self.tokens.to_tokens(tokens));
-                }
-            }
+            self.delimiter
+                .surround(tokens, |tokens| self.tokens.to_tokens(tokens));
         }
     }
 }

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -201,17 +201,12 @@ mod printing {
     use quote::ToTokens;
 
     impl MacroDelimiter {
-        pub(crate) fn surround<F>(&self, tokens: &mut TokenStream, f: F)
-        where
-            F: FnOnce(&mut TokenStream),
-        {
+        pub(crate) fn surround(&self, tokens: &mut TokenStream, inner: TokenStream) {
             let (delim, span) = match self {
                 MacroDelimiter::Paren(paren) => (Delimiter::Parenthesis, paren.span),
                 MacroDelimiter::Brace(brace) => (Delimiter::Brace, brace.span),
                 MacroDelimiter::Bracket(bracket) => (Delimiter::Bracket, bracket.span),
             };
-            let mut inner = TokenStream::new();
-            f(&mut inner);
             token::printing::delim(delim, span, tokens, inner);
         }
     }
@@ -221,8 +216,7 @@ mod printing {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             self.path.to_tokens(tokens);
             self.bang_token.to_tokens(tokens);
-            self.delimiter
-                .surround(tokens, |tokens| self.tokens.to_tokens(tokens));
+            self.delimiter.surround(tokens, self.tokens.clone());
         }
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -543,7 +543,9 @@ macro_rules! define_delimiters {
                 where
                     F: FnOnce(&mut TokenStream),
                 {
-                    printing::delim($token, self.span, tokens, f);
+                    let mut inner = TokenStream::new();
+                    f(&mut inner);
+                    printing::delim($token, self.span, tokens, inner);
                 }
             }
 
@@ -993,10 +995,7 @@ pub mod printing {
         tokens.append(Ident::new(s, span));
     }
 
-    pub fn delim<F>(s: &str, span: Span, tokens: &mut TokenStream, f: F)
-    where
-        F: FnOnce(&mut TokenStream),
-    {
+    pub fn delim(s: &str, span: Span, tokens: &mut TokenStream, inner: TokenStream) {
         let delim = match s {
             "(" => Delimiter::Parenthesis,
             "[" => Delimiter::Bracket,
@@ -1004,8 +1003,6 @@ pub mod printing {
             " " => Delimiter::None,
             _ => panic!("unknown delimiter: {}", s),
         };
-        let mut inner = TokenStream::new();
-        f(&mut inner);
         let mut g = Group::new(delim, inner);
         g.set_span(span);
         tokens.append(g);

--- a/src/token.rs
+++ b/src/token.rs
@@ -102,13 +102,13 @@ use crate::lookahead;
 #[cfg(feature = "parsing")]
 use crate::parse::{Parse, ParseStream};
 use crate::span::IntoSpans;
-#[cfg(any(feature = "parsing", feature = "printing"))]
-use proc_macro2::Ident;
 use proc_macro2::Span;
 #[cfg(feature = "printing")]
 use proc_macro2::TokenStream;
+#[cfg(any(feature = "parsing", feature = "printing"))]
+use proc_macro2::{Delimiter, Ident};
 #[cfg(feature = "parsing")]
-use proc_macro2::{Delimiter, Literal, Punct, TokenTree};
+use proc_macro2::{Literal, Punct, TokenTree};
 #[cfg(feature = "printing")]
 use quote::{ToTokens, TokenStreamExt};
 #[cfg(feature = "extra-traits")]
@@ -476,7 +476,7 @@ macro_rules! define_punctuation {
 }
 
 macro_rules! define_delimiters {
-    ($($token:tt pub struct $name:ident #[$doc:meta])*) => {
+    ($($delim:ident pub struct $name:ident #[$doc:meta])*) => {
         $(
             #[$doc]
             pub struct $name {
@@ -545,7 +545,7 @@ macro_rules! define_delimiters {
                 {
                     let mut inner = TokenStream::new();
                     f(&mut inner);
-                    printing::delim($token, self.span, tokens, inner);
+                    printing::delim(Delimiter::$delim, self.span, tokens, inner);
                 }
             }
 
@@ -756,10 +756,10 @@ define_punctuation! {
 }
 
 define_delimiters! {
-    "{"           pub struct Brace        /// `{...}`
-    "["           pub struct Bracket      /// `[...]`
-    "("           pub struct Paren        /// `(...)`
-    " "           pub struct Group        /// None-delimited group
+    Brace         pub struct Brace        /// `{...}`
+    Bracket       pub struct Bracket      /// `[...]`
+    Parenthesis   pub struct Paren        /// `(...)`
+    None          pub struct Group        /// None-delimited group
 }
 
 macro_rules! export_token_macro {
@@ -995,14 +995,7 @@ pub mod printing {
         tokens.append(Ident::new(s, span));
     }
 
-    pub fn delim(s: &str, span: Span, tokens: &mut TokenStream, inner: TokenStream) {
-        let delim = match s {
-            "(" => Delimiter::Parenthesis,
-            "[" => Delimiter::Bracket,
-            "{" => Delimiter::Brace,
-            " " => Delimiter::None,
-            _ => panic!("unknown delimiter: {}", s),
-        };
+    pub fn delim(delim: Delimiter, span: Span, tokens: &mut TokenStream, inner: TokenStream) {
         let mut g = Group::new(delim, inner);
         g.set_span(span);
         tokens.append(g);


### PR DESCRIPTION
This code is going to be shared with an upcoming redesign of `Attribute`, since the attribute syntax also involves macro delimiters containing arbitrary tokens: `#[pa::th(...)]`, `#[pa::th[...]]`, `#[pa::th { ... }]`.