### PR TITLE
Generalize BoundLifetimes to hold non-lifetime generic params

### DIFF
--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -987,7 +987,7 @@ where
     BoundLifetimes {
         for_token: Token![for](tokens_helper(f, &node.for_token.span)),
         lt_token: Token![<](tokens_helper(f, &node.lt_token.spans)),
-        lifetimes: FoldHelper::lift(node.lifetimes, |it| f.fold_lifetime_param(it)),
+        lifetimes: FoldHelper::lift(node.lifetimes, |it| f.fold_generic_param(it)),
         gt_token: Token![>](tokens_helper(f, &node.gt_token.spans)),
     }
 }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -991,7 +991,7 @@ where
     tokens_helper(v, &node.lt_token.spans);
     for el in Punctuated::pairs(&node.lifetimes) {
         let (it, p) = el.into_tuple();
-        v.visit_lifetime_param(it);
+        v.visit_generic_param(it);
         if let Some(p) = p {
             tokens_helper(v, &p.spans);
         }

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -992,7 +992,7 @@ where
     tokens_helper(v, &mut node.lt_token.spans);
     for el in Punctuated::pairs_mut(&mut node.lifetimes) {
         let (it, p) = el.into_tuple();
-        v.visit_lifetime_param_mut(it);
+        v.visit_generic_param_mut(it);
         if let Some(p) = p {
             tokens_helper(v, &mut p.spans);
         }

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -402,7 +402,7 @@ ast_struct! {
     pub struct BoundLifetimes {
         pub for_token: Token![for],
         pub lt_token: Token![<],
-        pub lifetimes: Punctuated<LifetimeParam, Token![,]>,
+        pub lifetimes: Punctuated<GenericParam, Token![,]>,
         pub gt_token: Token![>],
     }
 }
@@ -674,12 +674,12 @@ pub(crate) mod parsing {
                     while !input.peek(Token![>]) {
                         let attrs = input.call(Attribute::parse_outer)?;
                         let lifetime: Lifetime = input.parse()?;
-                        lifetimes.push_value(LifetimeParam {
+                        lifetimes.push_value(GenericParam::Lifetime(LifetimeParam {
                             attrs,
                             lifetime,
                             colon_token: None,
                             bounds: Punctuated::new(),
-                        });
+                        }));
                         if input.peek(Token![>]) {
                             break;
                         }

--- a/syn.json
+++ b/syn.json
@@ -439,7 +439,7 @@
         "lifetimes": {
           "punctuated": {
             "element": {
-              "syn": "LifetimeParam"
+              "syn": "GenericParam"
             },
             "punct": "Comma"
           }

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -223,11 +223,11 @@ fn test_trait_object() {
             TypeParamBound::Trait(TraitBound {
                 lifetimes: Some(BoundLifetimes {
                     lifetimes: [
-                        LifetimeParam {
+                        GenericParam::Lifetime(LifetimeParam {
                             lifetime: Lifetime {
                                 ident: "a",
                             },
-                        },
+                        }),
                     ],
                 }),
                 path: Path {


### PR DESCRIPTION
The Rust Reference allows `for<>` syntax to contain any generic param, not only lifetime params. https://doc.rust-lang.org/1.67.0/reference/trait-bounds.html#higher-ranked-trait-bounds

In a world of GATS getting more fleshed out I can easily see that syntax getting used eventually.&mdash;

```rust
trait Trait {
    type Assoc<T>;
}

fn f<K>() where K: for<T> Trait<Assoc<T> = u8> {}

```

The type name `BoundLifetimes` is not great in that situation but it's better than breaking changes.