### PR TITLE
Delete WherePredicate::Eq and PredicateEq

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1619,17 +1619,6 @@ impl Clone for PathSegment {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
-impl Clone for PredicateEq {
-    fn clone(&self) -> Self {
-        PredicateEq {
-            lhs_ty: self.lhs_ty.clone(),
-            eq_token: self.eq_token.clone(),
-            rhs_ty: self.rhs_ty.clone(),
-        }
-    }
-}
-#[cfg(any(feature = "derive", feature = "full"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
 impl Clone for PredicateLifetime {
     fn clone(&self) -> Self {
         PredicateLifetime {
@@ -2179,7 +2168,6 @@ impl Clone for WherePredicate {
         match self {
             WherePredicate::Type(v0) => WherePredicate::Type(v0.clone()),
             WherePredicate::Lifetime(v0) => WherePredicate::Lifetime(v0.clone()),
-            WherePredicate::Eq(v0) => WherePredicate::Eq(v0.clone()),
         }
     }
 }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -2223,17 +2223,6 @@ impl Debug for PathSegment {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Debug for PredicateEq {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let mut formatter = formatter.debug_struct("PredicateEq");
-        formatter.field("lhs_ty", &self.lhs_ty);
-        formatter.field("eq_token", &self.eq_token);
-        formatter.field("rhs_ty", &self.rhs_ty);
-        formatter.finish()
-    }
-}
-#[cfg(any(feature = "derive", feature = "full"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Debug for PredicateLifetime {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("PredicateLifetime");
@@ -2961,11 +2950,6 @@ impl Debug for WherePredicate {
             }
             WherePredicate::Lifetime(v0) => {
                 let mut formatter = formatter.debug_tuple("Lifetime");
-                formatter.field(v0);
-                formatter.finish()
-            }
-            WherePredicate::Eq(v0) => {
-                let mut formatter = formatter.debug_tuple("Eq");
                 formatter.field(v0);
                 formatter.finish()
             }

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1546,16 +1546,6 @@ impl PartialEq for PathSegment {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Eq for PredicateEq {}
-#[cfg(any(feature = "derive", feature = "full"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl PartialEq for PredicateEq {
-    fn eq(&self, other: &Self) -> bool {
-        self.lhs_ty == other.lhs_ty && self.rhs_ty == other.rhs_ty
-    }
-}
-#[cfg(any(feature = "derive", feature = "full"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Eq for PredicateLifetime {}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
@@ -2139,7 +2129,6 @@ impl PartialEq for WherePredicate {
             (WherePredicate::Lifetime(self0), WherePredicate::Lifetime(other0)) => {
                 self0 == other0
             }
-            (WherePredicate::Eq(self0), WherePredicate::Eq(other0)) => self0 == other0,
             _ => false,
         }
     }

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -552,10 +552,6 @@ pub trait Fold {
         fold_path_segment(self, i)
     }
     #[cfg(any(feature = "derive", feature = "full"))]
-    fn fold_predicate_eq(&mut self, i: PredicateEq) -> PredicateEq {
-        fold_predicate_eq(self, i)
-    }
-    #[cfg(any(feature = "derive", feature = "full"))]
     fn fold_predicate_lifetime(&mut self, i: PredicateLifetime) -> PredicateLifetime {
         fold_predicate_lifetime(self, i)
     }
@@ -2618,17 +2614,6 @@ where
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
-pub fn fold_predicate_eq<F>(f: &mut F, node: PredicateEq) -> PredicateEq
-where
-    F: Fold + ?Sized,
-{
-    PredicateEq {
-        lhs_ty: f.fold_type(node.lhs_ty),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
-        rhs_ty: f.fold_type(node.rhs_ty),
-    }
-}
-#[cfg(any(feature = "derive", feature = "full"))]
 pub fn fold_predicate_lifetime<F>(
     f: &mut F,
     node: PredicateLifetime,
@@ -3250,9 +3235,6 @@ where
         }
         WherePredicate::Lifetime(_binding_0) => {
             WherePredicate::Lifetime(f.fold_predicate_lifetime(_binding_0))
-        }
-        WherePredicate::Eq(_binding_0) => {
-            WherePredicate::Eq(f.fold_predicate_eq(_binding_0))
         }
     }
 }

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -2065,17 +2065,6 @@ impl Hash for PathSegment {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Hash for PredicateEq {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: Hasher,
-    {
-        self.lhs_ty.hash(state);
-        self.rhs_ty.hash(state);
-    }
-}
-#[cfg(any(feature = "derive", feature = "full"))]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Hash for PredicateLifetime {
     fn hash<H>(&self, state: &mut H)
     where
@@ -2789,10 +2778,6 @@ impl Hash for WherePredicate {
             }
             WherePredicate::Lifetime(v0) => {
                 state.write_u8(1u8);
-                v0.hash(state);
-            }
-            WherePredicate::Eq(v0) => {
-                state.write_u8(2u8);
                 v0.hash(state);
             }
         }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -554,10 +554,6 @@ pub trait Visit<'ast> {
         visit_path_segment(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
-    fn visit_predicate_eq(&mut self, i: &'ast PredicateEq) {
-        visit_predicate_eq(self, i);
-    }
-    #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_predicate_lifetime(&mut self, i: &'ast PredicateLifetime) {
         visit_predicate_lifetime(self, i);
     }
@@ -2961,15 +2957,6 @@ where
     v.visit_path_arguments(&node.arguments);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
-pub fn visit_predicate_eq<'ast, V>(v: &mut V, node: &'ast PredicateEq)
-where
-    V: Visit<'ast> + ?Sized,
-{
-    v.visit_type(&node.lhs_ty);
-    tokens_helper(v, &node.eq_token.spans);
-    v.visit_type(&node.rhs_ty);
-}
-#[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_predicate_lifetime<'ast, V>(v: &mut V, node: &'ast PredicateLifetime)
 where
     V: Visit<'ast> + ?Sized,
@@ -3706,9 +3693,6 @@ where
         }
         WherePredicate::Lifetime(_binding_0) => {
             v.visit_predicate_lifetime(_binding_0);
-        }
-        WherePredicate::Eq(_binding_0) => {
-            v.visit_predicate_eq(_binding_0);
         }
     }
 }

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -555,10 +555,6 @@ pub trait VisitMut {
         visit_path_segment_mut(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
-    fn visit_predicate_eq_mut(&mut self, i: &mut PredicateEq) {
-        visit_predicate_eq_mut(self, i);
-    }
-    #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_predicate_lifetime_mut(&mut self, i: &mut PredicateLifetime) {
         visit_predicate_lifetime_mut(self, i);
     }
@@ -2964,15 +2960,6 @@ where
     v.visit_path_arguments_mut(&mut node.arguments);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
-pub fn visit_predicate_eq_mut<V>(v: &mut V, node: &mut PredicateEq)
-where
-    V: VisitMut + ?Sized,
-{
-    v.visit_type_mut(&mut node.lhs_ty);
-    tokens_helper(v, &mut node.eq_token.spans);
-    v.visit_type_mut(&mut node.rhs_ty);
-}
-#[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_predicate_lifetime_mut<V>(v: &mut V, node: &mut PredicateLifetime)
 where
     V: VisitMut + ?Sized,
@@ -3709,9 +3696,6 @@ where
         }
         WherePredicate::Lifetime(_binding_0) => {
             v.visit_predicate_lifetime_mut(_binding_0);
-        }
-        WherePredicate::Eq(_binding_0) => {
-            v.visit_predicate_eq_mut(_binding_0);
         }
     }
 }

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -501,9 +501,6 @@ ast_enum_of_structs! {
 
         /// A lifetime predicate in a `where` clause: `'a: 'b + 'c`.
         Lifetime(PredicateLifetime),
-
-        /// An equality predicate in a `where` clause (unsupported).
-        Eq(PredicateEq),
     }
 }
 
@@ -528,16 +525,6 @@ ast_struct! {
         pub lifetime: Lifetime,
         pub colon_token: Token![:],
         pub bounds: Punctuated<Lifetime, Token![+]>,
-    }
-}
-
-ast_struct! {
-    /// An equality predicate in a `where` clause (unsupported).
-    #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
-    pub struct PredicateEq {
-        pub lhs_ty: Type,
-        pub eq_token: Token![=],
-        pub rhs_ty: Type,
     }
 }
 
@@ -1227,15 +1214,6 @@ mod printing {
             self.lifetime.to_tokens(tokens);
             self.colon_token.to_tokens(tokens);
             self.bounds.to_tokens(tokens);
-        }
-    }
-
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
-    impl ToTokens for PredicateEq {
-        fn to_tokens(&self, tokens: &mut TokenStream) {
-            self.lhs_ty.to_tokens(tokens);
-            self.eq_token.to_tokens(tokens);
-            self.rhs_ty.to_tokens(tokens);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,9 +369,9 @@ pub use crate::file::File;
 mod generics;
 #[cfg(any(feature = "full", feature = "derive"))]
 pub use crate::generics::{
-    BoundLifetimes, ConstParam, GenericParam, Generics, LifetimeDef, PredicateEq,
-    PredicateLifetime, PredicateType, TraitBound, TraitBoundModifier, TypeParam, TypeParamBound,
-    WhereClause, WherePredicate,
+    BoundLifetimes, ConstParam, GenericParam, Generics, LifetimeDef, PredicateLifetime,
+    PredicateType, TraitBound, TraitBoundModifier, TypeParam, TypeParamBound, WhereClause,
+    WherePredicate,
 };
 #[cfg(all(any(feature = "full", feature = "derive"), feature = "printing"))]
 pub use crate::generics::{ImplGenerics, Turbofish, TypeGenerics};

--- a/syn.json
+++ b/syn.json
@@ -4089,26 +4089,6 @@
       }
     },
     {
-      "ident": "PredicateEq",
-      "features": {
-        "any": [
-          "derive",
-          "full"
-        ]
-      },
-      "fields": {
-        "lhs_ty": {
-          "syn": "Type"
-        },
-        "eq_token": {
-          "token": "Eq"
-        },
-        "rhs_ty": {
-          "syn": "Type"
-        }
-      }
-    },
-    {
       "ident": "PredicateLifetime",
       "features": {
         "any": [
@@ -5429,11 +5409,6 @@
         "Lifetime": [
           {
             "syn": "PredicateLifetime"
-          }
-        ],
-        "Eq": [
-          {
-            "syn": "PredicateEq"
           }
         ]
       }

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -4344,15 +4344,6 @@ impl Debug for Lite<syn::PathSegment> {
         formatter.finish()
     }
 }
-impl Debug for Lite<syn::PredicateEq> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let _val = &self.value;
-        let mut formatter = formatter.debug_struct("PredicateEq");
-        formatter.field("lhs_ty", Lite(&_val.lhs_ty));
-        formatter.field("rhs_ty", Lite(&_val.rhs_ty));
-        formatter.finish()
-    }
-}
 impl Debug for Lite<syn::PredicateLifetime> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let _val = &self.value;
@@ -5830,13 +5821,6 @@ impl Debug for Lite<syn::WherePredicate> {
             }
             syn::WherePredicate::Lifetime(_val) => {
                 formatter.write_str("Lifetime")?;
-                formatter.write_str("(")?;
-                Debug::fmt(Lite(_val), formatter)?;
-                formatter.write_str(")")?;
-                Ok(())
-            }
-            syn::WherePredicate::Eq(_val) => {
-                formatter.write_str("Eq")?;
                 formatter.write_str("(")?;
                 Debug::fmt(Lite(_val), formatter)?;
                 formatter.write_str(")")?;

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -264,7 +264,7 @@ fn test_fn_precedence_in_where_clause() {
 
     let predicate = match &where_clause.predicates[0] {
         WherePredicate::Type(pred) => pred,
-        _ => panic!("wrong predicate kind"),
+        WherePredicate::Lifetime(_) => panic!("wrong predicate kind"),
     };
 
     assert_eq!(predicate.bounds.len(), 2, "{:#?}", predicate.bounds);


### PR DESCRIPTION
This syntax does not appear to be on track for stabilization. https://github.com/rust-lang/rust/issues/20041