### PR TITLE
Delete all 'available only if' comments in favor of doc(cfg())

### DIFF
--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -274,8 +274,6 @@ pub fn generate(defs: &Definitions) -> Result<()> {
             /// See the [module documentation] for details.
             ///
             /// [module documentation]: self
-            ///
-            /// *This trait is available only if Syn is built with the `"fold"` feature.*
             pub trait Fold {
                 #traits
             }

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -253,8 +253,6 @@ pub fn generate(defs: &Definitions) -> Result<()> {
             /// See the [module documentation] for details.
             ///
             /// [module documentation]: self
-            ///
-            /// *This trait is available only if Syn is built with the `"visit"` feature.*
             pub trait Visit<'ast> {
                 #traits
             }

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -250,8 +250,6 @@ pub fn generate(defs: &Definitions) -> Result<()> {
             /// See the [module documentation] for details.
             ///
             /// [module documentation]: self
-            ///
-            /// *This trait is available only if Syn is built with the `"visit-mut"` feature.*
             pub trait VisitMut {
                 #traits
             }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -11,9 +11,6 @@ use std::fmt::Write;
 ast_struct! {
     /// An attribute, like `#[repr(transparent)]`.
     ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
-    ///
     /// <br>
     ///
     /// # Syntax
@@ -194,9 +191,6 @@ impl Attribute {
     /// #[my_attr(value < 5)]
     ///           ^^^^^^^^^ what gets parsed
     /// ```
-    ///
-    /// *This function is available only if Syn is built with the `"parsing"`
-    /// feature.*
     #[cfg(feature = "parsing")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_args<T: Parse>(&self) -> Result<T> {
@@ -204,9 +198,6 @@ impl Attribute {
     }
 
     /// Parse the arguments to the attribute using the given parser.
-    ///
-    /// *This function is available only if Syn is built with the `"parsing"`
-    /// feature.*
     #[cfg(feature = "parsing")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_args_with<F: Parser>(&self, parser: F) -> Result<F::Output> {
@@ -230,9 +221,6 @@ impl Attribute {
     }
 
     /// Parses zero or more outer attributes from the stream.
-    ///
-    /// *This function is available only if Syn is built with the `"parsing"`
-    /// feature.*
     #[cfg(feature = "parsing")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_outer(input: ParseStream) -> Result<Vec<Self>> {
@@ -244,9 +232,6 @@ impl Attribute {
     }
 
     /// Parses zero or more inner attributes from the stream.
-    ///
-    /// *This function is available only if Syn is built with the `"parsing"`
-    /// feature.*
     #[cfg(feature = "parsing")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_inner(input: ParseStream) -> Result<Vec<Self>> {
@@ -280,9 +265,6 @@ ast_enum! {
     /// Distinguishes between attributes that decorate an item and attributes
     /// that are contained within an item.
     ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
-    ///
     /// # Outer attributes
     ///
     /// - `#[repr(transparent)]`
@@ -303,9 +285,6 @@ ast_enum! {
 
 ast_enum_of_structs! {
     /// Content of a compile-time structured attribute.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     ///
     /// ## Path
     ///
@@ -339,9 +318,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A structured list within an attribute, like `derive(Copy, Clone)`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct MetaList {
         pub path: Path,
@@ -352,9 +328,6 @@ ast_struct! {
 
 ast_struct! {
     /// A name-value pair within an attribute, like `feature = "nightly"`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct MetaNameValue {
         pub path: Path,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,5 @@
 //! A stably addressed token buffer supporting efficient traversal based on a
 //! cheaply copyable cursor.
-//!
-//! *This module is available only if Syn is built with the `"parsing"` feature.*
 
 // This module is heavily commented as it contains most of the unsafe code in
 // Syn, and caution should be used when editing it. The public-facing interface
@@ -33,8 +31,6 @@ enum Entry {
 /// A buffer that can be efficiently traversed multiple times, unlike
 /// `TokenStream` which requires a deep copy in order to traverse more than
 /// once.
-///
-/// *This type is available only if Syn is built with the `"parsing"` feature.*
 pub struct TokenBuffer {
     // NOTE: Do not implement clone on this - while the current design could be
     // cloned, other designs which could be desirable may not be cloneable.
@@ -63,13 +59,11 @@ impl TokenBuffer {
 
     /// Creates a `TokenBuffer` containing all the tokens from the input
     /// `proc_macro::TokenStream`.
-    ///
-    /// *This method is available only if Syn is built with both the `"parsing"` and
-    /// `"proc-macro"` features.*
     #[cfg(all(
         not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "wasi"))),
         feature = "proc-macro"
     ))]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "proc-macro")))]
     pub fn new(stream: pm::TokenStream) -> Self {
         Self::new2(stream.into())
     }
@@ -104,8 +98,6 @@ impl TokenBuffer {
 ///
 /// Two cursors are equal if they have the same location in the same input
 /// stream, and have the same scope.
-///
-/// *This type is available only if Syn is built with the `"parsing"` feature.*
 pub struct Cursor<'a> {
     // The current entry which the `Cursor` is pointing at.
     ptr: *const Entry,

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,9 +3,6 @@ use crate::punctuated::Punctuated;
 
 ast_struct! {
     /// An enum variant.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Variant {
         /// Attributes tagged on the variant.
@@ -24,9 +21,6 @@ ast_struct! {
 
 ast_enum_of_structs! {
     /// Data stored within an enum variant or struct.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     ///
     /// # Syntax tree enum
     ///
@@ -50,9 +44,6 @@ ast_enum_of_structs! {
 ast_struct! {
     /// Named fields of a struct or struct variant such as `Point { x: f64,
     /// y: f64 }`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct FieldsNamed {
         pub brace_token: token::Brace,
@@ -62,9 +53,6 @@ ast_struct! {
 
 ast_struct! {
     /// Unnamed fields of a tuple struct or tuple variant such as `Some(T)`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct FieldsUnnamed {
         pub paren_token: token::Paren,
@@ -147,9 +135,6 @@ impl<'a> IntoIterator for &'a mut Fields {
 
 ast_struct! {
     /// A field of a struct or enum variant.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Field {
         /// Attributes tagged on the field.
@@ -173,9 +158,6 @@ ast_struct! {
 ast_enum_of_structs! {
     /// The visibility level of an item: inherited or `pub` or
     /// `pub(restricted)`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     ///
     /// # Syntax tree enum
     ///
@@ -201,9 +183,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A public visibility level: `pub`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct VisPublic {
         pub pub_token: Token![pub],
@@ -212,9 +191,6 @@ ast_struct! {
 
 ast_struct! {
     /// A crate-level visibility: `crate`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct VisCrate {
         pub crate_token: Token![crate],
@@ -224,9 +200,6 @@ ast_struct! {
 ast_struct! {
     /// A visibility level restricted to some path: `pub(self)` or
     /// `pub(super)` or `pub(crate)` or `pub(in some::module)`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct VisRestricted {
         pub pub_token: Token![pub],

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -3,8 +3,6 @@ use crate::punctuated::Punctuated;
 
 ast_struct! {
     /// Data structure sent to a `proc_macro_derive` macro.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
     pub struct DeriveInput {
         /// Attributes tagged on the whole struct or enum.
@@ -26,8 +24,6 @@ ast_struct! {
 
 ast_enum_of_structs! {
     /// The storage of a struct, enum or union data structure.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` feature.*
     ///
     /// # Syntax tree enum
     ///
@@ -51,9 +47,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A struct input to a `proc_macro_derive` macro.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
     pub struct DataStruct {
         pub struct_token: Token![struct],
@@ -64,9 +57,6 @@ ast_struct! {
 
 ast_struct! {
     /// An enum input to a `proc_macro_derive` macro.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
     pub struct DataEnum {
         pub enum_token: Token![enum],
@@ -77,9 +67,6 @@ ast_struct! {
 
 ast_struct! {
     /// An untagged union input to a `proc_macro_derive` macro.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "derive")))]
     pub struct DataUnion {
         pub union_token: Token![union],

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -249,8 +249,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A slice literal expression: `[a, b, c, d]`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprArray #full {
         pub attrs: Vec<Attribute>,
@@ -261,8 +259,6 @@ ast_struct! {
 
 ast_struct! {
     /// An assignment expression: `a = compute()`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprAssign #full {
         pub attrs: Vec<Attribute>,
@@ -274,8 +270,6 @@ ast_struct! {
 
 ast_struct! {
     /// A compound assignment expression: `counter += 1`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprAssignOp #full {
         pub attrs: Vec<Attribute>,
@@ -287,8 +281,6 @@ ast_struct! {
 
 ast_struct! {
     /// An async block: `async { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprAsync #full {
         pub attrs: Vec<Attribute>,
@@ -300,8 +292,6 @@ ast_struct! {
 
 ast_struct! {
     /// An await expression: `fut.await`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprAwait #full {
         pub attrs: Vec<Attribute>,
@@ -313,9 +303,6 @@ ast_struct! {
 
 ast_struct! {
     /// A binary operation: `a + b`, `a * b`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprBinary {
         pub attrs: Vec<Attribute>,
@@ -327,8 +314,6 @@ ast_struct! {
 
 ast_struct! {
     /// A blocked scope: `{ ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprBlock #full {
         pub attrs: Vec<Attribute>,
@@ -339,8 +324,6 @@ ast_struct! {
 
 ast_struct! {
     /// A box expression: `box f`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprBox #full {
         pub attrs: Vec<Attribute>,
@@ -352,8 +335,6 @@ ast_struct! {
 ast_struct! {
     /// A `break`, with an optional label to break and an optional
     /// expression.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprBreak #full {
         pub attrs: Vec<Attribute>,
@@ -365,9 +346,6 @@ ast_struct! {
 
 ast_struct! {
     /// A function call expression: `invoke(a, b)`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprCall {
         pub attrs: Vec<Attribute>,
@@ -379,9 +357,6 @@ ast_struct! {
 
 ast_struct! {
     /// A cast expression: `foo as f64`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprCast {
         pub attrs: Vec<Attribute>,
@@ -393,8 +368,6 @@ ast_struct! {
 
 ast_struct! {
     /// A closure expression: `|a, b| a + b`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprClosure #full {
         pub attrs: Vec<Attribute>,
@@ -411,8 +384,6 @@ ast_struct! {
 
 ast_struct! {
     /// A `continue`, with an optional label.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprContinue #full {
         pub attrs: Vec<Attribute>,
@@ -424,8 +395,6 @@ ast_struct! {
 ast_struct! {
     /// Access of a named struct field (`obj.k`) or unnamed tuple struct
     /// field (`obj.0`).
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprField {
         pub attrs: Vec<Attribute>,
@@ -437,8 +406,6 @@ ast_struct! {
 
 ast_struct! {
     /// A for loop: `for pat in expr { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprForLoop #full {
         pub attrs: Vec<Attribute>,
@@ -457,8 +424,6 @@ ast_struct! {
     /// This variant is important for faithfully representing the precedence
     /// of expressions and is related to `None`-delimited spans in a
     /// `TokenStream`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprGroup #full {
         pub attrs: Vec<Attribute>,
@@ -473,8 +438,6 @@ ast_struct! {
     ///
     /// The `else` branch expression may only be an `If` or `Block`
     /// expression, not any of the other types of expression.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprIf #full {
         pub attrs: Vec<Attribute>,
@@ -487,9 +450,6 @@ ast_struct! {
 
 ast_struct! {
     /// A square bracketed indexing expression: `vector[2]`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprIndex {
         pub attrs: Vec<Attribute>,
@@ -501,8 +461,6 @@ ast_struct! {
 
 ast_struct! {
     /// A `let` guard: `let Some(x) = opt`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprLet #full {
         pub attrs: Vec<Attribute>,
@@ -515,9 +473,6 @@ ast_struct! {
 
 ast_struct! {
     /// A literal in place of an expression: `1`, `"foo"`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprLit {
         pub attrs: Vec<Attribute>,
@@ -527,8 +482,6 @@ ast_struct! {
 
 ast_struct! {
     /// Conditionless loop: `loop { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprLoop #full {
         pub attrs: Vec<Attribute>,
@@ -540,8 +493,6 @@ ast_struct! {
 
 ast_struct! {
     /// A macro invocation expression: `format!("{}", q)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprMacro #full {
         pub attrs: Vec<Attribute>,
@@ -551,8 +502,6 @@ ast_struct! {
 
 ast_struct! {
     /// A `match` expression: `match n { Some(n) => {}, None => {} }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprMatch #full {
         pub attrs: Vec<Attribute>,
@@ -565,8 +514,6 @@ ast_struct! {
 
 ast_struct! {
     /// A method call expression: `x.foo::<T>(a, b)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprMethodCall #full {
         pub attrs: Vec<Attribute>,
@@ -581,8 +528,6 @@ ast_struct! {
 
 ast_struct! {
     /// A parenthesized expression: `(a + b)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprParen {
         pub attrs: Vec<Attribute>,
@@ -596,9 +541,6 @@ ast_struct! {
     /// parameters and a qualified self-type.
     ///
     /// A plain identifier like `x` is a path of length 1.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprPath {
         pub attrs: Vec<Attribute>,
@@ -609,8 +551,6 @@ ast_struct! {
 
 ast_struct! {
     /// A range expression: `1..2`, `1..`, `..2`, `1..=2`, `..=2`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprRange #full {
         pub attrs: Vec<Attribute>,
@@ -622,8 +562,6 @@ ast_struct! {
 
 ast_struct! {
     /// A referencing operation: `&a` or `&mut a`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprReference #full {
         pub attrs: Vec<Attribute>,
@@ -635,8 +573,6 @@ ast_struct! {
 
 ast_struct! {
     /// An array literal constructed from one repeated element: `[0u8; N]`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprRepeat #full {
         pub attrs: Vec<Attribute>,
@@ -649,8 +585,6 @@ ast_struct! {
 
 ast_struct! {
     /// A `return`, with an optional value to be returned.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprReturn #full {
         pub attrs: Vec<Attribute>,
@@ -664,8 +598,6 @@ ast_struct! {
     ///
     /// The `rest` provides the value of the remaining fields as in `S { a:
     /// 1, b: 1, ..rest }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprStruct #full {
         pub attrs: Vec<Attribute>,
@@ -679,8 +611,6 @@ ast_struct! {
 
 ast_struct! {
     /// A try-expression: `expr?`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprTry #full {
         pub attrs: Vec<Attribute>,
@@ -691,8 +621,6 @@ ast_struct! {
 
 ast_struct! {
     /// A try block: `try { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprTryBlock #full {
         pub attrs: Vec<Attribute>,
@@ -703,8 +631,6 @@ ast_struct! {
 
 ast_struct! {
     /// A tuple expression: `(a, b, c, d)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprTuple #full {
         pub attrs: Vec<Attribute>,
@@ -715,8 +641,6 @@ ast_struct! {
 
 ast_struct! {
     /// A type ascription expression: `foo: f64`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprType #full {
         pub attrs: Vec<Attribute>,
@@ -728,9 +652,6 @@ ast_struct! {
 
 ast_struct! {
     /// A unary operation: `!x`, `*x`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ExprUnary {
         pub attrs: Vec<Attribute>,
@@ -741,8 +662,6 @@ ast_struct! {
 
 ast_struct! {
     /// An unsafe block: `unsafe { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprUnsafe #full {
         pub attrs: Vec<Attribute>,
@@ -753,8 +672,6 @@ ast_struct! {
 
 ast_struct! {
     /// A while loop: `while expr { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprWhile #full {
         pub attrs: Vec<Attribute>,
@@ -767,8 +684,6 @@ ast_struct! {
 
 ast_struct! {
     /// A yield expression: `yield expr`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ExprYield #full {
         pub attrs: Vec<Attribute>,
@@ -841,9 +756,6 @@ impl Expr {
 ast_enum! {
     /// A struct or tuple struct field accessed in a struct literal or field
     /// expression.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum Member {
         /// A named field like `self.x`.
@@ -911,9 +823,6 @@ impl IdentFragment for Member {
 
 ast_struct! {
     /// The index of an unnamed tuple struct field.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Index {
         pub index: u32,
@@ -960,8 +869,6 @@ impl IdentFragment for Index {
 ast_struct! {
     /// The `::<>` explicit type parameters passed to a method call:
     /// `parse::<u64>()`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct MethodTurbofish {
         pub colon2_token: Token![::],
@@ -974,8 +881,6 @@ ast_struct! {
 #[cfg(feature = "full")]
 ast_enum! {
     /// An individual generic argument to a method, like `T`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub enum GenericMethodArgument {
         /// A type argument.
@@ -991,8 +896,6 @@ ast_enum! {
 #[cfg(feature = "full")]
 ast_struct! {
     /// A field-value pair in a struct literal.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct FieldValue {
         /// Attributes tagged on the field.
@@ -1013,8 +916,6 @@ ast_struct! {
 #[cfg(feature = "full")]
 ast_struct! {
     /// A lifetime labeling a `for`, `while`, or `loop`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct Label {
         pub name: Lifetime,
@@ -1041,8 +942,6 @@ ast_struct! {
     /// #   false
     /// # }
     /// ```
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct Arm {
         pub attrs: Vec<Attribute>,
@@ -1057,8 +956,6 @@ ast_struct! {
 #[cfg(feature = "full")]
 ast_enum! {
     /// Limit types of a range, inclusive or exclusive.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub enum RangeLimits {
         /// Inclusive at the beginning, exclusive at the end.

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,6 +1,4 @@
 //! Extension traits to provide parsing methods on foreign types.
-//!
-//! *This module is available only if Syn is built with the `"parsing"` feature.*
 
 use crate::buffer::Cursor;
 use crate::parse::Peek;
@@ -13,8 +11,6 @@ use proc_macro2::Ident;
 ///
 /// This trait is sealed and cannot be implemented for types outside of Syn. It
 /// is implemented only for `proc_macro2::Ident`.
-///
-/// *This trait is available only if Syn is built with the `"parsing"` feature.*
 pub trait IdentExt: Sized + private::Sealed {
     /// Parses any identifier including keywords.
     ///

--- a/src/file.rs
+++ b/src/file.rs
@@ -3,8 +3,6 @@ use super::*;
 ast_struct! {
     /// A complete file of Rust source code.
     ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
-    ///
     /// # Example
     ///
     /// Parse a Rust source file into a `syn::File` and print out a debug

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -26,8 +26,6 @@ macro_rules! full {
 /// See the [module documentation] for details.
 ///
 /// [module documentation]: self
-///
-/// *This trait is available only if Syn is built with the `"fold"` feature.*
 pub trait Fold {
     #[cfg(any(feature = "derive", feature = "full"))]
     fn fold_abi(&mut self, i: Abi) -> Abi {

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -28,8 +28,6 @@ macro_rules! skip {
 /// See the [module documentation] for details.
 ///
 /// [module documentation]: self
-///
-/// *This trait is available only if Syn is built with the `"visit"` feature.*
 pub trait Visit<'ast> {
     #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_abi(&mut self, i: &'ast Abi) {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -29,8 +29,6 @@ macro_rules! skip {
 /// See the [module documentation] for details.
 ///
 /// [module documentation]: self
-///
-/// *This trait is available only if Syn is built with the `"visit-mut"` feature.*
 pub trait VisitMut {
     #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_abi_mut(&mut self, i: &mut Abi) {

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -13,9 +13,6 @@ ast_struct! {
     /// [generic parameters] and [where clause]. In some locations of the
     /// grammar, there may be other tokens in between these two things.
     ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
-    ///
     /// [generic parameters]: https://doc.rust-lang.org/stable/reference/items/generics.html#generic-parameters
     /// [where clause]: https://doc.rust-lang.org/stable/reference/items/generics.html#where-clauses
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
@@ -30,9 +27,6 @@ ast_struct! {
 ast_enum_of_structs! {
     /// A generic type parameter, lifetime, or const generic: `T: Into<String>`,
     /// `'a: 'b`, `const LEN: usize`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     ///
     /// # Syntax tree enum
     ///
@@ -54,9 +48,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A generic type parameter: `T: Into<String>`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeParam {
         pub attrs: Vec<Attribute>,
@@ -70,9 +61,6 @@ ast_struct! {
 
 ast_struct! {
     /// A lifetime definition: `'a: 'b + 'c + 'd`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct LifetimeDef {
         pub attrs: Vec<Attribute>,
@@ -84,9 +72,6 @@ ast_struct! {
 
 ast_struct! {
     /// A const generic parameter: `const LENGTH: usize`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ConstParam {
         pub attrs: Vec<Attribute>,
@@ -295,9 +280,6 @@ impl<'a> Iterator for ConstParamsMut<'a> {
 }
 
 /// Returned by `Generics::split_for_impl`.
-///
-/// *This type is available only if Syn is built with the `"derive"` or `"full"`
-/// feature and the `"printing"` feature.*
 #[cfg(feature = "printing")]
 #[cfg_attr(
     doc_cfg,
@@ -306,9 +288,6 @@ impl<'a> Iterator for ConstParamsMut<'a> {
 pub struct ImplGenerics<'a>(&'a Generics);
 
 /// Returned by `Generics::split_for_impl`.
-///
-/// *This type is available only if Syn is built with the `"derive"` or `"full"`
-/// feature and the `"printing"` feature.*
 #[cfg(feature = "printing")]
 #[cfg_attr(
     doc_cfg,
@@ -317,9 +296,6 @@ pub struct ImplGenerics<'a>(&'a Generics);
 pub struct TypeGenerics<'a>(&'a Generics);
 
 /// Returned by `TypeGenerics::as_turbofish`.
-///
-/// *This type is available only if Syn is built with the `"derive"` or `"full"`
-/// feature and the `"printing"` feature.*
 #[cfg(feature = "printing")]
 #[cfg_attr(
     doc_cfg,
@@ -347,9 +323,6 @@ impl Generics {
     /// }
     /// # ;
     /// ```
-    ///
-    /// *This method is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature and the `"printing"` feature.*
     #[cfg_attr(
         doc_cfg,
         doc(cfg(all(any(feature = "full", feature = "derive"), feature = "printing")))
@@ -417,9 +390,6 @@ generics_wrapper_impls!(Turbofish);
 #[cfg(feature = "printing")]
 impl<'a> TypeGenerics<'a> {
     /// Turn a type's generics like `<X, Y>` into a turbofish like `::<X, Y>`.
-    ///
-    /// *This method is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature and the `"printing"` feature.*
     pub fn as_turbofish(&self) -> Turbofish {
         Turbofish(self.0)
     }
@@ -427,9 +397,6 @@ impl<'a> TypeGenerics<'a> {
 
 ast_struct! {
     /// A set of bound lifetimes: `for<'a, 'b, 'c>`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct BoundLifetimes {
         pub for_token: Token![for],
@@ -476,9 +443,6 @@ impl From<Ident> for TypeParam {
 
 ast_enum_of_structs! {
     /// A trait or lifetime used as a bound on a type parameter.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum TypeParamBound {
         Trait(TraitBound),
@@ -488,9 +452,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A trait used as a bound on a type parameter.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TraitBound {
         pub paren_token: Option<token::Paren>,
@@ -505,9 +466,6 @@ ast_struct! {
 ast_enum! {
     /// A modifier on a trait bound, currently only used for the `?` in
     /// `?Sized`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum TraitBoundModifier {
         None,
@@ -518,9 +476,6 @@ ast_enum! {
 ast_struct! {
     /// A `where` clause in a definition: `where T: Deserialize<'de>, D:
     /// 'static`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct WhereClause {
         pub where_token: Token![where],
@@ -530,9 +485,6 @@ ast_struct! {
 
 ast_enum_of_structs! {
     /// A single predicate in a `where` clause: `T: Deserialize<'de>`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     ///
     /// # Syntax tree enum
     ///
@@ -554,9 +506,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A type predicate in a `where` clause: `for<'c> Foo<'c>: Trait<'c>`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct PredicateType {
         /// Any lifetimes from a `for` binding
@@ -571,9 +520,6 @@ ast_struct! {
 
 ast_struct! {
     /// A lifetime predicate in a `where` clause: `'a: 'b + 'c`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct PredicateLifetime {
         pub lifetime: Lifetime,
@@ -584,9 +530,6 @@ ast_struct! {
 
 ast_struct! {
     /// An equality predicate in a `where` clause (unsupported).
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct PredicateEq {
         pub lhs_ty: Type,

--- a/src/item.rs
+++ b/src/item.rs
@@ -9,8 +9,6 @@ use std::mem;
 ast_enum_of_structs! {
     /// Things that can appear directly inside of a module or scope.
     ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
-    ///
     /// # Syntax tree enum
     ///
     /// This type is a [syntax tree enum].
@@ -98,8 +96,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A constant item: `const MAX: u16 = 65535`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemConst {
         pub attrs: Vec<Attribute>,
@@ -116,8 +112,6 @@ ast_struct! {
 
 ast_struct! {
     /// An enum definition: `enum Foo<A, B> { A(A), B(B) }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemEnum {
         pub attrs: Vec<Attribute>,
@@ -132,8 +126,6 @@ ast_struct! {
 
 ast_struct! {
     /// An `extern crate` item: `extern crate serde`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemExternCrate {
         pub attrs: Vec<Attribute>,
@@ -147,10 +139,7 @@ ast_struct! {
 }
 
 ast_struct! {
-    /// A free-standing function: `fn process(n: usize) -> Result<()> { ...
-    /// }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
+    /// A free-standing function: `fn process(n: usize) -> Result<()> { ... }`.
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemFn {
         pub attrs: Vec<Attribute>,
@@ -162,8 +151,6 @@ ast_struct! {
 
 ast_struct! {
     /// A block of foreign items: `extern "C" { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemForeignMod {
         pub attrs: Vec<Attribute>,
@@ -176,8 +163,6 @@ ast_struct! {
 ast_struct! {
     /// An impl block providing trait or associated items: `impl<A> Trait
     /// for Data<A> { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemImpl {
         pub attrs: Vec<Attribute>,
@@ -196,8 +181,6 @@ ast_struct! {
 
 ast_struct! {
     /// A macro invocation, which includes `macro_rules!` definitions.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemMacro {
         pub attrs: Vec<Attribute>,
@@ -210,8 +193,6 @@ ast_struct! {
 
 ast_struct! {
     /// A 2.0-style declarative macro introduced by the `macro` keyword.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemMacro2 {
         pub attrs: Vec<Attribute>,
@@ -224,8 +205,6 @@ ast_struct! {
 
 ast_struct! {
     /// A module or module declaration: `mod m` or `mod m { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemMod {
         pub attrs: Vec<Attribute>,
@@ -239,8 +218,6 @@ ast_struct! {
 
 ast_struct! {
     /// A static item: `static BIKE: Shed = Shed(42)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemStatic {
         pub attrs: Vec<Attribute>,
@@ -258,8 +235,6 @@ ast_struct! {
 
 ast_struct! {
     /// A struct definition: `struct Foo<A> { x: A }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemStruct {
         pub attrs: Vec<Attribute>,
@@ -274,8 +249,6 @@ ast_struct! {
 
 ast_struct! {
     /// A trait definition: `pub trait Iterator { ... }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemTrait {
         pub attrs: Vec<Attribute>,
@@ -294,8 +267,6 @@ ast_struct! {
 
 ast_struct! {
     /// A trait alias: `pub trait SharableIterator = Iterator + Sync`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemTraitAlias {
         pub attrs: Vec<Attribute>,
@@ -311,8 +282,6 @@ ast_struct! {
 
 ast_struct! {
     /// A type alias: `type Result<T> = std::result::Result<T, MyError>`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemType {
         pub attrs: Vec<Attribute>,
@@ -328,8 +297,6 @@ ast_struct! {
 
 ast_struct! {
     /// A union definition: `union Foo<A, B> { x: A, y: B }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemUnion {
         pub attrs: Vec<Attribute>,
@@ -343,8 +310,6 @@ ast_struct! {
 
 ast_struct! {
     /// A use declaration: `use std::collections::HashMap`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ItemUse {
         pub attrs: Vec<Attribute>,
@@ -467,8 +432,6 @@ impl From<ItemUnion> for DeriveInput {
 ast_enum_of_structs! {
     /// A suffix of an import tree in a `use` item: `Type as Renamed` or `*`.
     ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
-    ///
     /// # Syntax tree enum
     ///
     /// This type is a [syntax tree enum].
@@ -495,8 +458,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A path prefix of imports in a `use` item: `std::...`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct UsePath {
         pub ident: Ident,
@@ -507,8 +468,6 @@ ast_struct! {
 
 ast_struct! {
     /// An identifier imported by a `use` item: `HashMap`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct UseName {
         pub ident: Ident,
@@ -517,8 +476,6 @@ ast_struct! {
 
 ast_struct! {
     /// An renamed identifier imported by a `use` item: `HashMap as Map`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct UseRename {
         pub ident: Ident,
@@ -529,8 +486,6 @@ ast_struct! {
 
 ast_struct! {
     /// A glob import in a `use` item: `*`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct UseGlob {
         pub star_token: Token![*],
@@ -539,8 +494,6 @@ ast_struct! {
 
 ast_struct! {
     /// A braced group of imports in a `use` item: `{A, B, C}`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct UseGroup {
         pub brace_token: token::Brace,
@@ -550,8 +503,6 @@ ast_struct! {
 
 ast_enum_of_structs! {
     /// An item within an `extern` block.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     ///
     /// # Syntax tree enum
     ///
@@ -602,8 +553,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A foreign function in an `extern` block.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ForeignItemFn {
         pub attrs: Vec<Attribute>,
@@ -615,8 +564,6 @@ ast_struct! {
 
 ast_struct! {
     /// A foreign static item in an `extern` block: `static ext: u8`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ForeignItemStatic {
         pub attrs: Vec<Attribute>,
@@ -632,8 +579,6 @@ ast_struct! {
 
 ast_struct! {
     /// A foreign type in an `extern` block: `type void`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ForeignItemType {
         pub attrs: Vec<Attribute>,
@@ -646,8 +591,6 @@ ast_struct! {
 
 ast_struct! {
     /// A macro invocation within an extern block.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ForeignItemMacro {
         pub attrs: Vec<Attribute>,
@@ -658,8 +601,6 @@ ast_struct! {
 
 ast_enum_of_structs! {
     /// An item declaration within the definition of a trait.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     ///
     /// # Syntax tree enum
     ///
@@ -710,8 +651,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// An associated constant within the definition of a trait.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct TraitItemConst {
         pub attrs: Vec<Attribute>,
@@ -726,8 +665,6 @@ ast_struct! {
 
 ast_struct! {
     /// A trait method within the definition of a trait.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct TraitItemMethod {
         pub attrs: Vec<Attribute>,
@@ -739,8 +676,6 @@ ast_struct! {
 
 ast_struct! {
     /// An associated type within the definition of a trait.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct TraitItemType {
         pub attrs: Vec<Attribute>,
@@ -756,8 +691,6 @@ ast_struct! {
 
 ast_struct! {
     /// A macro invocation within the definition of a trait.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct TraitItemMacro {
         pub attrs: Vec<Attribute>,
@@ -768,8 +701,6 @@ ast_struct! {
 
 ast_enum_of_structs! {
     /// An item within an impl block.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     ///
     /// # Syntax tree enum
     ///
@@ -820,8 +751,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// An associated constant within an impl block.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ImplItemConst {
         pub attrs: Vec<Attribute>,
@@ -839,8 +768,6 @@ ast_struct! {
 
 ast_struct! {
     /// A method within an impl block.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ImplItemMethod {
         pub attrs: Vec<Attribute>,
@@ -853,8 +780,6 @@ ast_struct! {
 
 ast_struct! {
     /// An associated type within an impl block.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ImplItemType {
         pub attrs: Vec<Attribute>,
@@ -871,8 +796,6 @@ ast_struct! {
 
 ast_struct! {
     /// A macro invocation within an impl block.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct ImplItemMacro {
         pub attrs: Vec<Attribute>,
@@ -884,8 +807,6 @@ ast_struct! {
 ast_struct! {
     /// A function signature in a trait or implementation: `unsafe fn
     /// initialize(&self)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct Signature {
         pub constness: Option<Token![const]>,
@@ -922,8 +843,6 @@ impl Signature {
 
 ast_enum_of_structs! {
     /// An argument in a function signature: the `n: usize` in `fn f(n: usize)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub enum FnArg {
         /// The `self` argument of an associated method, whether taken by value
@@ -944,8 +863,6 @@ ast_struct! {
     ///
     /// Note that `self` receivers with a specified type, such as `self:
     /// Box<Self>`, are parsed as a `FnArg::Typed`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct Receiver {
         pub attrs: Vec<Attribute>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,8 +530,6 @@ mod gen {
     /// /* ... */
     /// ```
     ///
-    /// *This module is available only if Syn is built with the `"fold"` feature.*
-    ///
     /// <br>
     ///
     /// # Example
@@ -612,8 +610,6 @@ mod gen {
     ///
     /// /* ... */
     /// ```
-    ///
-    /// *This module is available only if Syn is built with the `"visit"` feature.*
     ///
     /// <br>
     ///
@@ -735,9 +731,6 @@ mod gen {
     /// /* ... */
     /// ```
     ///
-    /// *This module is available only if Syn is built with the `"visit-mut"`
-    /// feature.*
-    ///
     /// <br>
     ///
     /// # Example
@@ -831,9 +824,6 @@ pub mod __private;
 ///
 /// [`syn::parse2`]: parse2
 ///
-/// *This function is available only if Syn is built with both the `"parsing"` and
-/// `"proc-macro"` features.*
-///
 /// # Examples
 ///
 /// ```
@@ -881,8 +871,6 @@ pub fn parse<T: parse::Parse>(tokens: proc_macro::TokenStream) -> Result<T> {
 /// instead.
 ///
 /// [`syn::parse`]: parse()
-///
-/// *This function is available only if Syn is built with the `"parsing"` feature.*
 #[cfg(feature = "parsing")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
 pub fn parse2<T: parse::Parse>(tokens: proc_macro2::TokenStream) -> Result<T> {
@@ -890,8 +878,6 @@ pub fn parse2<T: parse::Parse>(tokens: proc_macro2::TokenStream) -> Result<T> {
 }
 
 /// Parse a string of Rust code into the chosen syntax tree node.
-///
-/// *This function is available only if Syn is built with the `"parsing"` feature.*
 ///
 /// # Hygiene
 ///
@@ -928,9 +914,6 @@ pub fn parse_str<T: parse::Parse>(s: &str) -> Result<T> {
 /// - It preserves the shebang line of the file, such as `#!/usr/bin/env rustx`.
 ///
 /// If present, either of these would be an error using `from_str`.
-///
-/// *This function is available only if Syn is built with the `"parsing"` and
-/// `"full"` features.*
 ///
 /// # Examples
 ///

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -11,9 +11,6 @@ use crate::parse::{Parse, ParseStream, Parser, Result};
 
 ast_struct! {
     /// A macro invocation: `println!("{}", mac)`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Macro {
         pub path: Path,
@@ -25,9 +22,6 @@ ast_struct! {
 
 ast_enum! {
     /// A grouping token that surrounds a macro body: `m!(...)` or `m!{...}` or `m![...]`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum MacroDelimiter {
         Paren(Paren),

--- a/src/op.rs
+++ b/src/op.rs
@@ -1,8 +1,5 @@
 ast_enum! {
     /// A binary operator: `+`, `+=`, `&`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum BinOp {
         /// The `+` operator (addition)
@@ -66,9 +63,6 @@ ast_enum! {
 
 ast_enum! {
     /// A unary operator: `*`, `!`, `-`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum UnOp {
         /// The `*` operator for dereferencing

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -178,10 +178,6 @@
 //!     Ok(())
 //! }
 //! ```
-//!
-//! ---
-//!
-//! *This module is available only if Syn is built with the `"parsing"` feature.*
 
 #[path = "discouraged.rs"]
 pub mod discouraged;
@@ -1191,8 +1187,6 @@ impl Parse for Literal {
 /// Refer to the [module documentation] for details about parsing in Syn.
 ///
 /// [module documentation]: self
-///
-/// *This trait is available only if Syn is built with the `"parsing"` feature.*
 pub trait Parser: Sized {
     type Output;
 
@@ -1206,13 +1200,11 @@ pub trait Parser: Sized {
     ///
     /// This function will check that the input is fully parsed. If there are
     /// any unparsed tokens at the end of the stream, an error is returned.
-    ///
-    /// *This method is available only if Syn is built with both the `"parsing"` and
-    /// `"proc-macro"` features.*
     #[cfg(all(
         not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "wasi"))),
         feature = "proc-macro"
     ))]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "proc-macro")))]
     fn parse(self, tokens: proc_macro::TokenStream) -> Result<Self::Output> {
         self.parse2(proc_macro2::TokenStream::from(tokens))
     }

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -6,8 +6,6 @@ ast_enum_of_structs! {
     /// A pattern in a local binding, function signature, match expression, or
     /// various other places.
     ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
-    ///
     /// # Syntax tree enum
     ///
     /// This type is a [syntax tree enum].
@@ -99,8 +97,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A box pattern: `box v`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatBox {
         pub attrs: Vec<Attribute>,
@@ -114,8 +110,6 @@ ast_struct! {
     ///
     /// It may also be a unit struct or struct variant (e.g. `None`), or a
     /// constant; these cannot be distinguished syntactically.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatIdent {
         pub attrs: Vec<Attribute>,
@@ -131,8 +125,6 @@ ast_struct! {
     ///
     /// This holds an `Expr` rather than a `Lit` because negative numbers
     /// are represented as an `Expr::Unary`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatLit {
         pub attrs: Vec<Attribute>,
@@ -142,8 +134,6 @@ ast_struct! {
 
 ast_struct! {
     /// A macro in pattern position.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatMacro {
         pub attrs: Vec<Attribute>,
@@ -153,8 +143,6 @@ ast_struct! {
 
 ast_struct! {
     /// A pattern that matches any one of a set of cases.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatOr {
         pub attrs: Vec<Attribute>,
@@ -171,8 +159,6 @@ ast_struct! {
     /// constants or associated constants. Qualified path patterns like
     /// `<A>::B::C` and `<A as Trait>::B::C` can only legally refer to
     /// associated constants.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatPath {
         pub attrs: Vec<Attribute>,
@@ -183,8 +169,6 @@ ast_struct! {
 
 ast_struct! {
     /// A range pattern: `1..=2`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatRange {
         pub attrs: Vec<Attribute>,
@@ -196,8 +180,6 @@ ast_struct! {
 
 ast_struct! {
     /// A reference pattern: `&mut var`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatReference {
         pub attrs: Vec<Attribute>,
@@ -209,8 +191,6 @@ ast_struct! {
 
 ast_struct! {
     /// The dots in a tuple or slice pattern: `[0, 1, ..]`
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatRest {
         pub attrs: Vec<Attribute>,
@@ -220,8 +200,6 @@ ast_struct! {
 
 ast_struct! {
     /// A dynamically sized slice pattern: `[a, b, ref i @ .., y, z]`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatSlice {
         pub attrs: Vec<Attribute>,
@@ -232,8 +210,6 @@ ast_struct! {
 
 ast_struct! {
     /// A struct or struct variant pattern: `Variant { x, y, .. }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatStruct {
         pub attrs: Vec<Attribute>,
@@ -246,8 +222,6 @@ ast_struct! {
 
 ast_struct! {
     /// A tuple pattern: `(a, b)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatTuple {
         pub attrs: Vec<Attribute>,
@@ -258,8 +232,6 @@ ast_struct! {
 
 ast_struct! {
     /// A tuple struct or tuple variant pattern: `Variant(x, y, .., z)`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatTupleStruct {
         pub attrs: Vec<Attribute>,
@@ -270,8 +242,6 @@ ast_struct! {
 
 ast_struct! {
     /// A type ascription pattern: `foo: f64`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatType {
         pub attrs: Vec<Attribute>,
@@ -283,8 +253,6 @@ ast_struct! {
 
 ast_struct! {
     /// A pattern that matches any value: `_`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct PatWild {
         pub attrs: Vec<Attribute>,
@@ -297,8 +265,6 @@ ast_struct! {
     ///
     /// Patterns like the fields of Foo `{ x, ref y, ref mut z }` are treated
     /// the same as `x: x, y: ref y, z: ref mut z` but there is no colon token.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct FieldPat {
         pub attrs: Vec<Attribute>,

--- a/src/path.rs
+++ b/src/path.rs
@@ -3,9 +3,6 @@ use crate::punctuated::Punctuated;
 
 ast_struct! {
     /// A path at which a named item is exported (e.g. `std::collections::HashMap`).
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Path {
         pub leading_colon: Option<Token![::]>,
@@ -29,9 +26,6 @@ where
 
 ast_struct! {
     /// A segment of a path together with any path arguments on that segment.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct PathSegment {
         pub ident: Ident,
@@ -53,9 +47,6 @@ where
 
 ast_enum! {
     /// Angle bracketed or parenthesized arguments of a path segment.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     ///
     /// ## Angle bracketed
     ///
@@ -99,9 +90,6 @@ impl PathArguments {
 
 ast_enum! {
     /// An individual generic argument, like `'a`, `T`, or `Item = T`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum GenericArgument {
         /// A lifetime argument.
@@ -124,9 +112,6 @@ ast_enum! {
 ast_struct! {
     /// Angle bracketed arguments of a path segment: the `<K, V>` in `HashMap<K,
     /// V>`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct AngleBracketedGenericArguments {
         pub colon2_token: Option<Token![::]>,
@@ -138,9 +123,6 @@ ast_struct! {
 
 ast_struct! {
     /// A binding (equality constraint) on an associated type: `Item = u8`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Binding {
         pub ident: Ident,
@@ -151,9 +133,6 @@ ast_struct! {
 
 ast_struct! {
     /// An associated type bound: `Iterator<Item: Display>`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Constraint {
         pub ident: Ident,
@@ -165,9 +144,6 @@ ast_struct! {
 ast_struct! {
     /// Arguments of a function path segment: the `(A, B) -> C` in `Fn(A,B) ->
     /// C`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct ParenthesizedGenericArguments {
         pub paren_token: token::Paren,
@@ -195,9 +171,6 @@ ast_struct! {
     ///  ^~~~~~   ^
     ///  ty       position = 0
     /// ```
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct QSelf {
         pub lt_token: Token![<],
@@ -471,9 +444,6 @@ pub mod parsing {
     impl Path {
         /// Parse a `Path` containing no path arguments on any of its segments.
         ///
-        /// *This function is available only if Syn is built with the `"parsing"`
-        /// feature.*
-        ///
         /// # Example
         ///
         /// ```
@@ -546,9 +516,6 @@ pub mod parsing {
         ///   path arguments, and
         /// - the ident of the first path segment is equal to the given one.
         ///
-        /// *This function is available only if Syn is built with the `"parsing"`
-        /// feature.*
-        ///
         /// # Example
         ///
         /// ```
@@ -586,9 +553,6 @@ pub mod parsing {
         /// - the number of path segments is 1, and
         /// - the first path segment has no angle bracketed or parenthesized
         ///   path arguments.
-        ///
-        /// *This function is available only if Syn is built with the `"parsing"`
-        /// feature.*
         #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
         pub fn get_ident(&self) -> Option<&Ident> {
             if self.leading_colon.is_none()

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -260,9 +260,6 @@ impl<T, P> Punctuated<T, P> {
     ///
     /// Parsing continues until the end of this parse stream. The entire content
     /// of this parse stream must consist of `T` and `P`.
-    ///
-    /// *This function is available only if Syn is built with the `"parsing"`
-    /// feature.*
     #[cfg(feature = "parsing")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_terminated(input: ParseStream) -> Result<Self>
@@ -281,9 +278,6 @@ impl<T, P> Punctuated<T, P> {
     /// to be parsed.
     ///
     /// [`parse_terminated`]: Punctuated::parse_terminated
-    ///
-    /// *This function is available only if Syn is built with the `"parsing"`
-    /// feature.*
     #[cfg(feature = "parsing")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_terminated_with(
@@ -318,9 +312,6 @@ impl<T, P> Punctuated<T, P> {
     /// the stream. This method returns upon parsing a `T` and observing that it
     /// is not followed by a `P`, even if there are remaining tokens in the
     /// stream.
-    ///
-    /// *This function is available only if Syn is built with the `"parsing"`
-    /// feature.*
     #[cfg(feature = "parsing")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_separated_nonempty(input: ParseStream) -> Result<Self>
@@ -339,9 +330,6 @@ impl<T, P> Punctuated<T, P> {
     /// the entire content of this stream.
     ///
     /// [`parse_separated_nonempty`]: Punctuated::parse_separated_nonempty
-    ///
-    /// *This function is available only if Syn is built with the `"parsing"`
-    /// feature.*
     #[cfg(feature = "parsing")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     pub fn parse_separated_nonempty_with(

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,9 +1,6 @@
 //! A trait that can provide the `Span` of the complete contents of a syntax
 //! tree node.
 //!
-//! *This module is available only if Syn is built with both the `"parsing"` and
-//! `"printing"` features.*
-//!
 //! <br>
 //!
 //! # Example
@@ -96,9 +93,6 @@ use quote::spanned::Spanned as ToTokens;
 /// See the [module documentation] for an example.
 ///
 /// [module documentation]: self
-///
-/// *This trait is available only if Syn is built with both the `"parsing"` and
-/// `"printing"` features.*
 pub trait Spanned {
     /// Returns a `Span` covering the complete contents of this syntax tree
     /// node, or [`Span::call_site()`] if this node is empty.

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -2,8 +2,6 @@ use super::*;
 
 ast_struct! {
     /// A braced block containing Rust statements.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct Block {
         pub brace_token: token::Brace,
@@ -14,8 +12,6 @@ ast_struct! {
 
 ast_enum! {
     /// A statement, usually ending in a semicolon.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub enum Stmt {
         /// A local (let) binding.
@@ -31,8 +27,6 @@ ast_enum! {
 
 ast_struct! {
     /// A local `let` binding: `let x: u64 = s.parse()?`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct Local {
         pub attrs: Vec<Attribute>,
@@ -49,8 +43,6 @@ ast_struct! {
     ///
     /// `LocalInit` represents `= s.parse()?` in `let x: u64 = s.parse()?` and
     /// `= r else { return }` in `let Ok(x) = r else { return }`.
-    ///
-    /// *This type is available only if Syn is built with the `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(feature = "full")))]
     pub struct LocalInit {
         pub eq_token: Token![=],
@@ -71,9 +63,6 @@ pub mod parsing {
     impl Block {
         /// Parse the body of a block as zero or more statements, possibly
         /// including one trailing expression.
-        ///
-        /// *This function is available only if Syn is built with the `"parsing"`
-        /// feature.*
         ///
         /// # Example
         ///

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -5,9 +5,6 @@ use proc_macro2::TokenStream;
 ast_enum_of_structs! {
     /// The possible types that a Rust value could have.
     ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
-    ///
     /// # Syntax tree enum
     ///
     /// This type is a [syntax tree enum].
@@ -90,9 +87,6 @@ ast_enum_of_structs! {
 
 ast_struct! {
     /// A fixed size array type: `[T; n]`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeArray {
         pub bracket_token: token::Bracket,
@@ -104,9 +98,6 @@ ast_struct! {
 
 ast_struct! {
     /// A bare function type: `fn(usize) -> bool`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeBareFn {
         pub lifetimes: Option<BoundLifetimes>,
@@ -122,9 +113,6 @@ ast_struct! {
 
 ast_struct! {
     /// A type contained within invisible delimiters.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeGroup {
         pub group_token: token::Group,
@@ -135,9 +123,6 @@ ast_struct! {
 ast_struct! {
     /// An `impl Bound1 + Bound2 + Bound3` type where `Bound` is a trait or
     /// a lifetime.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeImplTrait {
         pub impl_token: Token![impl],
@@ -147,9 +132,6 @@ ast_struct! {
 
 ast_struct! {
     /// Indication that a type should be inferred by the compiler: `_`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeInfer {
         pub underscore_token: Token![_],
@@ -158,9 +140,6 @@ ast_struct! {
 
 ast_struct! {
     /// A macro in the type position.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeMacro {
         pub mac: Macro,
@@ -169,9 +148,6 @@ ast_struct! {
 
 ast_struct! {
     /// The never type: `!`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeNever {
         pub bang_token: Token![!],
@@ -180,9 +156,6 @@ ast_struct! {
 
 ast_struct! {
     /// A parenthesized type equivalent to the inner type.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeParen {
         pub paren_token: token::Paren,
@@ -193,9 +166,6 @@ ast_struct! {
 ast_struct! {
     /// A path like `std::slice::Iter`, optionally qualified with a
     /// self-type as in `<Vec<T> as SomeTrait>::Associated`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypePath {
         pub qself: Option<QSelf>,
@@ -205,9 +175,6 @@ ast_struct! {
 
 ast_struct! {
     /// A raw pointer type: `*const T` or `*mut T`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypePtr {
         pub star_token: Token![*],
@@ -219,9 +186,6 @@ ast_struct! {
 
 ast_struct! {
     /// A reference type: `&'a T` or `&'a mut T`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeReference {
         pub and_token: Token![&],
@@ -233,9 +197,6 @@ ast_struct! {
 
 ast_struct! {
     /// A dynamically sized slice type: `[T]`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeSlice {
         pub bracket_token: token::Bracket,
@@ -246,9 +207,6 @@ ast_struct! {
 ast_struct! {
     /// A trait object type `dyn Bound1 + Bound2 + Bound3` where `Bound` is a
     /// trait or a lifetime.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeTraitObject {
         pub dyn_token: Option<Token![dyn]>,
@@ -258,9 +216,6 @@ ast_struct! {
 
 ast_struct! {
     /// A tuple type: `(A, B, C, String)`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or
-    /// `"full"` feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeTuple {
         pub paren_token: token::Paren,
@@ -270,9 +225,6 @@ ast_struct! {
 
 ast_struct! {
     /// The binary interface of a function: `extern "C"`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Abi {
         pub extern_token: Token![extern],
@@ -282,9 +234,6 @@ ast_struct! {
 
 ast_struct! {
     /// An argument in a function type: the `usize` in `fn(usize) -> bool`.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct BareFnArg {
         pub attrs: Vec<Attribute>,
@@ -305,9 +254,6 @@ ast_struct! {
     ///     //                               ^^^
     /// }
     /// ```
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Variadic {
         pub attrs: Vec<Attribute>,
@@ -317,9 +263,6 @@ ast_struct! {
 
 ast_enum! {
     /// Return type of a function signature.
-    ///
-    /// *This type is available only if Syn is built with the `"derive"` or `"full"`
-    /// feature.*
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum ReturnType {
         /// Return type is not specified.


### PR DESCRIPTION
This was originally deferred from #925.