### PR TITLE
Make WherePredicate enum non-exhaustive

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -495,6 +495,7 @@ ast_enum_of_structs! {
     ///
     /// [syntax tree enum]: Expr#syntax-tree-enums
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
+    #[non_exhaustive]
     pub enum WherePredicate {
         /// A type predicate in a `where` clause: `for<'c> Foo<'c>: Trait<'c>`.
         Type(PredicateType),

--- a/syn.json
+++ b/syn.json
@@ -5411,7 +5411,8 @@
             "syn": "PredicateLifetime"
           }
         ]
-      }
+      },
+      "exhaustive": false
     }
   ],
   "tokens": {

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -5826,6 +5826,7 @@ impl Debug for Lite<syn::WherePredicate> {
                 formatter.write_str(")")?;
                 Ok(())
             }
+            _ => unreachable!(),
         }
     }
 }

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -264,7 +264,7 @@ fn test_fn_precedence_in_where_clause() {
 
     let predicate = match &where_clause.predicates[0] {
         WherePredicate::Type(pred) => pred,
-        WherePredicate::Lifetime(_) => panic!("wrong predicate kind"),
+        _ => panic!("wrong predicate kind"),
     };
 
     assert_eq!(predicate.bounds.len(), 2, "{:#?}", predicate.bounds);


### PR DESCRIPTION
Between equality constraints and "const if const" bounds and [contexts/capabilities](https://tmandry.gitlab.io/blog/posts/2021-12-21-context-capabilities/#scoped-bounds), it's unclear what might appear in `where`-predicates later.