### PR TITLE
Make Lit enum non-exhaustive

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -19,6 +19,7 @@ ast_enum_of_structs! {
     /// This type is a [syntax tree enum].
     ///
     /// [syntax tree enum]: crate::Expr#syntax-tree-enums
+    #[non_exhaustive]
     pub enum Lit {
         /// A UTF-8 string literal: `"foo"`.
         Str(LitStr),

--- a/syn.json
+++ b/syn.json
@@ -3381,7 +3381,8 @@
             "proc_macro2": "Literal"
           }
         ]
-      }
+      },
+      "exhaustive": false
     },
     {
       "ident": "LitBool",

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -3589,6 +3589,7 @@ impl Debug for Lite<syn::Lit> {
                 formatter.write_str("`)")?;
                 Ok(())
             }
+            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
New kind of literal on the horizon: https://github.com/rust-lang/rfcs/pull/3348