### PR TITLE
Do not parse bounds on lifetime as part of BoundLifetimes

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -672,8 +672,14 @@ pub(crate) mod parsing {
                 lifetimes: {
                     let mut lifetimes = Punctuated::new();
                     while !input.peek(Token![>]) {
-                        let lifetime: LifetimeParam = input.parse()?;
-                        lifetimes.push_value(lifetime);
+                        let attrs = input.call(Attribute::parse_outer)?;
+                        let lifetime: Lifetime = input.parse()?;
+                        lifetimes.push_value(LifetimeParam {
+                            attrs,
+                            lifetime,
+                            colon_token: None,
+                            bounds: Punctuated::new(),
+                        });
                         if input.peek(Token![>]) {
                             break;
                         }

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -672,7 +672,8 @@ pub(crate) mod parsing {
                 lifetimes: {
                     let mut lifetimes = Punctuated::new();
                     while !input.peek(Token![>]) {
-                        lifetimes.push_value(input.parse()?);
+                        let lifetime: LifetimeParam = input.parse()?;
+                        lifetimes.push_value(lifetime);
                         if input.peek(Token![>]) {
                             break;
                         }

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -31,6 +31,9 @@ static EXCLUDE_FILES: &[&str] = &[
     // Need at least one trait in impl Trait, no such type as impl 'static
     "tests/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.rs",
 
+    // Lifetime bound inside for<>: `T: ~const ?for<'a: 'b> Trait<'a>`
+    "tests/ui/rfc-2632-const-trait-impl/tilde-const-syntax.rs",
+
     // Deprecated anonymous parameter syntax in traits
     "src/tools/rustfmt/tests/source/trait.rs",
     "src/tools/rustfmt/tests/target/trait.rs",


### PR DESCRIPTION
Rustc's parser allows `for<'a: 'b>` and rejects it later. We can reject until somebody has a  use case that requires being able to parse this pseudo-syntax.