### PR TITLE
Eliminate second redundant ThreadId from ErrorMessage

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -48,5 +48,3 @@ impl<T: Clone> Clone for ThreadBound<T> {
         }
     }
 }
-
-impl<T: Copy> Copy for ThreadBound<T> {}


### PR DESCRIPTION
This PR shrinks the size of ErrorMessage from 56 bytes to 40 bytes.