### PR TITLE
Add Expr::Const variant for const blocks

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -224,6 +224,8 @@ impl Clone for Expr {
             #[cfg(feature = "full")]
             Expr::Closure(v0) => Expr::Closure(v0.clone()),
             #[cfg(feature = "full")]
+            Expr::Const(v0) => Expr::Const(v0.clone()),
+            #[cfg(feature = "full")]
             Expr::Continue(v0) => Expr::Continue(v0.clone()),
             Expr::Field(v0) => Expr::Field(v0.clone()),
             #[cfg(feature = "full")]
@@ -420,6 +422,17 @@ impl Clone for ExprClosure {
             or2_token: self.or2_token.clone(),
             output: self.output.clone(),
             body: self.body.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for ExprConst {
+    fn clone(&self) -> Self {
+        ExprConst {
+            attrs: self.attrs.clone(),
+            const_token: self.const_token.clone(),
+            block: self.block.clone(),
         }
     }
 }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -426,6 +426,12 @@ impl Debug for Expr {
                 formatter.finish()
             }
             #[cfg(feature = "full")]
+            Expr::Const(v0) => {
+                let mut formatter = formatter.debug_tuple("Const");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            #[cfg(feature = "full")]
             Expr::Continue(v0) => {
                 let mut formatter = formatter.debug_tuple("Continue");
                 formatter.field(v0);
@@ -734,6 +740,17 @@ impl Debug for ExprClosure {
         formatter.field("or2_token", &self.or2_token);
         formatter.field("output", &self.output);
         formatter.field("body", &self.body);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for ExprConst {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ExprConst");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("const_token", &self.const_token);
+        formatter.field("block", &self.block);
         formatter.finish()
     }
 }

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -246,6 +246,8 @@ impl PartialEq for Expr {
             #[cfg(feature = "full")]
             (Expr::Closure(self0), Expr::Closure(other0)) => self0 == other0,
             #[cfg(feature = "full")]
+            (Expr::Const(self0), Expr::Const(other0)) => self0 == other0,
+            #[cfg(feature = "full")]
             (Expr::Continue(self0), Expr::Continue(other0)) => self0 == other0,
             (Expr::Field(self0), Expr::Field(other0)) => self0 == other0,
             #[cfg(feature = "full")]
@@ -425,6 +427,16 @@ impl PartialEq for ExprClosure {
             && self.asyncness == other.asyncness && self.capture == other.capture
             && self.inputs == other.inputs && self.output == other.output
             && self.body == other.body
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for ExprConst {}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for ExprConst {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.block == other.block
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -151,6 +151,10 @@ pub trait Fold {
         fold_expr_closure(self, i)
     }
     #[cfg(feature = "full")]
+    fn fold_expr_const(&mut self, i: ExprConst) -> ExprConst {
+        fold_expr_const(self, i)
+    }
+    #[cfg(feature = "full")]
     fn fold_expr_continue(&mut self, i: ExprContinue) -> ExprContinue {
         fold_expr_continue(self, i)
     }
@@ -1089,6 +1093,7 @@ where
         Expr::Closure(_binding_0) => {
             Expr::Closure(full!(f.fold_expr_closure(_binding_0)))
         }
+        Expr::Const(_binding_0) => Expr::Const(full!(f.fold_expr_const(_binding_0))),
         Expr::Continue(_binding_0) => {
             Expr::Continue(full!(f.fold_expr_continue(_binding_0)))
         }
@@ -1276,6 +1281,17 @@ where
         or2_token: Token![|](tokens_helper(f, &node.or2_token.spans)),
         output: f.fold_return_type(node.output),
         body: Box::new(f.fold_expr(*node.body)),
+    }
+}
+#[cfg(feature = "full")]
+pub fn fold_expr_const<F>(f: &mut F, node: ExprConst) -> ExprConst
+where
+    F: Fold + ?Sized,
+{
+    ExprConst {
+        attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
+        const_token: Token![const](tokens_helper(f, &node.const_token.span)),
+        block: f.fold_block(node.block),
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -365,136 +365,141 @@ impl Hash for Expr {
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Continue(v0) => {
+            Expr::Const(v0) => {
                 state.write_u8(12u8);
                 v0.hash(state);
             }
-            Expr::Field(v0) => {
+            #[cfg(feature = "full")]
+            Expr::Continue(v0) => {
                 state.write_u8(13u8);
                 v0.hash(state);
             }
-            #[cfg(feature = "full")]
-            Expr::ForLoop(v0) => {
+            Expr::Field(v0) => {
                 state.write_u8(14u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Group(v0) => {
+            Expr::ForLoop(v0) => {
                 state.write_u8(15u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::If(v0) => {
+            Expr::Group(v0) => {
                 state.write_u8(16u8);
                 v0.hash(state);
             }
-            Expr::Index(v0) => {
+            #[cfg(feature = "full")]
+            Expr::If(v0) => {
                 state.write_u8(17u8);
+                v0.hash(state);
+            }
+            Expr::Index(v0) => {
+                state.write_u8(18u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
             Expr::Let(v0) => {
-                state.write_u8(18u8);
-                v0.hash(state);
-            }
-            Expr::Lit(v0) => {
                 state.write_u8(19u8);
                 v0.hash(state);
             }
-            #[cfg(feature = "full")]
-            Expr::Loop(v0) => {
+            Expr::Lit(v0) => {
                 state.write_u8(20u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Macro(v0) => {
+            Expr::Loop(v0) => {
                 state.write_u8(21u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Match(v0) => {
+            Expr::Macro(v0) => {
                 state.write_u8(22u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::MethodCall(v0) => {
+            Expr::Match(v0) => {
                 state.write_u8(23u8);
                 v0.hash(state);
             }
-            Expr::Paren(v0) => {
+            #[cfg(feature = "full")]
+            Expr::MethodCall(v0) => {
                 state.write_u8(24u8);
                 v0.hash(state);
             }
-            Expr::Path(v0) => {
+            Expr::Paren(v0) => {
                 state.write_u8(25u8);
                 v0.hash(state);
             }
-            #[cfg(feature = "full")]
-            Expr::Range(v0) => {
+            Expr::Path(v0) => {
                 state.write_u8(26u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Reference(v0) => {
+            Expr::Range(v0) => {
                 state.write_u8(27u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Repeat(v0) => {
+            Expr::Reference(v0) => {
                 state.write_u8(28u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Return(v0) => {
+            Expr::Repeat(v0) => {
                 state.write_u8(29u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Struct(v0) => {
+            Expr::Return(v0) => {
                 state.write_u8(30u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Try(v0) => {
+            Expr::Struct(v0) => {
                 state.write_u8(31u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::TryBlock(v0) => {
+            Expr::Try(v0) => {
                 state.write_u8(32u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Tuple(v0) => {
+            Expr::TryBlock(v0) => {
                 state.write_u8(33u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
-            Expr::Type(v0) => {
+            Expr::Tuple(v0) => {
                 state.write_u8(34u8);
                 v0.hash(state);
             }
-            Expr::Unary(v0) => {
+            #[cfg(feature = "full")]
+            Expr::Type(v0) => {
                 state.write_u8(35u8);
+                v0.hash(state);
+            }
+            Expr::Unary(v0) => {
+                state.write_u8(36u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
             Expr::Unsafe(v0) => {
-                state.write_u8(36u8);
+                state.write_u8(37u8);
                 v0.hash(state);
             }
             Expr::Verbatim(v0) => {
-                state.write_u8(37u8);
+                state.write_u8(38u8);
                 TokenStreamHelper(v0).hash(state);
             }
             #[cfg(feature = "full")]
             Expr::While(v0) => {
-                state.write_u8(38u8);
+                state.write_u8(39u8);
                 v0.hash(state);
             }
             #[cfg(feature = "full")]
             Expr::Yield(v0) => {
-                state.write_u8(39u8);
+                state.write_u8(40u8);
                 v0.hash(state);
             }
             #[cfg(any(syn_no_non_exhaustive, not(feature = "full")))]
@@ -647,6 +652,17 @@ impl Hash for ExprClosure {
         self.inputs.hash(state);
         self.output.hash(state);
         self.body.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for ExprConst {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.block.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -153,6 +153,10 @@ pub trait Visit<'ast> {
         visit_expr_closure(self, i);
     }
     #[cfg(feature = "full")]
+    fn visit_expr_const(&mut self, i: &'ast ExprConst) {
+        visit_expr_const(self, i);
+    }
+    #[cfg(feature = "full")]
     fn visit_expr_continue(&mut self, i: &'ast ExprContinue) {
         visit_expr_continue(self, i);
     }
@@ -1126,6 +1130,9 @@ where
         Expr::Closure(_binding_0) => {
             full!(v.visit_expr_closure(_binding_0));
         }
+        Expr::Const(_binding_0) => {
+            full!(v.visit_expr_const(_binding_0));
+        }
         Expr::Continue(_binding_0) => {
             full!(v.visit_expr_continue(_binding_0));
         }
@@ -1391,6 +1398,17 @@ where
     tokens_helper(v, &node.or2_token.spans);
     v.visit_return_type(&node.output);
     v.visit_expr(&*node.body);
+}
+#[cfg(feature = "full")]
+pub fn visit_expr_const<'ast, V>(v: &mut V, node: &'ast ExprConst)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    tokens_helper(v, &node.const_token.span);
+    v.visit_block(&node.block);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_continue<'ast, V>(v: &mut V, node: &'ast ExprContinue)

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -154,6 +154,10 @@ pub trait VisitMut {
         visit_expr_closure_mut(self, i);
     }
     #[cfg(feature = "full")]
+    fn visit_expr_const_mut(&mut self, i: &mut ExprConst) {
+        visit_expr_const_mut(self, i);
+    }
+    #[cfg(feature = "full")]
     fn visit_expr_continue_mut(&mut self, i: &mut ExprContinue) {
         visit_expr_continue_mut(self, i);
     }
@@ -1127,6 +1131,9 @@ where
         Expr::Closure(_binding_0) => {
             full!(v.visit_expr_closure_mut(_binding_0));
         }
+        Expr::Const(_binding_0) => {
+            full!(v.visit_expr_const_mut(_binding_0));
+        }
         Expr::Continue(_binding_0) => {
             full!(v.visit_expr_continue_mut(_binding_0));
         }
@@ -1392,6 +1399,17 @@ where
     tokens_helper(v, &mut node.or2_token.spans);
     v.visit_return_type_mut(&mut node.output);
     v.visit_expr_mut(&mut *node.body);
+}
+#[cfg(feature = "full")]
+pub fn visit_expr_const_mut<V>(v: &mut V, node: &mut ExprConst)
+where
+    V: VisitMut + ?Sized,
+{
+    for it in &mut node.attrs {
+        v.visit_attribute_mut(it);
+    }
+    tokens_helper(v, &mut node.const_token.span);
+    v.visit_block_mut(&mut node.block);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_continue_mut<V>(v: &mut V, node: &mut ExprContinue)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,10 +348,11 @@ pub use crate::expr::{
 #[cfg(any(feature = "full", feature = "derive"))]
 pub use crate::expr::{
     Expr, ExprArray, ExprAssign, ExprAssignOp, ExprAsync, ExprAwait, ExprBinary, ExprBlock,
-    ExprBox, ExprBreak, ExprCall, ExprCast, ExprClosure, ExprContinue, ExprField, ExprForLoop,
-    ExprGroup, ExprIf, ExprIndex, ExprLet, ExprLit, ExprLoop, ExprMacro, ExprMatch, ExprMethodCall,
-    ExprParen, ExprPath, ExprRange, ExprReference, ExprRepeat, ExprReturn, ExprStruct, ExprTry,
-    ExprTryBlock, ExprTuple, ExprType, ExprUnary, ExprUnsafe, ExprWhile, ExprYield, Index, Member,
+    ExprBox, ExprBreak, ExprCall, ExprCast, ExprClosure, ExprConst, ExprContinue, ExprField,
+    ExprForLoop, ExprGroup, ExprIf, ExprIndex, ExprLet, ExprLit, ExprLoop, ExprMacro, ExprMatch,
+    ExprMethodCall, ExprParen, ExprPath, ExprRange, ExprReference, ExprRepeat, ExprReturn,
+    ExprStruct, ExprTry, ExprTryBlock, ExprTuple, ExprType, ExprUnary, ExprUnsafe, ExprWhile,
+    ExprYield, Index, Member,
 };
 
 #[cfg(feature = "parsing")]

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -746,7 +746,7 @@ pub mod parsing {
         {
             Expr::Path(input.parse()?)
         } else if lookahead.peek(Token![const]) {
-            Expr::Verbatim(input.call(expr::parsing::expr_const)?)
+            Expr::Const(input.parse()?)
         } else {
             return Err(lookahead.error());
         };

--- a/syn.json
+++ b/syn.json
@@ -628,6 +628,11 @@
             "syn": "ExprClosure"
           }
         ],
+        "Const": [
+          {
+            "syn": "ExprConst"
+          }
+        ],
         "Continue": [
           {
             "syn": "ExprContinue"
@@ -1120,6 +1125,27 @@
           "box": {
             "syn": "Expr"
           }
+        }
+      }
+    },
+    {
+      "ident": "ExprConst",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "const_token": {
+          "token": "Const"
+        },
+        "block": {
+          "syn": "Block"
         }
       }
     },

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -633,6 +633,14 @@ impl Debug for Lite<syn::Expr> {
                 formatter.field("body", Lite(&_val.body));
                 formatter.finish()
             }
+            syn::Expr::Const(_val) => {
+                let mut formatter = formatter.debug_struct("Expr::Const");
+                if !_val.attrs.is_empty() {
+                    formatter.field("attrs", Lite(&_val.attrs));
+                }
+                formatter.field("block", Lite(&_val.block));
+                formatter.finish()
+            }
             syn::Expr::Continue(_val) => {
                 let mut formatter = formatter.debug_struct("Expr::Continue");
                 if !_val.attrs.is_empty() {
@@ -1334,6 +1342,17 @@ impl Debug for Lite<syn::ExprClosure> {
         }
         formatter.field("output", Lite(&_val.output));
         formatter.field("body", Lite(&_val.body));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ExprConst> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let _val = &self.value;
+        let mut formatter = formatter.debug_struct("ExprConst");
+        if !_val.attrs.is_empty() {
+            formatter.field("attrs", Lite(&_val.attrs));
+        }
+        formatter.field("block", Lite(&_val.block));
         formatter.finish()
     }
 }

--- a/tests/test_precedence.rs
+++ b/tests/test_precedence.rs
@@ -271,10 +271,7 @@ fn librustc_brackets(mut librustc_expr: P<ast::Expr>) -> Option<P<ast::Expr>> {
 
     impl MutVisitor for BracketsVisitor {
         fn visit_expr(&mut self, e: &mut P<Expr>) {
-            match e.kind {
-                ExprKind::ConstBlock(..) => {}
-                _ => noop_visit_expr(e, self),
-            }
+            noop_visit_expr(e, self);
             match e.kind {
                 ExprKind::If(..) | ExprKind::Block(..) | ExprKind::Let(..) => {}
                 _ => {


### PR DESCRIPTION
This seems sufficiently likely to land in stable Rust eventually.

Tracking issue: https://github.com/rust-lang/rust/issues/76001