### PR TITLE
Add note to `File` rustdoc about `parse_file`.

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -3,6 +3,8 @@ use super::*;
 ast_struct! {
     /// A complete file of Rust source code.
     ///
+    /// Typically `File` objects are created with [`parse_file`].
+    ///
     /// # Example
     ///
     /// Parse a Rust source file into a `syn::File` and print out a debug


### PR DESCRIPTION
Mostly I'm doing this to make `parse_file` easy to discover with rustdoc hyperlinks