### PR TITLE
Add `Item::attrs` to get the attributes of an item if available

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -347,6 +347,32 @@ impl Item {
             _ => unreachable!(),
         }
     }
+
+    #[cfg(feature = "parsing")]
+    pub fn attrs(&self) -> Option<&Vec<Attribute>> {
+        match self {
+            Item::ExternCrate(ItemExternCrate { attrs, .. })
+            | Item::Use(ItemUse { attrs, .. })
+            | Item::Static(ItemStatic { attrs, .. })
+            | Item::Const(ItemConst { attrs, .. })
+            | Item::Fn(ItemFn { attrs, .. })
+            | Item::Mod(ItemMod { attrs, .. })
+            | Item::ForeignMod(ItemForeignMod { attrs, .. })
+            | Item::Type(ItemType { attrs, .. })
+            | Item::Struct(ItemStruct { attrs, .. })
+            | Item::Enum(ItemEnum { attrs, .. })
+            | Item::Union(ItemUnion { attrs, .. })
+            | Item::Trait(ItemTrait { attrs, .. })
+            | Item::TraitAlias(ItemTraitAlias { attrs, .. })
+            | Item::Impl(ItemImpl { attrs, .. })
+            | Item::Macro(ItemMacro { attrs, .. })
+            | Item::Macro2(ItemMacro2 { attrs, .. }) => Some(attrs),
+            Item::Verbatim(_) => None,
+
+            #[cfg(syn_no_non_exhaustive)]
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl From<DeriveInput> for Item {


### PR DESCRIPTION
Hello, thanks for the crate!

When looking at `Item` I was surprised not to find APIs that ease its use, without having to pattern-match every time, like for [`rustc_hir::ItemKind`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/hir/enum.ItemKind.html). This PR add a convenience method to have an easy access to the attributes of an item. 

I don't know the policy about new APIs, so feel free to close if deemed out-of-scope. About the feature-flag to use and the documentation I can fix what's needed, when for `parsing` as a first guess.

As a side note `test_expr_size` and `test_type_size` fail on arm64 (M1).