### PR TITLE
Fix attrs and labels incorrectly accepted on let-else diverge block

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -262,8 +262,12 @@ pub mod parsing {
 
             let diverge = if input.peek(Token![else]) {
                 let else_token = input.parse::<Token![else]>()?;
-                let expr_block = input.parse::<ExprBlock>()?;
-                Some((else_token, Box::new(Expr::Block(expr_block))))
+                let diverge = ExprBlock {
+                    attrs: Vec::new(),
+                    label: None,
+                    block: input.parse()?,
+                };
+                Some((else_token, Box::new(Expr::Block(diverge))))
             } else {
                 None
             };


### PR DESCRIPTION
Fixes https://github.com/dtolnay/syn/pull/1231#discussion_r1051508698.

The following are not valid syntax in Rust.

```rust
let true = false else 'label: { return; };
```

```rust
let true = false else #[foo] { return; };
```