### PR TITLE
stricter parsing of string_continue escapes

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -1182,9 +1182,9 @@ mod value {
                         b'\'' => '\'',
                         b'"' => '"',
                         b'\r' | b'\n' => loop {
-                            let ch = next_chr(s);
-                            if ch.is_whitespace() {
-                                s = &s[ch.len_utf8()..];
+                            let b = byte(s, 0);
+                            if matches!(b, b' ' | b'\t' | b'\n' | b'\r') {
+                                s = &s[1..];
                             } else {
                                 continue 'outer;
                             }

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -53,6 +53,10 @@ fn strings() {
         "\"contains\nnewlines\\\nescaped newlines\"",
         "contains\nnewlinesescaped newlines",
     );
+    test_string(
+        "\"escaped newline\\\n \x0C unsupported whitespace\"",
+        "escaped newline\x0C unsupported whitespace",
+    );
     test_string("r\"raw\nstring\\\nhere\"", "raw\nstring\\\nhere");
     test_string("\"...\"q", "...");
     test_string("r\"...\"q", "...");


### PR DESCRIPTION
According to https://doc.rust-lang.org/reference/tokens.html#string-literals
only these 4 characters are actually skipped.
