### PR TITLE
Preserve Error's span thread id if cloned from a different thread

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -362,15 +362,9 @@ impl Clone for Error {
 
 impl Clone for ErrorMessage {
     fn clone(&self) -> Self {
-        let start = self
-            .start_span
-            .get()
-            .copied()
-            .unwrap_or_else(Span::call_site);
-        let end = self.end_span.get().copied().unwrap_or_else(Span::call_site);
         ErrorMessage {
-            start_span: ThreadBound::new(start),
-            end_span: ThreadBound::new(end),
+            start_span: self.start_span.clone(),
+            end_span: self.end_span.clone(),
             message: self.message.clone(),
         }
     }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -39,3 +39,12 @@ impl<T: Debug> Debug for ThreadBound<T> {
         }
     }
 }
+
+impl<T: Clone> Clone for ThreadBound<T> {
+    fn clone(&self) -> Self {
+        ThreadBound {
+            value: self.value.clone(),
+            thread_id: self.thread_id,
+        }
+    }
+}


### PR DESCRIPTION
Previously if you took a syn::Error with a non-call_site span, moved it to a different thread, cloned it, moved the clone back to the original thread, and called span() on that, you'd have lost the original span.

Now the span will be preserved during clone even if the clone occurs on a thread which doesn't have access to the span.