### PR TITLE
Reorder GenericParams so lifetimes come before types

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -955,8 +955,8 @@ impl Clone for GenericArgument {
 impl Clone for GenericParam {
     fn clone(&self) -> Self {
         match self {
-            GenericParam::Type(v0) => GenericParam::Type(v0.clone()),
             GenericParam::Lifetime(v0) => GenericParam::Lifetime(v0.clone()),
+            GenericParam::Type(v0) => GenericParam::Type(v0.clone()),
             GenericParam::Const(v0) => GenericParam::Const(v0.clone()),
         }
     }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1392,13 +1392,13 @@ impl Debug for GenericParam {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("GenericParam::")?;
         match self {
-            GenericParam::Type(v0) => {
-                let mut formatter = formatter.debug_tuple("Type");
+            GenericParam::Lifetime(v0) => {
+                let mut formatter = formatter.debug_tuple("Lifetime");
                 formatter.field(v0);
                 formatter.finish()
             }
-            GenericParam::Lifetime(v0) => {
-                let mut formatter = formatter.debug_tuple("Lifetime");
+            GenericParam::Type(v0) => {
+                let mut formatter = formatter.debug_tuple("Type");
                 formatter.field(v0);
                 formatter.finish()
             }

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -938,10 +938,10 @@ impl Eq for GenericParam {}
 impl PartialEq for GenericParam {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (GenericParam::Type(self0), GenericParam::Type(other0)) => self0 == other0,
             (GenericParam::Lifetime(self0), GenericParam::Lifetime(other0)) => {
                 self0 == other0
             }
+            (GenericParam::Type(self0), GenericParam::Type(other0)) => self0 == other0,
             (GenericParam::Const(self0), GenericParam::Const(other0)) => self0 == other0,
             _ => false,
         }

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -1818,11 +1818,11 @@ where
     F: Fold + ?Sized,
 {
     match node {
-        GenericParam::Type(_binding_0) => {
-            GenericParam::Type(f.fold_type_param(_binding_0))
-        }
         GenericParam::Lifetime(_binding_0) => {
             GenericParam::Lifetime(f.fold_lifetime_param(_binding_0))
+        }
+        GenericParam::Type(_binding_0) => {
+            GenericParam::Type(f.fold_type_param(_binding_0))
         }
         GenericParam::Const(_binding_0) => {
             GenericParam::Const(f.fold_const_param(_binding_0))

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1250,11 +1250,11 @@ impl Hash for GenericParam {
         H: Hasher,
     {
         match self {
-            GenericParam::Type(v0) => {
+            GenericParam::Lifetime(v0) => {
                 state.write_u8(0u8);
                 v0.hash(state);
             }
-            GenericParam::Lifetime(v0) => {
+            GenericParam::Type(v0) => {
                 state.write_u8(1u8);
                 v0.hash(state);
             }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -2017,11 +2017,11 @@ where
     V: Visit<'ast> + ?Sized,
 {
     match node {
-        GenericParam::Type(_binding_0) => {
-            v.visit_type_param(_binding_0);
-        }
         GenericParam::Lifetime(_binding_0) => {
             v.visit_lifetime_param(_binding_0);
+        }
+        GenericParam::Type(_binding_0) => {
+            v.visit_type_param(_binding_0);
         }
         GenericParam::Const(_binding_0) => {
             v.visit_const_param(_binding_0);

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -2018,11 +2018,11 @@ where
     V: VisitMut + ?Sized,
 {
     match node {
-        GenericParam::Type(_binding_0) => {
-            v.visit_type_param_mut(_binding_0);
-        }
         GenericParam::Lifetime(_binding_0) => {
             v.visit_lifetime_param_mut(_binding_0);
+        }
+        GenericParam::Type(_binding_0) => {
+            v.visit_type_param_mut(_binding_0);
         }
         GenericParam::Const(_binding_0) => {
             v.visit_const_param_mut(_binding_0);

--- a/syn.json
+++ b/syn.json
@@ -2360,14 +2360,14 @@
         ]
       },
       "variants": {
-        "Type": [
-          {
-            "syn": "TypeParam"
-          }
-        ],
         "Lifetime": [
           {
             "syn": "LifetimeParam"
+          }
+        ],
+        "Type": [
+          {
+            "syn": "TypeParam"
           }
         ],
         "Const": [

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -2045,15 +2045,15 @@ impl Debug for Lite<syn::GenericArgument> {
 impl Debug for Lite<syn::GenericParam> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match &self.value {
-            syn::GenericParam::Type(_val) => {
-                formatter.write_str("GenericParam::Type")?;
+            syn::GenericParam::Lifetime(_val) => {
+                formatter.write_str("GenericParam::Lifetime")?;
                 formatter.write_str("(")?;
                 Debug::fmt(Lite(_val), formatter)?;
                 formatter.write_str(")")?;
                 Ok(())
             }
-            syn::GenericParam::Lifetime(_val) => {
-                formatter.write_str("GenericParam::Lifetime")?;
+            syn::GenericParam::Type(_val) => {
+                formatter.write_str("GenericParam::Type")?;
                 formatter.write_str("(")?;
                 Debug::fmt(Lite(_val), formatter)?;
                 formatter.write_str(")")?;


### PR DESCRIPTION
This matches the order in the Rust Reference. It also matches the order these parameters are *required* to appear in source code &mdash; makes sense.

https://doc.rust-lang.org/nightly/reference/items/generics.html