### PR TITLE
Rename LifetimeDef -> LifetimeParam

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1327,9 +1327,9 @@ impl Clone for Label {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
-impl Clone for LifetimeDef {
+impl Clone for LifetimeParam {
     fn clone(&self) -> Self {
-        LifetimeDef {
+        LifetimeParam {
             attrs: self.attrs.clone(),
             lifetime: self.lifetime.clone(),
             colon_token: self.colon_token.clone(),

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1895,9 +1895,9 @@ impl Debug for Lifetime {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Debug for LifetimeDef {
+impl Debug for LifetimeParam {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let mut formatter = formatter.debug_struct("LifetimeDef");
+        let mut formatter = formatter.debug_struct("LifetimeParam");
         formatter.field("attrs", &self.attrs);
         formatter.field("lifetime", &self.lifetime);
         formatter.field("colon_token", &self.colon_token);

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1249,10 +1249,10 @@ impl PartialEq for Label {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Eq for LifetimeDef {}
+impl Eq for LifetimeParam {}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl PartialEq for LifetimeDef {
+impl PartialEq for LifetimeParam {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.lifetime == other.lifetime
             && self.colon_token == other.colon_token && self.bounds == other.bounds

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -437,8 +437,8 @@ pub trait Fold {
         fold_lifetime(self, i)
     }
     #[cfg(any(feature = "derive", feature = "full"))]
-    fn fold_lifetime_def(&mut self, i: LifetimeDef) -> LifetimeDef {
-        fold_lifetime_def(self, i)
+    fn fold_lifetime_param(&mut self, i: LifetimeParam) -> LifetimeParam {
+        fold_lifetime_param(self, i)
     }
     fn fold_lit(&mut self, i: Lit) -> Lit {
         fold_lit(self, i)
@@ -987,7 +987,7 @@ where
     BoundLifetimes {
         for_token: Token![for](tokens_helper(f, &node.for_token.span)),
         lt_token: Token![<](tokens_helper(f, &node.lt_token.spans)),
-        lifetimes: FoldHelper::lift(node.lifetimes, |it| f.fold_lifetime_def(it)),
+        lifetimes: FoldHelper::lift(node.lifetimes, |it| f.fold_lifetime_param(it)),
         gt_token: Token![>](tokens_helper(f, &node.gt_token.spans)),
     }
 }
@@ -1822,7 +1822,7 @@ where
             GenericParam::Type(f.fold_type_param(_binding_0))
         }
         GenericParam::Lifetime(_binding_0) => {
-            GenericParam::Lifetime(f.fold_lifetime_def(_binding_0))
+            GenericParam::Lifetime(f.fold_lifetime_param(_binding_0))
         }
         GenericParam::Const(_binding_0) => {
             GenericParam::Const(f.fold_const_param(_binding_0))
@@ -2243,11 +2243,11 @@ where
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
-pub fn fold_lifetime_def<F>(f: &mut F, node: LifetimeDef) -> LifetimeDef
+pub fn fold_lifetime_param<F>(f: &mut F, node: LifetimeParam) -> LifetimeParam
 where
     F: Fold + ?Sized,
 {
-    LifetimeDef {
+    LifetimeParam {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         lifetime: f.fold_lifetime(node.lifetime),
         colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1677,7 +1677,7 @@ impl Hash for Label {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
-impl Hash for LifetimeDef {
+impl Hash for LifetimeParam {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -439,8 +439,8 @@ pub trait Visit<'ast> {
         visit_lifetime(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
-    fn visit_lifetime_def(&mut self, i: &'ast LifetimeDef) {
-        visit_lifetime_def(self, i);
+    fn visit_lifetime_param(&mut self, i: &'ast LifetimeParam) {
+        visit_lifetime_param(self, i);
     }
     fn visit_lit(&mut self, i: &'ast Lit) {
         visit_lit(self, i);
@@ -991,7 +991,7 @@ where
     tokens_helper(v, &node.lt_token.spans);
     for el in Punctuated::pairs(&node.lifetimes) {
         let (it, p) = el.into_tuple();
-        v.visit_lifetime_def(it);
+        v.visit_lifetime_param(it);
         if let Some(p) = p {
             tokens_helper(v, &p.spans);
         }
@@ -2021,7 +2021,7 @@ where
             v.visit_type_param(_binding_0);
         }
         GenericParam::Lifetime(_binding_0) => {
-            v.visit_lifetime_def(_binding_0);
+            v.visit_lifetime_param(_binding_0);
         }
         GenericParam::Const(_binding_0) => {
             v.visit_const_param(_binding_0);
@@ -2522,7 +2522,7 @@ where
     v.visit_ident(&node.ident);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
-pub fn visit_lifetime_def<'ast, V>(v: &mut V, node: &'ast LifetimeDef)
+pub fn visit_lifetime_param<'ast, V>(v: &mut V, node: &'ast LifetimeParam)
 where
     V: Visit<'ast> + ?Sized,
 {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -440,8 +440,8 @@ pub trait VisitMut {
         visit_lifetime_mut(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
-    fn visit_lifetime_def_mut(&mut self, i: &mut LifetimeDef) {
-        visit_lifetime_def_mut(self, i);
+    fn visit_lifetime_param_mut(&mut self, i: &mut LifetimeParam) {
+        visit_lifetime_param_mut(self, i);
     }
     fn visit_lit_mut(&mut self, i: &mut Lit) {
         visit_lit_mut(self, i);
@@ -992,7 +992,7 @@ where
     tokens_helper(v, &mut node.lt_token.spans);
     for el in Punctuated::pairs_mut(&mut node.lifetimes) {
         let (it, p) = el.into_tuple();
-        v.visit_lifetime_def_mut(it);
+        v.visit_lifetime_param_mut(it);
         if let Some(p) = p {
             tokens_helper(v, &mut p.spans);
         }
@@ -2022,7 +2022,7 @@ where
             v.visit_type_param_mut(_binding_0);
         }
         GenericParam::Lifetime(_binding_0) => {
-            v.visit_lifetime_def_mut(_binding_0);
+            v.visit_lifetime_param_mut(_binding_0);
         }
         GenericParam::Const(_binding_0) => {
             v.visit_const_param_mut(_binding_0);
@@ -2525,7 +2525,7 @@ where
     v.visit_ident_mut(&mut node.ident);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
-pub fn visit_lifetime_def_mut<V>(v: &mut V, node: &mut LifetimeDef)
+pub fn visit_lifetime_param_mut<V>(v: &mut V, node: &mut LifetimeParam)
 where
     V: VisitMut + ?Sized,
 {

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -40,7 +40,7 @@ ast_enum_of_structs! {
         Type(TypeParam),
 
         /// A lifetime definition: `'a: 'b + 'c + 'd`.
-        Lifetime(LifetimeDef),
+        Lifetime(LifetimeParam),
 
         /// A const generic parameter: `const LENGTH: usize`.
         Const(ConstParam),
@@ -63,7 +63,7 @@ ast_struct! {
 ast_struct! {
     /// A lifetime definition: `'a: 'b + 'c + 'd`.
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
-    pub struct LifetimeDef {
+    pub struct LifetimeParam {
         pub attrs: Vec<Attribute>,
         pub lifetime: Lifetime,
         pub colon_token: Option<Token![:]>,
@@ -122,8 +122,8 @@ impl Generics {
     /// Returns an
     /// <code
     ///   style="padding-right:0;">Iterator&lt;Item = &amp;</code><a
-    ///   href="struct.LifetimeDef.html"><code
-    ///   style="padding-left:0;padding-right:0;">LifetimeDef</code></a><code
+    ///   href="struct.LifetimeParam.html"><code
+    ///   style="padding-left:0;padding-right:0;">LifetimeParam</code></a><code
     ///   style="padding-left:0;">&gt;</code>
     /// over the lifetime parameters in `self.params`.
     pub fn lifetimes(&self) -> Lifetimes {
@@ -133,8 +133,8 @@ impl Generics {
     /// Returns an
     /// <code
     ///   style="padding-right:0;">Iterator&lt;Item = &amp;mut </code><a
-    ///   href="struct.LifetimeDef.html"><code
-    ///   style="padding-left:0;padding-right:0;">LifetimeDef</code></a><code
+    ///   href="struct.LifetimeParam.html"><code
+    ///   style="padding-left:0;padding-right:0;">LifetimeParam</code></a><code
     ///   style="padding-left:0;">&gt;</code>
     /// over the lifetime parameters in `self.params`.
     pub fn lifetimes_mut(&mut self) -> LifetimesMut {
@@ -211,7 +211,7 @@ impl<'a> Iterator for TypeParamsMut<'a> {
 pub struct Lifetimes<'a>(Iter<'a, GenericParam>);
 
 impl<'a> Iterator for Lifetimes<'a> {
-    type Item = &'a LifetimeDef;
+    type Item = &'a LifetimeParam;
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = match self.0.next() {
@@ -229,7 +229,7 @@ impl<'a> Iterator for Lifetimes<'a> {
 pub struct LifetimesMut<'a>(IterMut<'a, GenericParam>);
 
 impl<'a> Iterator for LifetimesMut<'a> {
-    type Item = &'a mut LifetimeDef;
+    type Item = &'a mut LifetimeParam;
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = match self.0.next() {
@@ -402,7 +402,7 @@ ast_struct! {
     pub struct BoundLifetimes {
         pub for_token: Token![for],
         pub lt_token: Token![<],
-        pub lifetimes: Punctuated<LifetimeDef, Token![,]>,
+        pub lifetimes: Punctuated<LifetimeParam, Token![,]>,
         pub gt_token: Token![>],
     }
 }
@@ -418,9 +418,9 @@ impl Default for BoundLifetimes {
     }
 }
 
-impl LifetimeDef {
+impl LifetimeParam {
     pub fn new(lifetime: Lifetime) -> Self {
-        LifetimeDef {
+        LifetimeParam {
             attrs: Vec::new(),
             lifetime,
             colon_token: None,
@@ -553,7 +553,7 @@ pub(crate) mod parsing {
                 let attrs = input.call(Attribute::parse_outer)?;
                 let lookahead = input.lookahead1();
                 if lookahead.peek(Lifetime) {
-                    params.push_value(GenericParam::Lifetime(LifetimeDef {
+                    params.push_value(GenericParam::Lifetime(LifetimeParam {
                         attrs,
                         ..input.parse()?
                     }));
@@ -610,7 +610,7 @@ pub(crate) mod parsing {
                     ..input.parse()?
                 }))
             } else if lookahead.peek(Lifetime) {
-                Ok(GenericParam::Lifetime(LifetimeDef {
+                Ok(GenericParam::Lifetime(LifetimeParam {
                     attrs,
                     ..input.parse()?
                 }))
@@ -626,10 +626,10 @@ pub(crate) mod parsing {
     }
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
-    impl Parse for LifetimeDef {
+    impl Parse for LifetimeParam {
         fn parse(input: ParseStream) -> Result<Self> {
             let has_colon;
-            Ok(LifetimeDef {
+            Ok(LifetimeParam {
                 attrs: input.call(Attribute::parse_outer)?,
                 lifetime: input.parse()?,
                 colon_token: {
@@ -1122,7 +1122,7 @@ mod printing {
     }
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "printing")))]
-    impl ToTokens for LifetimeDef {
+    impl ToTokens for LifetimeParam {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             tokens.append_all(self.attrs.outer());
             self.lifetime.to_tokens(tokens);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,7 @@ pub use crate::file::File;
 mod generics;
 #[cfg(any(feature = "full", feature = "derive"))]
 pub use crate::generics::{
-    BoundLifetimes, ConstParam, GenericParam, Generics, LifetimeDef, PredicateLifetime,
+    BoundLifetimes, ConstParam, GenericParam, Generics, LifetimeParam, PredicateLifetime,
     PredicateType, TraitBound, TraitBoundModifier, TypeParam, TypeParamBound, WhereClause,
     WherePredicate,
 };

--- a/src/lookahead.rs
+++ b/src/lookahead.rs
@@ -24,7 +24,7 @@ use std::cell::RefCell;
 /// # Example
 ///
 /// ```
-/// use syn::{ConstParam, Ident, Lifetime, LifetimeDef, Result, Token, TypeParam};
+/// use syn::{ConstParam, Ident, Lifetime, LifetimeParam, Result, Token, TypeParam};
 /// use syn::parse::{Parse, ParseStream};
 ///
 /// // A generic parameter, a single one of the comma-separated elements inside
@@ -40,7 +40,7 @@ use std::cell::RefCell;
 /// //       |          ^
 /// enum GenericParam {
 ///     Type(TypeParam),
-///     Lifetime(LifetimeDef),
+///     Lifetime(LifetimeParam),
 ///     Const(ConstParam),
 /// }
 ///

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -799,7 +799,7 @@ impl<'a> ParseBuffer<'a> {
     /// # Example
     ///
     /// ```
-    /// use syn::{ConstParam, Ident, Lifetime, LifetimeDef, Result, Token, TypeParam};
+    /// use syn::{ConstParam, Ident, Lifetime, LifetimeParam, Result, Token, TypeParam};
     /// use syn::parse::{Parse, ParseStream};
     ///
     /// // A generic parameter, a single one of the comma-separated elements inside
@@ -815,7 +815,7 @@ impl<'a> ParseBuffer<'a> {
     /// //       |          ^
     /// enum GenericParam {
     ///     Type(TypeParam),
-    ///     Lifetime(LifetimeDef),
+    ///     Lifetime(LifetimeParam),
     ///     Const(ConstParam),
     /// }
     ///

--- a/syn.json
+++ b/syn.json
@@ -439,7 +439,7 @@
         "lifetimes": {
           "punctuated": {
             "element": {
-              "syn": "LifetimeDef"
+              "syn": "LifetimeParam"
             },
             "punct": "Comma"
           }
@@ -2367,7 +2367,7 @@
         ],
         "Lifetime": [
           {
-            "syn": "LifetimeDef"
+            "syn": "LifetimeParam"
           }
         ],
         "Const": [
@@ -3331,7 +3331,7 @@
       }
     },
     {
-      "ident": "LifetimeDef",
+      "ident": "LifetimeParam",
       "features": {
         "any": [
           "derive",

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -2850,9 +2850,9 @@ impl Debug for Lite<syn::Lifetime> {
         formatter.finish()
     }
 }
-impl Debug for Lite<syn::LifetimeDef> {
+impl Debug for Lite<syn::LifetimeParam> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let mut formatter = formatter.debug_struct("LifetimeDef");
+        let mut formatter = formatter.debug_struct("LifetimeParam");
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -23,12 +23,12 @@ fn test_split_for_impl() {
         generics: Generics {
             lt_token: Some,
             params: [
-                GenericParam::Lifetime(LifetimeDef {
+                GenericParam::Lifetime(LifetimeParam {
                     lifetime: Lifetime {
                         ident: "a",
                     },
                 }),
-                GenericParam::Lifetime(LifetimeDef {
+                GenericParam::Lifetime(LifetimeParam {
                     lifetime: Lifetime {
                         ident: "b",
                     },

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -223,7 +223,7 @@ fn test_trait_object() {
             TypeParamBound::Trait(TraitBound {
                 lifetimes: Some(BoundLifetimes {
                     lifetimes: [
-                        LifetimeDef {
+                        LifetimeParam {
                             lifetime: Lifetime {
                                 ident: "a",
                             },


### PR DESCRIPTION
This name makes more sense in the context of then `GenericParam` enum, and is the name that the Rust Reference uses. 

```rust
pub enum GenericParam {
    Type(TypeParam),
    Lifetime(LifetimeParam),
    Const(ConstParam),
}
```

https://doc.rust-lang.org/nightly/reference/items/generics.html