### PR TITLE
Delete MethodTurbofish in favor of AngleBracketedGenericArguments

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1418,18 +1418,6 @@ impl Clone for MetaNameValue {
         }
     }
 }
-#[cfg(feature = "full")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
-impl Clone for MethodTurbofish {
-    fn clone(&self) -> Self {
-        MethodTurbofish {
-            colon2_token: self.colon2_token.clone(),
-            lt_token: self.lt_token.clone(),
-            args: self.args.clone(),
-            gt_token: self.gt_token.clone(),
-        }
-    }
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
 impl Clone for ParenthesizedGenericArguments {

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1952,18 +1952,6 @@ impl Debug for MetaNameValue {
         formatter.finish()
     }
 }
-#[cfg(feature = "full")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Debug for MethodTurbofish {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let mut formatter = formatter.debug_struct("MethodTurbofish");
-        formatter.field("colon2_token", &self.colon2_token);
-        formatter.field("lt_token", &self.lt_token);
-        formatter.field("args", &self.args);
-        formatter.field("gt_token", &self.gt_token);
-        formatter.finish()
-    }
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Debug for ParenthesizedGenericArguments {

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1341,16 +1341,6 @@ impl PartialEq for MetaNameValue {
         self.path == other.path && self.value == other.value
     }
 }
-#[cfg(feature = "full")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Eq for MethodTurbofish {}
-#[cfg(feature = "full")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl PartialEq for MethodTurbofish {
-    fn eq(&self, other: &Self) -> bool {
-        self.args == other.args
-    }
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Eq for ParenthesizedGenericArguments {}

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -484,10 +484,6 @@ pub trait Fold {
     fn fold_meta_name_value(&mut self, i: MetaNameValue) -> MetaNameValue {
         fold_meta_name_value(self, i)
     }
-    #[cfg(feature = "full")]
-    fn fold_method_turbofish(&mut self, i: MethodTurbofish) -> MethodTurbofish {
-        fold_method_turbofish(self, i)
-    }
     #[cfg(any(feature = "derive", feature = "full"))]
     fn fold_parenthesized_generic_arguments(
         &mut self,
@@ -1407,7 +1403,8 @@ where
         receiver: Box::new(f.fold_expr(*node.receiver)),
         dot_token: Token![.](tokens_helper(f, &node.dot_token.spans)),
         method: f.fold_ident(node.method),
-        turbofish: (node.turbofish).map(|it| f.fold_method_turbofish(it)),
+        turbofish: (node.turbofish)
+            .map(|it| f.fold_angle_bracketed_generic_arguments(it)),
         paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
         args: FoldHelper::lift(node.args, |it| f.fold_expr(it)),
     }
@@ -2390,18 +2387,6 @@ where
         path: f.fold_path(node.path),
         eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
         value: f.fold_expr(node.value),
-    }
-}
-#[cfg(feature = "full")]
-pub fn fold_method_turbofish<F>(f: &mut F, node: MethodTurbofish) -> MethodTurbofish
-where
-    F: Fold + ?Sized,
-{
-    MethodTurbofish {
-        colon2_token: Token![::](tokens_helper(f, &node.colon2_token.spans)),
-        lt_token: Token![<](tokens_helper(f, &node.lt_token.spans)),
-        args: FoldHelper::lift(node.args, |it| f.fold_generic_argument(it)),
-        gt_token: Token![>](tokens_helper(f, &node.gt_token.spans)),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1799,16 +1799,6 @@ impl Hash for MetaNameValue {
         self.value.hash(state);
     }
 }
-#[cfg(feature = "full")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Hash for MethodTurbofish {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: Hasher,
-    {
-        self.args.hash(state);
-    }
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Hash for ParenthesizedGenericArguments {

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -486,10 +486,6 @@ pub trait Visit<'ast> {
     fn visit_meta_name_value(&mut self, i: &'ast MetaNameValue) {
         visit_meta_name_value(self, i);
     }
-    #[cfg(feature = "full")]
-    fn visit_method_turbofish(&mut self, i: &'ast MethodTurbofish) {
-        visit_method_turbofish(self, i);
-    }
     #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_parenthesized_generic_arguments(
         &mut self,
@@ -1537,7 +1533,7 @@ where
     tokens_helper(v, &node.dot_token.spans);
     v.visit_ident(&node.method);
     if let Some(it) = &node.turbofish {
-        v.visit_method_turbofish(it);
+        v.visit_angle_bracketed_generic_arguments(it);
     }
     tokens_helper(v, &node.paren_token.span);
     for el in Punctuated::pairs(&node.args) {
@@ -2661,22 +2657,6 @@ where
     v.visit_path(&node.path);
     tokens_helper(v, &node.eq_token.spans);
     v.visit_expr(&node.value);
-}
-#[cfg(feature = "full")]
-pub fn visit_method_turbofish<'ast, V>(v: &mut V, node: &'ast MethodTurbofish)
-where
-    V: Visit<'ast> + ?Sized,
-{
-    tokens_helper(v, &node.colon2_token.spans);
-    tokens_helper(v, &node.lt_token.spans);
-    for el in Punctuated::pairs(&node.args) {
-        let (it, p) = el.into_tuple();
-        v.visit_generic_argument(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
-    }
-    tokens_helper(v, &node.gt_token.spans);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_parenthesized_generic_arguments<'ast, V>(

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -487,10 +487,6 @@ pub trait VisitMut {
     fn visit_meta_name_value_mut(&mut self, i: &mut MetaNameValue) {
         visit_meta_name_value_mut(self, i);
     }
-    #[cfg(feature = "full")]
-    fn visit_method_turbofish_mut(&mut self, i: &mut MethodTurbofish) {
-        visit_method_turbofish_mut(self, i);
-    }
     #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_parenthesized_generic_arguments_mut(
         &mut self,
@@ -1538,7 +1534,7 @@ where
     tokens_helper(v, &mut node.dot_token.spans);
     v.visit_ident_mut(&mut node.method);
     if let Some(it) = &mut node.turbofish {
-        v.visit_method_turbofish_mut(it);
+        v.visit_angle_bracketed_generic_arguments_mut(it);
     }
     tokens_helper(v, &mut node.paren_token.span);
     for el in Punctuated::pairs_mut(&mut node.args) {
@@ -2664,22 +2660,6 @@ where
     v.visit_path_mut(&mut node.path);
     tokens_helper(v, &mut node.eq_token.spans);
     v.visit_expr_mut(&mut node.value);
-}
-#[cfg(feature = "full")]
-pub fn visit_method_turbofish_mut<V>(v: &mut V, node: &mut MethodTurbofish)
-where
-    V: VisitMut + ?Sized,
-{
-    tokens_helper(v, &mut node.colon2_token.spans);
-    tokens_helper(v, &mut node.lt_token.spans);
-    for el in Punctuated::pairs_mut(&mut node.args) {
-        let (it, p) = el.into_tuple();
-        v.visit_generic_argument_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
-    }
-    tokens_helper(v, &mut node.gt_token.spans);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_parenthesized_generic_arguments_mut<V>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,7 @@ pub use crate::error::{Error, Result};
 #[cfg(any(feature = "full", feature = "derive"))]
 mod expr;
 #[cfg(feature = "full")]
-pub use crate::expr::{Arm, FieldValue, Label, MethodTurbofish, RangeLimits};
+pub use crate::expr::{Arm, FieldValue, Label, RangeLimits};
 #[cfg(any(feature = "full", feature = "derive"))]
 pub use crate::expr::{
     Expr, ExprArray, ExprAssign, ExprAssignOp, ExprAsync, ExprAwait, ExprBinary, ExprBlock,

--- a/syn.json
+++ b/syn.json
@@ -1481,7 +1481,7 @@
         },
         "turbofish": {
           "option": {
-            "syn": "MethodTurbofish"
+            "syn": "AngleBracketedGenericArguments"
           }
         },
         "paren_token": {
@@ -3577,33 +3577,6 @@
         },
         "value": {
           "syn": "Expr"
-        }
-      }
-    },
-    {
-      "ident": "MethodTurbofish",
-      "features": {
-        "any": [
-          "full"
-        ]
-      },
-      "fields": {
-        "colon2_token": {
-          "token": "Colon2"
-        },
-        "lt_token": {
-          "token": "Lt"
-        },
-        "args": {
-          "punctuated": {
-            "element": {
-              "syn": "GenericArgument"
-            },
-            "punct": "Comma"
-          }
-        },
-        "gt_token": {
-          "token": "Gt"
         }
       }
     },

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -838,7 +838,7 @@ impl Debug for Lite<syn::Expr> {
                 if let Some(val) = &_val.turbofish {
                     #[derive(RefCast)]
                     #[repr(transparent)]
-                    struct Print(syn::MethodTurbofish);
+                    struct Print(syn::AngleBracketedGenericArguments);
                     impl Debug for Print {
                         fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                             formatter.write_str("Some")?;
@@ -1622,7 +1622,7 @@ impl Debug for Lite<syn::ExprMethodCall> {
         if let Some(val) = &_val.turbofish {
             #[derive(RefCast)]
             #[repr(transparent)]
-            struct Print(syn::MethodTurbofish);
+            struct Print(syn::AngleBracketedGenericArguments);
             impl Debug for Print {
                 fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                     formatter.write_str("Some")?;
@@ -3697,16 +3697,6 @@ impl Debug for Lite<syn::MetaNameValue> {
         let mut formatter = formatter.debug_struct("MetaNameValue");
         formatter.field("path", Lite(&_val.path));
         formatter.field("value", Lite(&_val.value));
-        formatter.finish()
-    }
-}
-impl Debug for Lite<syn::MethodTurbofish> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let _val = &self.value;
-        let mut formatter = formatter.debug_struct("MethodTurbofish");
-        if !_val.args.is_empty() {
-            formatter.field("args", Lite(&_val.args));
-        }
         formatter.finish()
     }
 }


### PR DESCRIPTION
Following #1320, these are practically equivalent pieces of syntax.