### PR TITLE
Experiment with peeking multiple tokens in one peek

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -562,7 +562,7 @@ pub mod parsing {
     }
 
     pub fn parse_meta_after_path(path: Path, input: ParseStream) -> Result<Meta> {
-        if input.peek(token::Paren) || input.peek(token::Bracket) || input.peek(token::Brace) {
+        if input.peek(token::Paren | token::Bracket | token::Brace) {
             parse_meta_list_after_path(path, input).map(Meta::List)
         } else if input.peek(Token![=]) {
             parse_meta_name_value_after_path(path, input).map(Meta::NameValue)

--- a/src/data.rs
+++ b/src/data.rs
@@ -330,10 +330,7 @@ pub mod parsing {
 
                 let content;
                 let paren_token = parenthesized!(content in ahead);
-                if content.peek(Token![crate])
-                    || content.peek(Token![self])
-                    || content.peek(Token![super])
-                {
+                if content.peek(Token![crate] | Token![self] | Token![super]) {
                     let path = content.call(Ident::parse_any)?;
 
                     // Ensure there are no additional tokens within `content`.

--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -68,11 +68,7 @@ pub trait Speculative {
     ///
     /// impl Parse for PathSegment {
     ///     fn parse(input: ParseStream) -> Result<Self> {
-    ///         if input.peek(Token![super])
-    ///             || input.peek(Token![self])
-    ///             || input.peek(Token![Self])
-    ///             || input.peek(Token![crate])
-    ///         {
+    ///         if input.peek(Token![super] | Token![self] | Token![Self] | Token![crate]) {
     ///             let ident = input.call(Ident::parse_any)?;
     ///             return Ok(PathSegment::from(ident));
     ///         }

--- a/src/export.rs
+++ b/src/export.rs
@@ -4,6 +4,7 @@ pub use std::default::Default;
 pub use std::fmt::{self, Debug, Formatter};
 pub use std::hash::{Hash, Hasher};
 pub use std::marker::Copy;
+pub use std::ops::{BitOr, Deref, FnMut};
 pub use std::option::Option::{None, Some};
 pub use std::result::Result::{Err, Ok};
 
@@ -13,7 +14,13 @@ pub use quote;
 pub use proc_macro2::{Span, TokenStream as TokenStream2};
 
 #[cfg(feature = "parsing")]
+pub use crate::buffer::Cursor;
+
+#[cfg(feature = "parsing")]
 pub use crate::group::{parse_braces, parse_brackets, parse_parens};
+
+#[cfg(feature = "parsing")]
+pub use crate::lookahead::Either;
 
 pub use crate::span::IntoSpans;
 
@@ -34,6 +41,12 @@ pub type str = help::Str;
 mod help {
     pub type Bool = bool;
     pub type Str = str;
+}
+
+#[cfg(feature = "parsing")]
+pub trait CustomToken {
+    type Peek;
+    const PEEK: Self::Peek;
 }
 
 pub struct private(pub(crate) ());

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,11 +1,12 @@
 //! Extension traits to provide parsing methods on foreign types.
 
 use crate::buffer::Cursor;
-use crate::parse::Peek;
+use crate::lookahead::{Either, Peek};
 use crate::parse::{ParseStream, Result};
 use crate::sealed::lookahead;
 use crate::token::CustomToken;
 use proc_macro2::Ident;
+use std::ops::BitOr;
 
 /// Additional methods for `Ident` not provided by proc-macro2 or libproc_macro.
 ///
@@ -102,6 +103,19 @@ impl IdentExt for Ident {
 
 impl Peek for private::PeekFn {
     type Token = private::IdentAny;
+    fn peek(cursor: Cursor) -> bool {
+        private::IdentAny::peek(cursor)
+    }
+    fn display(f: &mut dyn FnMut(&'static str)) {
+        f(private::IdentAny::display());
+    }
+}
+
+impl<U: Peek> BitOr<U> for private::PeekFn {
+    type Output = Either<Self, U>;
+    fn bitor(self, _other: U) -> Self::Output {
+        Either::new()
+    }
 }
 
 impl CustomToken for private::IdentAny {

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -657,7 +657,7 @@ pub mod parsing {
                     let mut bounds = Punctuated::new();
                     if has_colon {
                         loop {
-                            if input.peek(Token![,]) || input.peek(Token![>]) {
+                            if input.peek(Token![,] | Token![>]) {
                                 break;
                             }
                             let value = input.parse()?;
@@ -718,7 +718,7 @@ pub mod parsing {
             let mut bounds = Punctuated::new();
             if colon_token.is_some() {
                 loop {
-                    if input.peek(Token![,]) || input.peek(Token![>]) || input.peek(Token![=]) {
+                    if input.peek(Token![,] | Token![>] | Token![=]) {
                         break;
                     }
                     let value: TypeParamBound = input.parse()?;
@@ -795,13 +795,9 @@ pub mod parsing {
                     break;
                 }
                 bounds.push_punct(input.parse()?);
-                if !(input.peek(Ident::peek_any)
-                    || input.peek(Token![::])
-                    || input.peek(Token![?])
-                    || input.peek(Lifetime)
-                    || input.peek(token::Paren)
-                    || input.peek(Token![~]))
-                {
+                if !input.peek(
+                    Ident::peek_any | Token![::] | Token![?] | Lifetime | token::Paren | Token![~],
+                ) {
                     break;
                 }
             }
@@ -878,11 +874,8 @@ pub mod parsing {
                     let mut predicates = Punctuated::new();
                     loop {
                         if input.is_empty()
-                            || input.peek(token::Brace)
-                            || input.peek(Token![,])
-                            || input.peek(Token![;])
+                            || input.peek(token::Brace | Token![,] | Token![;] | Token![=])
                             || input.peek(Token![:]) && !input.peek(Token![::])
-                            || input.peek(Token![=])
                         {
                             break;
                         }
@@ -922,11 +915,9 @@ pub mod parsing {
                         let mut bounds = Punctuated::new();
                         loop {
                             if input.is_empty()
-                                || input.peek(token::Brace)
-                                || input.peek(Token![,])
-                                || input.peek(Token![;])
-                                || input.peek(Token![:])
-                                || input.peek(Token![=])
+                                || input.peek(
+                                    token::Brace | Token![,] | Token![;] | Token![:] | Token![=],
+                                )
                             {
                                 break;
                             }
@@ -950,11 +941,8 @@ pub mod parsing {
                         let mut bounds = Punctuated::new();
                         loop {
                             if input.is_empty()
-                                || input.peek(token::Brace)
-                                || input.peek(Token![,])
-                                || input.peek(Token![;])
+                                || input.peek(token::Brace | Token![,] | Token![;] | Token![=])
                                 || input.peek(Token![:]) && !input.peek(Token![::])
-                                || input.peek(Token![=])
                             {
                                 break;
                             }

--- a/src/item.rs
+++ b/src/item.rs
@@ -938,12 +938,12 @@ pub mod parsing {
             } else if lookahead.peek(Token![const]) {
                 ahead.parse::<Token![const]>()?;
                 let lookahead = ahead.lookahead1();
-                if lookahead.peek(Ident) || lookahead.peek(Token![_]) {
+                if lookahead.peek(Ident | Token![_]) {
                     let vis = input.parse()?;
                     let const_token = input.parse()?;
                     let ident = {
                         let lookahead = input.lookahead1();
-                        if lookahead.peek(Ident) || lookahead.peek(Token![_]) {
+                        if lookahead.peek(Ident | Token![_]) {
                             input.call(Ident::parse_any)?
                         } else {
                             return Err(lookahead.error());
@@ -1025,11 +1025,7 @@ pub mod parsing {
                 input.advance_to(&ahead);
                 parse_macro2(begin, vis, input)
             } else if vis.is_inherited()
-                && (lookahead.peek(Ident)
-                    || lookahead.peek(Token![self])
-                    || lookahead.peek(Token![super])
-                    || lookahead.peek(Token![crate])
-                    || lookahead.peek(Token![::]))
+                && lookahead.peek(Ident | Token![self] | Token![super] | Token![crate] | Token![::])
             {
                 input.parse().map(Item::Macro)
             } else {
@@ -1076,11 +1072,11 @@ pub mod parsing {
             let mut bounds = Punctuated::new();
             if colon_token.is_some() {
                 loop {
-                    if input.peek(Token![where]) || input.peek(Token![=]) || input.peek(Token![;]) {
+                    if input.peek(Token![where] | Token![=] | Token![;]) {
                         break;
                     }
                     bounds.push_value(input.parse::<TypeParamBound>()?);
-                    if input.peek(Token![where]) || input.peek(Token![=]) || input.peek(Token![;]) {
+                    if input.peek(Token![where] | Token![=] | Token![;]) {
                         break;
                     }
                     bounds.push_punct(input.parse::<Token![+]>()?);
@@ -1255,11 +1251,7 @@ pub mod parsing {
         allow_crate_root_in_path: bool,
     ) -> Result<Option<UseTree>> {
         let lookahead = input.lookahead1();
-        if lookahead.peek(Ident)
-            || lookahead.peek(Token![self])
-            || lookahead.peek(Token![super])
-            || lookahead.peek(Token![crate])
-        {
+        if lookahead.peek(Ident | Token![self] | Token![super] | Token![crate]) {
             let ident = input.call(Ident::parse_any)?;
             if input.peek(Token![::]) {
                 Ok(Some(UseTree::Path(UsePath {
@@ -1344,7 +1336,7 @@ pub mod parsing {
                 const_token: input.parse()?,
                 ident: {
                     let lookahead = input.lookahead1();
-                    if lookahead.peek(Ident) || lookahead.peek(Token![_]) {
+                    if lookahead.peek(Ident | Token![_]) {
                         input.call(Ident::parse_any)?
                     } else {
                         return Err(lookahead.error());
@@ -1707,11 +1699,7 @@ pub mod parsing {
             } else if lookahead.peek(Token![type]) {
                 parse_foreign_item_type(begin, input)
             } else if vis.is_inherited()
-                && (lookahead.peek(Ident)
-                    || lookahead.peek(Token![self])
-                    || lookahead.peek(Token![super])
-                    || lookahead.peek(Token![crate])
-                    || lookahead.peek(Token![::]))
+                && lookahead.peek(Ident | Token![self] | Token![super] | Token![crate] | Token![::])
             {
                 input.parse().map(ForeignItem::Macro)
             } else {
@@ -1950,10 +1938,7 @@ pub mod parsing {
     fn parse_trait_or_trait_alias(input: ParseStream) -> Result<Item> {
         let (attrs, vis, trait_token, ident, generics) = parse_start_of_trait_alias(input)?;
         let lookahead = input.lookahead1();
-        if lookahead.peek(token::Brace)
-            || lookahead.peek(Token![:])
-            || lookahead.peek(Token![where])
-        {
+        if lookahead.peek(token::Brace | Token![:] | Token![where]) {
             let unsafety = None;
             let auto_token = None;
             parse_rest_of_trait(
@@ -2013,11 +1998,11 @@ pub mod parsing {
         let mut supertraits = Punctuated::new();
         if colon_token.is_some() {
             loop {
-                if input.peek(Token![where]) || input.peek(token::Brace) {
+                if input.peek(Token![where] | token::Brace) {
                     break;
                 }
                 supertraits.push_value(input.parse()?);
-                if input.peek(Token![where]) || input.peek(token::Brace) {
+                if input.peek(Token![where] | token::Brace) {
                     break;
                 }
                 supertraits.push_punct(input.parse()?);
@@ -2080,11 +2065,11 @@ pub mod parsing {
 
         let mut bounds = Punctuated::new();
         loop {
-            if input.peek(Token![where]) || input.peek(Token![;]) {
+            if input.peek(Token![where] | Token![;]) {
                 break;
             }
             bounds.push_value(input.parse()?);
-            if input.peek(Token![where]) || input.peek(Token![;]) {
+            if input.peek(Token![where] | Token![;]) {
                 break;
             }
             bounds.push_punct(input.parse()?);
@@ -2120,12 +2105,10 @@ pub mod parsing {
             } else if lookahead.peek(Token![const]) {
                 ahead.parse::<Token![const]>()?;
                 let lookahead = ahead.lookahead1();
-                if lookahead.peek(Ident) || lookahead.peek(Token![_]) {
+                if lookahead.peek(Ident | Token![_]) {
                     input.parse().map(TraitItem::Const)
-                } else if lookahead.peek(Token![async])
-                    || lookahead.peek(Token![unsafe])
-                    || lookahead.peek(Token![extern])
-                    || lookahead.peek(Token![fn])
+                } else if lookahead
+                    .peek(Token![async] | Token![unsafe] | Token![extern] | Token![fn])
                 {
                     input.parse().map(TraitItem::Fn)
                 } else {
@@ -2133,11 +2116,8 @@ pub mod parsing {
                 }
             } else if lookahead.peek(Token![type]) {
                 parse_trait_item_type(begin.fork(), input)
-            } else if lookahead.peek(Ident)
-                || lookahead.peek(Token![self])
-                || lookahead.peek(Token![super])
-                || lookahead.peek(Token![crate])
-                || lookahead.peek(Token![::])
+            } else if lookahead
+                .peek(Ident | Token![self] | Token![super] | Token![crate] | Token![::])
             {
                 input.parse().map(TraitItem::Macro)
             } else {
@@ -2170,7 +2150,7 @@ pub mod parsing {
                 const_token: input.parse()?,
                 ident: {
                     let lookahead = input.lookahead1();
-                    if lookahead.peek(Ident) || lookahead.peek(Token![_]) {
+                    if lookahead.peek(Ident | Token![_]) {
                         input.call(Ident::parse_any)?
                     } else {
                         return Err(lookahead.error());
@@ -2233,8 +2213,7 @@ pub mod parsing {
 
             let mut bounds = Punctuated::new();
             if colon_token.is_some() {
-                while !input.peek(Token![where]) && !input.peek(Token![=]) && !input.peek(Token![;])
-                {
+                while !input.peek(Token![where] | Token![=] | Token![;]) {
                     if !bounds.is_empty() {
                         bounds.push_punct(input.parse()?);
                     }
@@ -2329,14 +2308,9 @@ pub mod parsing {
         let impl_token: Token![impl] = input.parse()?;
 
         let has_generics = input.peek(Token![<])
-            && (input.peek2(Token![>])
-                || input.peek2(Token![#])
-                || (input.peek2(Ident) || input.peek2(Lifetime))
-                    && (input.peek3(Token![:])
-                        || input.peek3(Token![,])
-                        || input.peek3(Token![>])
-                        || input.peek3(Token![=]))
-                || input.peek2(Token![const]));
+            && (input.peek2(Token![>] | Token![#] | Token![const])
+                || input.peek2(Ident | Lifetime | Token![const])
+                    && input.peek3(Token![:] | Token![,] | Token![>] | Token![=]));
         let mut generics: Generics = if has_generics {
             input.parse()?
         } else {
@@ -2447,7 +2421,7 @@ pub mod parsing {
             } else if lookahead.peek(Token![const]) {
                 let const_token: Token![const] = ahead.parse()?;
                 let lookahead = ahead.lookahead1();
-                if lookahead.peek(Ident) || lookahead.peek(Token![_]) {
+                if lookahead.peek(Ident | Token![_]) {
                     input.advance_to(&ahead);
                     let ident: Ident = input.call(Ident::parse_any)?;
                     let colon_token: Token![:] = input.parse()?;
@@ -2477,11 +2451,7 @@ pub mod parsing {
                 parse_impl_item_type(begin, input)
             } else if vis.is_inherited()
                 && defaultness.is_none()
-                && (lookahead.peek(Ident)
-                    || lookahead.peek(Token![self])
-                    || lookahead.peek(Token![super])
-                    || lookahead.peek(Token![crate])
-                    || lookahead.peek(Token![::]))
+                && lookahead.peek(Ident | Token![self] | Token![super] | Token![crate] | Token![::])
             {
                 input.parse().map(ImplItem::Macro)
             } else {
@@ -2514,7 +2484,7 @@ pub mod parsing {
                 const_token: input.parse()?,
                 ident: {
                     let lookahead = input.lookahead1();
-                    if lookahead.peek(Ident) || lookahead.peek(Token![_]) {
+                    if lookahead.peek(Ident | Token![_]) {
                         input.call(Ident::parse_any)?
                     } else {
                         return Err(lookahead.error());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,7 @@
     clippy::needless_doctest_main,
     clippy::needless_pass_by_value,
     clippy::never_loop,
+    clippy::new_without_default,
     clippy::redundant_else,
     clippy::return_self_not_must_use,
     clippy::similar_names,

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -1,6 +1,4 @@
 #[cfg(feature = "parsing")]
-use crate::lookahead;
-#[cfg(feature = "parsing")]
 use crate::parse::{Parse, Parser};
 use crate::{Error, Result};
 use proc_macro2::{Ident, Literal, Span};
@@ -682,13 +680,6 @@ macro_rules! lit_extra_traits {
                 self.repr.token.to_string().hash(state);
             }
         }
-
-        #[cfg(feature = "parsing")]
-        #[doc(hidden)]
-        #[allow(non_snake_case)]
-        pub fn $ty(marker: lookahead::TokenMarker) -> $ty {
-            match marker {}
-        }
     };
 }
 
@@ -701,10 +692,43 @@ lit_extra_traits!(LitFloat);
 
 #[cfg(feature = "parsing")]
 #[doc(hidden)]
-#[allow(non_snake_case)]
-pub fn LitBool(marker: lookahead::TokenMarker) -> LitBool {
-    match marker {}
-}
+#[allow(non_upper_case_globals)]
+pub const Lit: parsing::PeekLit = parsing::PeekLit {};
+
+#[cfg(feature = "parsing")]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+pub const LitStr: parsing::PeekLitStr = parsing::PeekLitStr {};
+
+#[cfg(feature = "parsing")]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+pub const LitByteStr: parsing::PeekLitByteStr = parsing::PeekLitByteStr {};
+
+#[cfg(feature = "parsing")]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+pub const LitByte: parsing::PeekLitByte = parsing::PeekLitByte {};
+
+#[cfg(feature = "parsing")]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+pub const LitChar: parsing::PeekLitChar = parsing::PeekLitChar {};
+
+#[cfg(feature = "parsing")]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+pub const LitInt: parsing::PeekLitInt = parsing::PeekLitInt {};
+
+#[cfg(feature = "parsing")]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+pub const LitFloat: parsing::PeekLitFloat = parsing::PeekLitFloat {};
+
+#[cfg(feature = "parsing")]
+#[doc(hidden)]
+#[allow(non_upper_case_globals)]
+pub const LitBool: parsing::PeekLitBool = parsing::PeekLitBool {};
 
 ast_enum! {
     /// The style of a string literal, either plain quoted or a raw string like
@@ -720,18 +744,14 @@ ast_enum! {
 }
 
 #[cfg(feature = "parsing")]
-#[doc(hidden)]
-#[allow(non_snake_case)]
-pub fn Lit(marker: lookahead::TokenMarker) -> Lit {
-    match marker {}
-}
-
-#[cfg(feature = "parsing")]
 pub mod parsing {
     use super::*;
     use crate::buffer::Cursor;
+    use crate::lookahead::{Either, Peek};
     use crate::parse::{Parse, ParseStream, Result};
+    use crate::token::Token;
     use proc_macro2::Punct;
+    use std::ops::BitOr;
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for Lit {
@@ -878,6 +898,150 @@ pub mod parsing {
                 Ok(Lit::Bool(lit)) => Ok(lit),
                 _ => Err(head.error("expected boolean literal")),
             }
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct PeekLit;
+    impl Peek for PeekLit {
+        type Token = Lit;
+        fn peek(cursor: Cursor) -> bool {
+            Lit::peek(cursor)
+        }
+        fn display(f: &mut dyn FnMut(&'static str)) {
+            f(Lit::display());
+        }
+    }
+    impl<U: Peek> BitOr<U> for PeekLit {
+        type Output = Either<Self, U>;
+        fn bitor(self, _other: U) -> Self::Output {
+            Either::new()
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct PeekLitStr;
+    impl Peek for PeekLitStr {
+        type Token = LitStr;
+        fn peek(cursor: Cursor) -> bool {
+            LitStr::peek(cursor)
+        }
+        fn display(f: &mut dyn FnMut(&'static str)) {
+            f(LitStr::display());
+        }
+    }
+    impl<U: Peek> BitOr<U> for PeekLitStr {
+        type Output = Either<Self, U>;
+        fn bitor(self, _other: U) -> Self::Output {
+            Either::new()
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct PeekLitByteStr;
+    impl Peek for PeekLitByteStr {
+        type Token = LitByteStr;
+        fn peek(cursor: Cursor) -> bool {
+            LitByteStr::peek(cursor)
+        }
+        fn display(f: &mut dyn FnMut(&'static str)) {
+            f(LitByteStr::display());
+        }
+    }
+    impl<U: Peek> BitOr<U> for PeekLitByteStr {
+        type Output = Either<Self, U>;
+        fn bitor(self, _other: U) -> Self::Output {
+            Either::new()
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct PeekLitByte;
+    impl Peek for PeekLitByte {
+        type Token = LitByte;
+        fn peek(cursor: Cursor) -> bool {
+            LitByte::peek(cursor)
+        }
+        fn display(f: &mut dyn FnMut(&'static str)) {
+            f(LitByte::display());
+        }
+    }
+    impl<U: Peek> BitOr<U> for PeekLitByte {
+        type Output = Either<Self, U>;
+        fn bitor(self, _other: U) -> Self::Output {
+            Either::new()
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct PeekLitChar;
+    impl Peek for PeekLitChar {
+        type Token = LitChar;
+        fn peek(cursor: Cursor) -> bool {
+            LitChar::peek(cursor)
+        }
+        fn display(f: &mut dyn FnMut(&'static str)) {
+            f(LitChar::display());
+        }
+    }
+    impl<U: Peek> BitOr<U> for PeekLitChar {
+        type Output = Either<Self, U>;
+        fn bitor(self, _other: U) -> Self::Output {
+            Either::new()
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct PeekLitInt;
+    impl Peek for PeekLitInt {
+        type Token = LitInt;
+        fn peek(cursor: Cursor) -> bool {
+            LitInt::peek(cursor)
+        }
+        fn display(f: &mut dyn FnMut(&'static str)) {
+            f(LitInt::display());
+        }
+    }
+    impl<U: Peek> BitOr<U> for PeekLitInt {
+        type Output = Either<Self, U>;
+        fn bitor(self, _other: U) -> Self::Output {
+            Either::new()
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct PeekLitFloat;
+    impl Peek for PeekLitFloat {
+        type Token = LitFloat;
+        fn peek(cursor: Cursor) -> bool {
+            LitFloat::peek(cursor)
+        }
+        fn display(f: &mut dyn FnMut(&'static str)) {
+            f(LitFloat::display());
+        }
+    }
+    impl<U: Peek> BitOr<U> for PeekLitFloat {
+        type Output = Either<Self, U>;
+        fn bitor(self, _other: U) -> Self::Output {
+            Either::new()
+        }
+    }
+
+    #[derive(Copy, Clone)]
+    pub struct PeekLitBool;
+    impl Peek for PeekLitBool {
+        type Token = LitBool;
+        fn peek(cursor: Cursor) -> bool {
+            LitBool::peek(cursor)
+        }
+        fn display(f: &mut dyn FnMut(&'static str)) {
+            f(LitBool::display());
+        }
+    }
+    impl<U: Peek> BitOr<U> for PeekLitBool {
+        type Output = Either<Self, U>;
+        fn bitor(self, _other: U) -> Self::Output {
+            Either::new()
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -554,7 +554,7 @@ impl<'a> ParseBuffer<'a> {
     ///         if colon_token.is_some() {
     ///             loop {
     ///                 supertraits.push_value(input.parse()?);
-    ///                 if input.peek(Token![where]) || input.peek(token::Brace) {
+    ///                 if input.peek(Token![where] | token::Brace) {
     ///                     break;
     ///                 }
     ///                 supertraits.push_punct(input.parse()?);
@@ -578,7 +578,7 @@ impl<'a> ParseBuffer<'a> {
     /// ```
     pub fn peek<T: Peek>(&self, token: T) -> bool {
         let _ = token;
-        T::Token::peek(self.cursor())
+        T::peek(self.cursor())
     }
 
     /// Looks at the second-next token in the parse stream.
@@ -626,7 +626,7 @@ impl<'a> ParseBuffer<'a> {
         }
 
         let _ = token;
-        peek2(self, T::Token::peek)
+        peek2(self, T::peek)
     }
 
     /// Looks at the third-next token in the parse stream.
@@ -645,7 +645,7 @@ impl<'a> ParseBuffer<'a> {
         }
 
         let _ = token;
-        peek3(self, T::Token::peek)
+        peek3(self, T::peek)
     }
 
     /// Parses zero or more occurrences of `T` separated by punctuation of type
@@ -933,10 +933,7 @@ impl<'a> ParseBuffer<'a> {
     ///             let mut content;
     ///             parenthesized!(content in ahead);
     ///
-    ///             if content.peek(Token![crate])
-    ///                 || content.peek(Token![self])
-    ///                 || content.peek(Token![super])
-    ///             {
+    ///             if content.peek(Token![crate] | Token![self] | Token![super]) {
     ///                 return Ok(PubVisibility {
     ///                     pub_token,
     ///                     restricted: Some(Restricted {
@@ -990,10 +987,7 @@ impl<'a> ParseBuffer<'a> {
     ///
     /// impl Parse for Loop {
     ///     fn parse(input: ParseStream) -> Result<Self> {
-    ///         if input.peek(Token![while])
-    ///             || input.peek(Token![for])
-    ///             || input.peek(Token![loop])
-    ///         {
+    ///         if input.peek(Token![while] | Token![for] | Token![loop]) {
     ///             Ok(Loop {
     ///                 expr: input.parse()?,
     ///             })

--- a/src/path.rs
+++ b/src/path.rs
@@ -220,7 +220,7 @@ pub mod parsing {
                 return Ok(GenericArgument::Lifetime(input.parse()?));
             }
 
-            if input.peek(Lit) || input.peek(token::Brace) {
+            if input.peek(Lit | token::Brace) {
                 return const_argument(input).map(GenericArgument::Const);
             }
 
@@ -244,7 +244,7 @@ pub mod parsing {
                             PathArguments::AngleBracketed(arguments) => Some(arguments),
                             PathArguments::Parenthesized(_) => unreachable!(),
                         };
-                        return if input.peek(Lit) || input.peek(token::Brace) {
+                        return if input.peek(Lit | token::Brace) {
                             Ok(GenericArgument::AssocConst(AssocConst {
                                 ident,
                                 generics,
@@ -275,7 +275,7 @@ pub mod parsing {
                             bounds: {
                                 let mut bounds = Punctuated::new();
                                 loop {
-                                    if input.peek(Token![,]) || input.peek(Token![>]) {
+                                    if input.peek(Token![,] | Token![>]) {
                                         break;
                                     }
                                     let value: TypeParamBound = input.parse()?;
@@ -405,7 +405,7 @@ pub mod parsing {
 
     impl PathSegment {
         fn parse_helper(input: ParseStream, expr_style: bool) -> Result<Self> {
-            if input.peek(Token![super]) || input.peek(Token![self]) || input.peek(Token![crate]) {
+            if input.peek(Token![super] | Token![self] | Token![crate]) {
                 let ident = input.call(Ident::parse_any)?;
                 return Ok(PathSegment::from(ident));
             }
@@ -467,12 +467,9 @@ pub mod parsing {
                 segments: {
                     let mut segments = Punctuated::new();
                     loop {
-                        if !input.peek(Ident)
-                            && !input.peek(Token![super])
-                            && !input.peek(Token![self])
-                            && !input.peek(Token![Self])
-                            && !input.peek(Token![crate])
-                        {
+                        if !input.peek(
+                            Ident | Token![super] | Token![self] | Token![Self] | Token![crate],
+                        ) {
                             break;
                         }
                         let ident = Ident::parse_any(input)?;

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -201,33 +201,30 @@ pub mod parsing {
 
         if input.peek(Token![let]) {
             stmt_local(input, attrs).map(Stmt::Local)
-        } else if input.peek(Token![pub])
-            || input.peek(Token![crate]) && !input.peek2(Token![::])
-            || input.peek(Token![extern])
-            || input.peek(Token![use])
+        } else if input.peek(
+            Token![pub]
+                | Token![extern]
+                | Token![use]
+                | Token![fn]
+                | Token![mod]
+                | Token![type]
+                | Token![struct]
+                | Token![enum]
+                | Token![trait]
+                | Token![impl]
+                | Token![macro],
+        ) || input.peek(Token![crate]) && !input.peek2(Token![::])
             || input.peek(Token![static])
                 && (input.peek2(Token![mut])
                     || input.peek2(Ident)
-                        && !(input.peek2(Token![async])
-                            && (input.peek3(Token![move]) || input.peek3(Token![|]))))
+                        && !(input.peek2(Token![async]) && input.peek3(Token![move] | Token![|])))
             || input.peek(Token![const]) && !input.peek2(token::Brace)
             || input.peek(Token![unsafe]) && !input.peek2(token::Brace)
             || input.peek(Token![async])
-                && (input.peek2(Token![unsafe])
-                    || input.peek2(Token![extern])
-                    || input.peek2(Token![fn]))
-            || input.peek(Token![fn])
-            || input.peek(Token![mod])
-            || input.peek(Token![type])
-            || input.peek(Token![struct])
-            || input.peek(Token![enum])
+                && input.peek2(Token![unsafe] | Token![extern] | Token![fn])
             || input.peek(Token![union]) && input.peek2(Ident)
             || input.peek(Token![auto]) && input.peek2(Token![trait])
-            || input.peek(Token![trait])
-            || input.peek(Token![default])
-                && (input.peek2(Token![unsafe]) || input.peek2(Token![impl]))
-            || input.peek(Token![impl])
-            || input.peek(Token![macro])
+            || input.peek(Token![default]) && input.peek2(Token![unsafe] | Token![impl])
             || is_item_macro
         {
             let mut item: Item = input.parse()?;


### PR DESCRIPTION
Before: `input.peek(Token![fn]) || input.peek(Token![unsafe])`
After: `input.peek(Token![fn] | Token![unsafe])`