### PR TITLE
Stricter parsing of ranges

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -64,6 +64,7 @@ static EXCLUDE_FILES: &[&str] = &[
     "src/tools/rust-analyzer/crates/parser/test_data/parser/ok/0055_dot_dot_dot.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/ok/0068_item_modifiers.rs",
     "src/tools/rust-analyzer/crates/syntax/test_data/parser/validation/0031_block_inner_attrs.rs",
+    "src/tools/rust-analyzer/crates/syntax/test_data/parser/validation/0038_endless_inclusive_range.rs",
     "src/tools/rust-analyzer/crates/syntax/test_data/parser/validation/0045_ambiguous_trait_object.rs",
     "src/tools/rust-analyzer/crates/syntax/test_data/parser/validation/0046_mutable_const_item.rs",
 

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -50,9 +50,13 @@ static EXCLUDE_FILES: &[&str] = &[
     "src/tools/rustfmt/tests/source/type-ascription.rs",
     "src/tools/rustfmt/tests/target/type-ascription.rs",
 
+    // Invalid unparenthesized range pattern inside slice pattern: `[1..]`
+    "tests/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs",
+
     // Various extensions to Rust syntax made up by rust-analyzer
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0012_type_item_where_clause.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0040_crate_keyword_vis.rs",
+    "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0058_range_pat.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0123_param_list_vararg.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0131_existential_type.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0156_fn_def_param.rs",

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -292,3 +292,21 @@ fn test_postfix_operator_after_cast() {
     syn::parse_str::<Expr>("|| &x as T[0]").unwrap_err();
     syn::parse_str::<Expr>("|| () as ()()").unwrap_err();
 }
+
+#[test]
+fn test_ranges() {
+    syn::parse_str::<Expr>("..").unwrap();
+    syn::parse_str::<Expr>("..hi").unwrap();
+    syn::parse_str::<Expr>("lo..").unwrap();
+    syn::parse_str::<Expr>("lo..hi").unwrap();
+
+    syn::parse_str::<Expr>("..=").unwrap(); // FIXME
+    syn::parse_str::<Expr>("..=hi").unwrap();
+    syn::parse_str::<Expr>("lo..=").unwrap(); // FIXME
+    syn::parse_str::<Expr>("lo..=hi").unwrap();
+
+    syn::parse_str::<Expr>("...").unwrap(); // FIXME
+    syn::parse_str::<Expr>("...hi").unwrap(); // FIXME
+    syn::parse_str::<Expr>("lo...").unwrap(); // FIXME
+    syn::parse_str::<Expr>("lo...hi").unwrap(); // FIXME
+}

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -300,13 +300,13 @@ fn test_ranges() {
     syn::parse_str::<Expr>("lo..").unwrap();
     syn::parse_str::<Expr>("lo..hi").unwrap();
 
-    syn::parse_str::<Expr>("..=").unwrap(); // FIXME
+    syn::parse_str::<Expr>("..=").unwrap_err();
     syn::parse_str::<Expr>("..=hi").unwrap();
-    syn::parse_str::<Expr>("lo..=").unwrap(); // FIXME
+    syn::parse_str::<Expr>("lo..=").unwrap_err();
     syn::parse_str::<Expr>("lo..=hi").unwrap();
 
-    syn::parse_str::<Expr>("...").unwrap(); // FIXME
-    syn::parse_str::<Expr>("...hi").unwrap(); // FIXME
-    syn::parse_str::<Expr>("lo...").unwrap(); // FIXME
-    syn::parse_str::<Expr>("lo...hi").unwrap(); // FIXME
+    syn::parse_str::<Expr>("...").unwrap_err();
+    syn::parse_str::<Expr>("...hi").unwrap_err();
+    syn::parse_str::<Expr>("lo...").unwrap_err();
+    syn::parse_str::<Expr>("lo...hi").unwrap_err();
 }

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -82,4 +82,12 @@ fn test_ranges() {
     Pat::parse_single.parse_str("...hi").unwrap_err();
     Pat::parse_single.parse_str("lo...").unwrap_err();
     Pat::parse_single.parse_str("lo...hi").unwrap();
+
+    Pat::parse_single.parse_str("[lo..]").unwrap(); // FIXME
+    Pat::parse_single.parse_str("[..=hi]").unwrap(); // FIXME
+    Pat::parse_single.parse_str("[lo..=hi]").unwrap();
+
+    Pat::parse_single.parse_str("[_, lo.., _]").unwrap(); // FIXME
+    Pat::parse_single.parse_str("[_, ..=hi, _]").unwrap(); // FIXME
+    Pat::parse_single.parse_str("[_, lo..=hi, _]").unwrap();
 }

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -65,3 +65,21 @@ fn test_group() {
     }
     "###);
 }
+
+#[test]
+fn test_ranges() {
+    Pat::parse_single.parse_str("..").unwrap();
+    Pat::parse_single.parse_str("..hi").unwrap();
+    Pat::parse_single.parse_str("lo..").unwrap_err(); // FIXME
+    Pat::parse_single.parse_str("lo..hi").unwrap();
+
+    Pat::parse_single.parse_str("..=").unwrap_err();
+    Pat::parse_single.parse_str("..=hi").unwrap();
+    Pat::parse_single.parse_str("lo..=").unwrap_err();
+    Pat::parse_single.parse_str("lo..=hi").unwrap();
+
+    Pat::parse_single.parse_str("...").unwrap_err();
+    Pat::parse_single.parse_str("...hi").unwrap_err();
+    Pat::parse_single.parse_str("lo...").unwrap_err();
+    Pat::parse_single.parse_str("lo...hi").unwrap();
+}

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -83,11 +83,15 @@ fn test_ranges() {
     Pat::parse_single.parse_str("lo...").unwrap_err();
     Pat::parse_single.parse_str("lo...hi").unwrap();
 
-    Pat::parse_single.parse_str("[lo..]").unwrap(); // FIXME
-    Pat::parse_single.parse_str("[..=hi]").unwrap(); // FIXME
+    Pat::parse_single.parse_str("[lo..]").unwrap_err();
+    Pat::parse_single.parse_str("[..=hi]").unwrap_err();
+    Pat::parse_single.parse_str("[(lo..)]").unwrap();
+    Pat::parse_single.parse_str("[(..=hi)]").unwrap();
     Pat::parse_single.parse_str("[lo..=hi]").unwrap();
 
-    Pat::parse_single.parse_str("[_, lo.., _]").unwrap(); // FIXME
-    Pat::parse_single.parse_str("[_, ..=hi, _]").unwrap(); // FIXME
+    Pat::parse_single.parse_str("[_, lo.., _]").unwrap_err();
+    Pat::parse_single.parse_str("[_, ..=hi, _]").unwrap_err();
+    Pat::parse_single.parse_str("[_, (lo..), _]").unwrap();
+    Pat::parse_single.parse_str("[_, (..=hi), _]").unwrap();
     Pat::parse_single.parse_str("[_, lo..=hi, _]").unwrap();
 }

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -70,7 +70,7 @@ fn test_group() {
 fn test_ranges() {
     Pat::parse_single.parse_str("..").unwrap();
     Pat::parse_single.parse_str("..hi").unwrap();
-    Pat::parse_single.parse_str("lo..").unwrap_err(); // FIXME
+    Pat::parse_single.parse_str("lo..").unwrap();
     Pat::parse_single.parse_str("lo..hi").unwrap();
 
     Pat::parse_single.parse_str("..=").unwrap_err();


### PR DESCRIPTION
None of the following are valid expressions, but were previously accepted by syn.

- `..=`
- `lo..=`
- `...`
- `...hi`
- `lo...`
- `lo...hi`

None of the following are valid patterns, but were previously accepted by syn.

- `[lo..]`
- `[..=hi]`