### PR TITLE
Make GenericArgument non-exhaustive

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -150,6 +150,7 @@ impl PathArguments {
 ast_enum! {
     /// An individual generic argument, like `'a`, `T`, or `Item = T`.
     #[cfg_attr(doc_cfg, doc(cfg(any(feature = "full", feature = "derive"))))]
+    #[non_exhaustive]
     pub enum GenericArgument {
         /// A lifetime argument.
         Lifetime(Lifetime),

--- a/syn.json
+++ b/syn.json
@@ -2320,7 +2320,8 @@
             "syn": "Constraint"
           }
         ]
-      }
+      },
+      "exhaustive": false
     },
     {
       "ident": "GenericParam",

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -2020,6 +2020,7 @@ impl Debug for Lite<syn::GenericArgument> {
                 formatter.write_str(")")?;
                 Ok(())
             }
+            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
As one example, "compact notation" for "return type notation" would require a path argument that is not covered by any of the existing variants. https://smallcultfollowing.com/babysteps/blog/2023/02/13/return-type-notation-send-bounds-part-2/#more-compact-notation