### PR TITLE
Add a Pat variant for a single parenthesized pattern

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2308,6 +2308,7 @@ pub(crate) mod parsing {
                 Pat::Lit(pat) => pat.attrs = attrs,
                 Pat::Macro(pat) => pat.attrs = attrs,
                 Pat::Or(pat) => pat.attrs = attrs,
+                Pat::Paren(pat) => pat.attrs = attrs,
                 Pat::Path(pat) => pat.attrs = attrs,
                 Pat::Range(pat) => pat.attrs = attrs,
                 Pat::Reference(pat) => pat.attrs = attrs,

--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1461,6 +1461,7 @@ impl Clone for Pat {
             Pat::Lit(v0) => Pat::Lit(v0.clone()),
             Pat::Macro(v0) => Pat::Macro(v0.clone()),
             Pat::Or(v0) => Pat::Or(v0.clone()),
+            Pat::Paren(v0) => Pat::Paren(v0.clone()),
             Pat::Path(v0) => Pat::Path(v0.clone()),
             Pat::Range(v0) => Pat::Range(v0.clone()),
             Pat::Reference(v0) => Pat::Reference(v0.clone()),
@@ -1496,6 +1497,17 @@ impl Clone for PatOr {
             attrs: self.attrs.clone(),
             leading_vert: self.leading_vert.clone(),
             cases: self.cases.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
+impl Clone for PatParen {
+    fn clone(&self) -> Self {
+        PatParen {
+            attrs: self.attrs.clone(),
+            paren_token: self.paren_token.clone(),
+            pat: self.pat.clone(),
         }
     }
 }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -2076,6 +2076,7 @@ impl Debug for Pat {
                 formatter.finish()
             }
             Pat::Or(v0) => v0.debug(formatter, "Or"),
+            Pat::Paren(v0) => v0.debug(formatter, "Paren"),
             Pat::Path(v0) => {
                 let mut formatter = formatter.debug_tuple("Path");
                 formatter.field(v0);
@@ -2134,6 +2135,22 @@ impl Debug for PatOr {
             }
         }
         self.debug(formatter, "PatOr")
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Debug for PatParen {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        impl PatParen {
+            fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
+                let mut formatter = formatter.debug_struct(name);
+                formatter.field("attrs", &self.attrs);
+                formatter.field("paren_token", &self.paren_token);
+                formatter.field("pat", &self.pat);
+                formatter.finish()
+            }
+        }
+        self.debug(formatter, "PatParen")
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1393,6 +1393,7 @@ impl PartialEq for Pat {
             (Pat::Lit(self0), Pat::Lit(other0)) => self0 == other0,
             (Pat::Macro(self0), Pat::Macro(other0)) => self0 == other0,
             (Pat::Or(self0), Pat::Or(other0)) => self0 == other0,
+            (Pat::Paren(self0), Pat::Paren(other0)) => self0 == other0,
             (Pat::Path(self0), Pat::Path(other0)) => self0 == other0,
             (Pat::Range(self0), Pat::Range(other0)) => self0 == other0,
             (Pat::Reference(self0), Pat::Reference(other0)) => self0 == other0,
@@ -1431,6 +1432,16 @@ impl PartialEq for PatOr {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.leading_vert == other.leading_vert
             && self.cases == other.cases
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Eq for PatParen {}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for PatParen {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.pat == other.pat
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -512,6 +512,10 @@ pub trait Fold {
         fold_pat_or(self, i)
     }
     #[cfg(feature = "full")]
+    fn fold_pat_paren(&mut self, i: PatParen) -> PatParen {
+        fold_pat_paren(self, i)
+    }
+    #[cfg(feature = "full")]
     fn fold_pat_reference(&mut self, i: PatReference) -> PatReference {
         fold_pat_reference(self, i)
     }
@@ -2443,6 +2447,7 @@ where
         Pat::Lit(_binding_0) => Pat::Lit(f.fold_expr_lit(_binding_0)),
         Pat::Macro(_binding_0) => Pat::Macro(f.fold_expr_macro(_binding_0)),
         Pat::Or(_binding_0) => Pat::Or(f.fold_pat_or(_binding_0)),
+        Pat::Paren(_binding_0) => Pat::Paren(f.fold_pat_paren(_binding_0)),
         Pat::Path(_binding_0) => Pat::Path(f.fold_expr_path(_binding_0)),
         Pat::Range(_binding_0) => Pat::Range(f.fold_expr_range(_binding_0)),
         Pat::Reference(_binding_0) => Pat::Reference(f.fold_pat_reference(_binding_0)),
@@ -2485,6 +2490,17 @@ where
         leading_vert: (node.leading_vert)
             .map(|it| Token![|](tokens_helper(f, &it.spans))),
         cases: FoldHelper::lift(node.cases, |it| f.fold_pat(it)),
+    }
+}
+#[cfg(feature = "full")]
+pub fn fold_pat_paren<F>(f: &mut F, node: PatParen) -> PatParen
+where
+    F: Fold + ?Sized,
+{
+    PatParen {
+        attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
+        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        pat: Box::new(f.fold_pat(*node.pat)),
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1864,48 +1864,52 @@ impl Hash for Pat {
                 state.write_u8(4u8);
                 v0.hash(state);
             }
-            Pat::Path(v0) => {
+            Pat::Paren(v0) => {
                 state.write_u8(5u8);
                 v0.hash(state);
             }
-            Pat::Range(v0) => {
+            Pat::Path(v0) => {
                 state.write_u8(6u8);
                 v0.hash(state);
             }
-            Pat::Reference(v0) => {
+            Pat::Range(v0) => {
                 state.write_u8(7u8);
                 v0.hash(state);
             }
-            Pat::Rest(v0) => {
+            Pat::Reference(v0) => {
                 state.write_u8(8u8);
                 v0.hash(state);
             }
-            Pat::Slice(v0) => {
+            Pat::Rest(v0) => {
                 state.write_u8(9u8);
                 v0.hash(state);
             }
-            Pat::Struct(v0) => {
+            Pat::Slice(v0) => {
                 state.write_u8(10u8);
                 v0.hash(state);
             }
-            Pat::Tuple(v0) => {
+            Pat::Struct(v0) => {
                 state.write_u8(11u8);
                 v0.hash(state);
             }
-            Pat::TupleStruct(v0) => {
+            Pat::Tuple(v0) => {
                 state.write_u8(12u8);
                 v0.hash(state);
             }
-            Pat::Type(v0) => {
+            Pat::TupleStruct(v0) => {
                 state.write_u8(13u8);
                 v0.hash(state);
             }
-            Pat::Verbatim(v0) => {
+            Pat::Type(v0) => {
                 state.write_u8(14u8);
+                v0.hash(state);
+            }
+            Pat::Verbatim(v0) => {
+                state.write_u8(15u8);
                 TokenStreamHelper(v0).hash(state);
             }
             Pat::Wild(v0) => {
-                state.write_u8(15u8);
+                state.write_u8(16u8);
                 v0.hash(state);
             }
         }
@@ -1935,6 +1939,17 @@ impl Hash for PatOr {
         self.attrs.hash(state);
         self.leading_vert.hash(state);
         self.cases.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
+impl Hash for PatParen {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.pat.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -514,6 +514,10 @@ pub trait Visit<'ast> {
         visit_pat_or(self, i);
     }
     #[cfg(feature = "full")]
+    fn visit_pat_paren(&mut self, i: &'ast PatParen) {
+        visit_pat_paren(self, i);
+    }
+    #[cfg(feature = "full")]
     fn visit_pat_reference(&mut self, i: &'ast PatReference) {
         visit_pat_reference(self, i);
     }
@@ -2733,6 +2737,9 @@ where
         Pat::Or(_binding_0) => {
             v.visit_pat_or(_binding_0);
         }
+        Pat::Paren(_binding_0) => {
+            v.visit_pat_paren(_binding_0);
+        }
         Pat::Path(_binding_0) => {
             v.visit_expr_path(_binding_0);
         }
@@ -2806,6 +2813,17 @@ where
             tokens_helper(v, &p.spans);
         }
     }
+}
+#[cfg(feature = "full")]
+pub fn visit_pat_paren<'ast, V>(v: &mut V, node: &'ast PatParen)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    tokens_helper(v, &node.paren_token.span);
+    v.visit_pat(&*node.pat);
 }
 #[cfg(feature = "full")]
 pub fn visit_pat_reference<'ast, V>(v: &mut V, node: &'ast PatReference)

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -515,6 +515,10 @@ pub trait VisitMut {
         visit_pat_or_mut(self, i);
     }
     #[cfg(feature = "full")]
+    fn visit_pat_paren_mut(&mut self, i: &mut PatParen) {
+        visit_pat_paren_mut(self, i);
+    }
+    #[cfg(feature = "full")]
     fn visit_pat_reference_mut(&mut self, i: &mut PatReference) {
         visit_pat_reference_mut(self, i);
     }
@@ -2736,6 +2740,9 @@ where
         Pat::Or(_binding_0) => {
             v.visit_pat_or_mut(_binding_0);
         }
+        Pat::Paren(_binding_0) => {
+            v.visit_pat_paren_mut(_binding_0);
+        }
         Pat::Path(_binding_0) => {
             v.visit_expr_path_mut(_binding_0);
         }
@@ -2809,6 +2816,17 @@ where
             tokens_helper(v, &mut p.spans);
         }
     }
+}
+#[cfg(feature = "full")]
+pub fn visit_pat_paren_mut<V>(v: &mut V, node: &mut PatParen)
+where
+    V: VisitMut + ?Sized,
+{
+    for it in &mut node.attrs {
+        v.visit_attribute_mut(it);
+    }
+    tokens_helper(v, &mut node.paren_token.span);
+    v.visit_pat_mut(&mut *node.pat);
 }
 #[cfg(feature = "full")]
 pub fn visit_pat_reference_mut<V>(v: &mut V, node: &mut PatReference)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,7 +442,7 @@ pub use crate::expr::{
 };
 #[cfg(feature = "full")]
 pub use crate::pat::{
-    FieldPat, Pat, PatIdent, PatOr, PatReference, PatRest, PatSlice, PatStruct, PatTuple,
+    FieldPat, Pat, PatIdent, PatOr, PatParen, PatReference, PatRest, PatSlice, PatStruct, PatTuple,
     PatTupleStruct, PatType, PatWild,
 };
 

--- a/syn.json
+++ b/syn.json
@@ -3697,6 +3697,11 @@
             "syn": "PatOr"
           }
         ],
+        "Paren": [
+          {
+            "syn": "PatParen"
+          }
+        ],
         "Path": [
           {
             "syn": "ExprPath"
@@ -3821,6 +3826,29 @@
               "syn": "Pat"
             },
             "punct": "Or"
+          }
+        }
+      }
+    },
+    {
+      "ident": "PatParen",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "paren_token": {
+          "group": "Paren"
+        },
+        "pat": {
+          "box": {
+            "syn": "Pat"
           }
         }
       }

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -3134,6 +3134,14 @@ impl Debug for Lite<syn::Pat> {
                 }
                 formatter.finish()
             }
+            syn::Pat::Paren(_val) => {
+                let mut formatter = formatter.debug_struct("Pat::Paren");
+                if !_val.attrs.is_empty() {
+                    formatter.field("attrs", Lite(&_val.attrs));
+                }
+                formatter.field("pat", Lite(&_val.pat));
+                formatter.finish()
+            }
             syn::Pat::Path(_val) => {
                 formatter.write_str("Pat::Path")?;
                 formatter.write_str("(")?;
@@ -3319,6 +3327,16 @@ impl Debug for Lite<syn::PatOr> {
         if !self.value.cases.is_empty() {
             formatter.field("cases", Lite(&self.value.cases));
         }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::PatParen> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("PatParen");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("pat", Lite(&self.value.pat));
         formatter.finish()
     }
 }


### PR DESCRIPTION
Closes #1352.

According to https://doc.rust-lang.org/1.67.0/reference/patterns.html#tuple-patterns `(..)` is a special case and is a tuple, not paren pattern, even without trailing comma.