### PR TITLE
Delete Span methods from fold, visit, visit_mut

### DIFF
--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -216,7 +216,7 @@ pub fn generate(defs: &Definitions) -> Result<()> {
         quote! {
             // Unreachable code is generated sometimes without the full feature.
             #![allow(unreachable_code, unused_variables)]
-            #![allow(clippy::match_wildcard_for_single_variants)]
+            #![allow(clippy::match_wildcard_for_single_variants, clippy::needless_match)]
 
             #[cfg(any(feature = "full", feature = "derive"))]
             use crate::gen::helper::fold::*;

--- a/codegen/src/visit.rs
+++ b/codegen/src/visit.rs
@@ -51,11 +51,8 @@ fn visit(
             let name = name.ref_tokens();
             Some(quote! {
                 for el in Punctuated::pairs(#name) {
-                    let (it, p) = el.into_tuple();
+                    let it = el.value();
                     #val;
-                    if let Some(p) = p {
-                        tokens_helper(v, &p.spans);
-                    }
                 }
             })
         }
@@ -81,25 +78,6 @@ fn visit(
             }
             Some(code)
         }
-        Type::Token(t) => {
-            let name = name.tokens();
-            let repr = &defs.tokens[t];
-            let is_keyword = repr.chars().next().unwrap().is_alphabetic();
-            let spans = if is_keyword {
-                quote!(span)
-            } else {
-                quote!(spans)
-            };
-            Some(quote! {
-                tokens_helper(v, &#name.#spans);
-            })
-        }
-        Type::Group(_) => {
-            let name = name.tokens();
-            Some(quote! {
-                tokens_helper(v, &#name.span);
-            })
-        }
         Type::Syn(t) => {
             fn requires_full(features: &Features) -> bool {
                 features.any.contains("full") && features.any.len() == 1
@@ -112,7 +90,7 @@ fn visit(
             Some(res)
         }
         Type::Ext(t) if gen::TERMINAL_TYPES.contains(&&t[..]) => Some(simple_visit(t, name)),
-        Type::Ext(_) | Type::Std(_) => None,
+        Type::Ext(_) | Type::Std(_) | Type::Token(_) | Type::Group(_) => None,
     }
 }
 
@@ -224,8 +202,6 @@ pub fn generate(defs: &Definitions) -> Result<()> {
         quote! {
             #![allow(unused_variables)]
 
-            #[cfg(any(feature = "full", feature = "derive"))]
-            use crate::gen::helper::visit::*;
             #[cfg(any(feature = "full", feature = "derive"))]
             use crate::punctuated::Punctuated;
             use crate::*;

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -2,7 +2,7 @@
 // It is not intended for manual editing.
 
 #![allow(unreachable_code, unused_variables)]
-#![allow(clippy::match_wildcard_for_single_variants)]
+#![allow(clippy::match_wildcard_for_single_variants, clippy::needless_match)]
 #[cfg(any(feature = "full", feature = "derive"))]
 use crate::gen::helper::fold::*;
 use crate::*;

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -5,8 +5,6 @@
 #![allow(clippy::match_wildcard_for_single_variants)]
 #[cfg(any(feature = "full", feature = "derive"))]
 use crate::gen::helper::fold::*;
-#[cfg(any(feature = "full", feature = "derive"))]
-use crate::token::{Brace, Bracket, Group, Paren};
 use crate::*;
 use proc_macro2::Span;
 #[cfg(feature = "full")]
@@ -760,7 +758,7 @@ where
     F: Fold + ?Sized,
 {
     Abi {
-        extern_token: Token![extern](tokens_helper(f, &node.extern_token.span)),
+        extern_token: node.extern_token,
         name: (node.name).map(|it| f.fold_lit_str(it)),
     }
 }
@@ -773,11 +771,10 @@ where
     F: Fold + ?Sized,
 {
     AngleBracketedGenericArguments {
-        colon2_token: (node.colon2_token)
-            .map(|it| Token![::](tokens_helper(f, &it.spans))),
-        lt_token: Token![<](tokens_helper(f, &node.lt_token.spans)),
+        colon2_token: node.colon2_token,
+        lt_token: node.lt_token,
         args: FoldHelper::lift(node.args, |it| f.fold_generic_argument(it)),
-        gt_token: Token![>](tokens_helper(f, &node.gt_token.spans)),
+        gt_token: node.gt_token,
     }
 }
 #[cfg(feature = "full")]
@@ -788,14 +785,10 @@ where
     Arm {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         pat: f.fold_pat(node.pat),
-        guard: (node.guard)
-            .map(|it| (
-                Token![if](tokens_helper(f, &(it).0.span)),
-                Box::new(f.fold_expr(*(it).1)),
-            )),
-        fat_arrow_token: Token![=>](tokens_helper(f, &node.fat_arrow_token.spans)),
+        guard: (node.guard).map(|it| ((it).0, Box::new(f.fold_expr(*(it).1)))),
+        fat_arrow_token: node.fat_arrow_token,
         body: Box::new(f.fold_expr(*node.body)),
-        comma: (node.comma).map(|it| Token![,](tokens_helper(f, &it.spans))),
+        comma: node.comma,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -806,7 +799,7 @@ where
     AssocConst {
         ident: f.fold_ident(node.ident),
         generics: (node.generics).map(|it| f.fold_angle_bracketed_generic_arguments(it)),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         value: f.fold_expr(node.value),
     }
 }
@@ -818,7 +811,7 @@ where
     AssocType {
         ident: f.fold_ident(node.ident),
         generics: (node.generics).map(|it| f.fold_angle_bracketed_generic_arguments(it)),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         ty: f.fold_type(node.ty),
     }
 }
@@ -829,9 +822,7 @@ where
 {
     match node {
         AttrStyle::Outer => AttrStyle::Outer,
-        AttrStyle::Inner(_binding_0) => {
-            AttrStyle::Inner(Token![!](tokens_helper(f, &_binding_0.spans)))
-        }
+        AttrStyle::Inner(_binding_0) => AttrStyle::Inner(_binding_0),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -840,9 +831,9 @@ where
     F: Fold + ?Sized,
 {
     Attribute {
-        pound_token: Token![#](tokens_helper(f, &node.pound_token.spans)),
+        pound_token: node.pound_token,
         style: f.fold_attr_style(node.style),
-        bracket_token: Bracket(tokens_helper(f, &node.bracket_token.span)),
+        bracket_token: node.bracket_token,
         meta: f.fold_meta(node.meta),
     }
 }
@@ -853,11 +844,7 @@ where
 {
     BareFnArg {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        name: (node.name)
-            .map(|it| (
-                f.fold_ident((it).0),
-                Token![:](tokens_helper(f, &(it).1.spans)),
-            )),
+        name: (node.name).map(|it| (f.fold_ident((it).0), (it).1)),
         ty: f.fold_type(node.ty),
     }
 }
@@ -868,13 +855,9 @@ where
 {
     BareVariadic {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        name: (node.name)
-            .map(|it| (
-                f.fold_ident((it).0),
-                Token![:](tokens_helper(f, &(it).1.spans)),
-            )),
-        dots: Token![...](tokens_helper(f, &node.dots.spans)),
-        comma: (node.comma).map(|it| Token![,](tokens_helper(f, &it.spans))),
+        name: (node.name).map(|it| (f.fold_ident((it).0), (it).1)),
+        dots: node.dots,
+        comma: node.comma,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -883,90 +866,34 @@ where
     F: Fold + ?Sized,
 {
     match node {
-        BinOp::Add(_binding_0) => {
-            BinOp::Add(Token![+](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Sub(_binding_0) => {
-            BinOp::Sub(Token![-](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Mul(_binding_0) => {
-            BinOp::Mul(Token![*](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Div(_binding_0) => {
-            BinOp::Div(Token![/](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Rem(_binding_0) => {
-            BinOp::Rem(Token![%](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::And(_binding_0) => {
-            BinOp::And(Token![&&](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Or(_binding_0) => {
-            BinOp::Or(Token![||](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::BitXor(_binding_0) => {
-            BinOp::BitXor(Token![^](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::BitAnd(_binding_0) => {
-            BinOp::BitAnd(Token![&](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::BitOr(_binding_0) => {
-            BinOp::BitOr(Token![|](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Shl(_binding_0) => {
-            BinOp::Shl(Token![<<](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Shr(_binding_0) => {
-            BinOp::Shr(Token![>>](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Eq(_binding_0) => {
-            BinOp::Eq(Token![==](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Lt(_binding_0) => {
-            BinOp::Lt(Token![<](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Le(_binding_0) => {
-            BinOp::Le(Token![<=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Ne(_binding_0) => {
-            BinOp::Ne(Token![!=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Ge(_binding_0) => {
-            BinOp::Ge(Token![>=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::Gt(_binding_0) => {
-            BinOp::Gt(Token![>](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::AddAssign(_binding_0) => {
-            BinOp::AddAssign(Token![+=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::SubAssign(_binding_0) => {
-            BinOp::SubAssign(Token![-=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::MulAssign(_binding_0) => {
-            BinOp::MulAssign(Token![*=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::DivAssign(_binding_0) => {
-            BinOp::DivAssign(Token![/=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::RemAssign(_binding_0) => {
-            BinOp::RemAssign(Token![%=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::BitXorAssign(_binding_0) => {
-            BinOp::BitXorAssign(Token![^=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::BitAndAssign(_binding_0) => {
-            BinOp::BitAndAssign(Token![&=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::BitOrAssign(_binding_0) => {
-            BinOp::BitOrAssign(Token![|=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::ShlAssign(_binding_0) => {
-            BinOp::ShlAssign(Token![<<=](tokens_helper(f, &_binding_0.spans)))
-        }
-        BinOp::ShrAssign(_binding_0) => {
-            BinOp::ShrAssign(Token![>>=](tokens_helper(f, &_binding_0.spans)))
-        }
+        BinOp::Add(_binding_0) => BinOp::Add(_binding_0),
+        BinOp::Sub(_binding_0) => BinOp::Sub(_binding_0),
+        BinOp::Mul(_binding_0) => BinOp::Mul(_binding_0),
+        BinOp::Div(_binding_0) => BinOp::Div(_binding_0),
+        BinOp::Rem(_binding_0) => BinOp::Rem(_binding_0),
+        BinOp::And(_binding_0) => BinOp::And(_binding_0),
+        BinOp::Or(_binding_0) => BinOp::Or(_binding_0),
+        BinOp::BitXor(_binding_0) => BinOp::BitXor(_binding_0),
+        BinOp::BitAnd(_binding_0) => BinOp::BitAnd(_binding_0),
+        BinOp::BitOr(_binding_0) => BinOp::BitOr(_binding_0),
+        BinOp::Shl(_binding_0) => BinOp::Shl(_binding_0),
+        BinOp::Shr(_binding_0) => BinOp::Shr(_binding_0),
+        BinOp::Eq(_binding_0) => BinOp::Eq(_binding_0),
+        BinOp::Lt(_binding_0) => BinOp::Lt(_binding_0),
+        BinOp::Le(_binding_0) => BinOp::Le(_binding_0),
+        BinOp::Ne(_binding_0) => BinOp::Ne(_binding_0),
+        BinOp::Ge(_binding_0) => BinOp::Ge(_binding_0),
+        BinOp::Gt(_binding_0) => BinOp::Gt(_binding_0),
+        BinOp::AddAssign(_binding_0) => BinOp::AddAssign(_binding_0),
+        BinOp::SubAssign(_binding_0) => BinOp::SubAssign(_binding_0),
+        BinOp::MulAssign(_binding_0) => BinOp::MulAssign(_binding_0),
+        BinOp::DivAssign(_binding_0) => BinOp::DivAssign(_binding_0),
+        BinOp::RemAssign(_binding_0) => BinOp::RemAssign(_binding_0),
+        BinOp::BitXorAssign(_binding_0) => BinOp::BitXorAssign(_binding_0),
+        BinOp::BitAndAssign(_binding_0) => BinOp::BitAndAssign(_binding_0),
+        BinOp::BitOrAssign(_binding_0) => BinOp::BitOrAssign(_binding_0),
+        BinOp::ShlAssign(_binding_0) => BinOp::ShlAssign(_binding_0),
+        BinOp::ShrAssign(_binding_0) => BinOp::ShrAssign(_binding_0),
     }
 }
 #[cfg(feature = "full")]
@@ -975,7 +902,7 @@ where
     F: Fold + ?Sized,
 {
     Block {
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         stmts: FoldHelper::lift(node.stmts, |it| f.fold_stmt(it)),
     }
 }
@@ -985,10 +912,10 @@ where
     F: Fold + ?Sized,
 {
     BoundLifetimes {
-        for_token: Token![for](tokens_helper(f, &node.for_token.span)),
-        lt_token: Token![<](tokens_helper(f, &node.lt_token.spans)),
+        for_token: node.for_token,
+        lt_token: node.lt_token,
         lifetimes: FoldHelper::lift(node.lifetimes, |it| f.fold_generic_param(it)),
-        gt_token: Token![>](tokens_helper(f, &node.gt_token.spans)),
+        gt_token: node.gt_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -998,11 +925,11 @@ where
 {
     ConstParam {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        const_token: Token![const](tokens_helper(f, &node.const_token.span)),
+        const_token: node.const_token,
         ident: f.fold_ident(node.ident),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         ty: f.fold_type(node.ty),
-        eq_token: (node.eq_token).map(|it| Token![=](tokens_helper(f, &it.spans))),
+        eq_token: node.eq_token,
         default: (node.default).map(|it| f.fold_expr(it)),
     }
 }
@@ -1014,7 +941,7 @@ where
     Constraint {
         ident: f.fold_ident(node.ident),
         generics: (node.generics).map(|it| f.fold_angle_bracketed_generic_arguments(it)),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_type_param_bound(it)),
     }
 }
@@ -1035,8 +962,8 @@ where
     F: Fold + ?Sized,
 {
     DataEnum {
-        enum_token: Token![enum](tokens_helper(f, &node.enum_token.span)),
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        enum_token: node.enum_token,
+        brace_token: node.brace_token,
         variants: FoldHelper::lift(node.variants, |it| f.fold_variant(it)),
     }
 }
@@ -1046,9 +973,9 @@ where
     F: Fold + ?Sized,
 {
     DataStruct {
-        struct_token: Token![struct](tokens_helper(f, &node.struct_token.span)),
+        struct_token: node.struct_token,
         fields: f.fold_fields(node.fields),
-        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "derive")]
@@ -1057,7 +984,7 @@ where
     F: Fold + ?Sized,
 {
     DataUnion {
-        union_token: Token![union](tokens_helper(f, &node.union_token.span)),
+        union_token: node.union_token,
         fields: f.fold_fields_named(node.fields),
     }
 }
@@ -1140,7 +1067,7 @@ where
 {
     ExprArray {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        bracket_token: Bracket(tokens_helper(f, &node.bracket_token.span)),
+        bracket_token: node.bracket_token,
         elems: FoldHelper::lift(node.elems, |it| f.fold_expr(it)),
     }
 }
@@ -1152,7 +1079,7 @@ where
     ExprAssign {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         left: Box::new(f.fold_expr(*node.left)),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         right: Box::new(f.fold_expr(*node.right)),
     }
 }
@@ -1163,8 +1090,8 @@ where
 {
     ExprAsync {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        async_token: Token![async](tokens_helper(f, &node.async_token.span)),
-        capture: (node.capture).map(|it| Token![move](tokens_helper(f, &it.span))),
+        async_token: node.async_token,
+        capture: node.capture,
         block: f.fold_block(node.block),
     }
 }
@@ -1176,8 +1103,8 @@ where
     ExprAwait {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         base: Box::new(f.fold_expr(*node.base)),
-        dot_token: Token![.](tokens_helper(f, &node.dot_token.spans)),
-        await_token: Token![await](tokens_helper(f, &node.await_token.span)),
+        dot_token: node.dot_token,
+        await_token: node.await_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1210,7 +1137,7 @@ where
 {
     ExprBreak {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        break_token: Token![break](tokens_helper(f, &node.break_token.span)),
+        break_token: node.break_token,
         label: (node.label).map(|it| f.fold_lifetime(it)),
         expr: (node.expr).map(|it| Box::new(f.fold_expr(*it))),
     }
@@ -1223,7 +1150,7 @@ where
     ExprCall {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         func: Box::new(f.fold_expr(*node.func)),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         args: FoldHelper::lift(node.args, |it| f.fold_expr(it)),
     }
 }
@@ -1235,7 +1162,7 @@ where
     ExprCast {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         expr: Box::new(f.fold_expr(*node.expr)),
-        as_token: Token![as](tokens_helper(f, &node.as_token.span)),
+        as_token: node.as_token,
         ty: Box::new(f.fold_type(*node.ty)),
     }
 }
@@ -1247,14 +1174,13 @@ where
     ExprClosure {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         lifetimes: (node.lifetimes).map(|it| f.fold_bound_lifetimes(it)),
-        constness: (node.constness).map(|it| Token![const](tokens_helper(f, &it.span))),
-        movability: (node.movability)
-            .map(|it| Token![static](tokens_helper(f, &it.span))),
-        asyncness: (node.asyncness).map(|it| Token![async](tokens_helper(f, &it.span))),
-        capture: (node.capture).map(|it| Token![move](tokens_helper(f, &it.span))),
-        or1_token: Token![|](tokens_helper(f, &node.or1_token.spans)),
+        constness: node.constness,
+        movability: node.movability,
+        asyncness: node.asyncness,
+        capture: node.capture,
+        or1_token: node.or1_token,
         inputs: FoldHelper::lift(node.inputs, |it| f.fold_pat(it)),
-        or2_token: Token![|](tokens_helper(f, &node.or2_token.spans)),
+        or2_token: node.or2_token,
         output: f.fold_return_type(node.output),
         body: Box::new(f.fold_expr(*node.body)),
     }
@@ -1266,7 +1192,7 @@ where
 {
     ExprConst {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        const_token: Token![const](tokens_helper(f, &node.const_token.span)),
+        const_token: node.const_token,
         block: f.fold_block(node.block),
     }
 }
@@ -1277,7 +1203,7 @@ where
 {
     ExprContinue {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        continue_token: Token![continue](tokens_helper(f, &node.continue_token.span)),
+        continue_token: node.continue_token,
         label: (node.label).map(|it| f.fold_lifetime(it)),
     }
 }
@@ -1289,7 +1215,7 @@ where
     ExprField {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         base: Box::new(f.fold_expr(*node.base)),
-        dot_token: Token![.](tokens_helper(f, &node.dot_token.spans)),
+        dot_token: node.dot_token,
         member: f.fold_member(node.member),
     }
 }
@@ -1301,9 +1227,9 @@ where
     ExprForLoop {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         label: (node.label).map(|it| f.fold_label(it)),
-        for_token: Token![for](tokens_helper(f, &node.for_token.span)),
+        for_token: node.for_token,
         pat: Box::new(f.fold_pat(*node.pat)),
-        in_token: Token![in](tokens_helper(f, &node.in_token.span)),
+        in_token: node.in_token,
         expr: Box::new(f.fold_expr(*node.expr)),
         body: f.fold_block(node.body),
     }
@@ -1315,7 +1241,7 @@ where
 {
     ExprGroup {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        group_token: Group(tokens_helper(f, &node.group_token.span)),
+        group_token: node.group_token,
         expr: Box::new(f.fold_expr(*node.expr)),
     }
 }
@@ -1326,14 +1252,11 @@ where
 {
     ExprIf {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        if_token: Token![if](tokens_helper(f, &node.if_token.span)),
+        if_token: node.if_token,
         cond: Box::new(f.fold_expr(*node.cond)),
         then_branch: f.fold_block(node.then_branch),
         else_branch: (node.else_branch)
-            .map(|it| (
-                Token![else](tokens_helper(f, &(it).0.span)),
-                Box::new(f.fold_expr(*(it).1)),
-            )),
+            .map(|it| ((it).0, Box::new(f.fold_expr(*(it).1)))),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1344,7 +1267,7 @@ where
     ExprIndex {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         expr: Box::new(f.fold_expr(*node.expr)),
-        bracket_token: Bracket(tokens_helper(f, &node.bracket_token.span)),
+        bracket_token: node.bracket_token,
         index: Box::new(f.fold_expr(*node.index)),
     }
 }
@@ -1355,7 +1278,7 @@ where
 {
     ExprInfer {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        underscore_token: Token![_](tokens_helper(f, &node.underscore_token.spans)),
+        underscore_token: node.underscore_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1365,9 +1288,9 @@ where
 {
     ExprLet {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        let_token: Token![let](tokens_helper(f, &node.let_token.span)),
+        let_token: node.let_token,
         pat: Box::new(f.fold_pat(*node.pat)),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         expr: Box::new(f.fold_expr(*node.expr)),
     }
 }
@@ -1389,7 +1312,7 @@ where
     ExprLoop {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         label: (node.label).map(|it| f.fold_label(it)),
-        loop_token: Token![loop](tokens_helper(f, &node.loop_token.span)),
+        loop_token: node.loop_token,
         body: f.fold_block(node.body),
     }
 }
@@ -1410,9 +1333,9 @@ where
 {
     ExprMatch {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        match_token: Token![match](tokens_helper(f, &node.match_token.span)),
+        match_token: node.match_token,
         expr: Box::new(f.fold_expr(*node.expr)),
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         arms: FoldHelper::lift(node.arms, |it| f.fold_arm(it)),
     }
 }
@@ -1424,11 +1347,11 @@ where
     ExprMethodCall {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         receiver: Box::new(f.fold_expr(*node.receiver)),
-        dot_token: Token![.](tokens_helper(f, &node.dot_token.spans)),
+        dot_token: node.dot_token,
         method: f.fold_ident(node.method),
         turbofish: (node.turbofish)
             .map(|it| f.fold_angle_bracketed_generic_arguments(it)),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         args: FoldHelper::lift(node.args, |it| f.fold_expr(it)),
     }
 }
@@ -1439,7 +1362,7 @@ where
 {
     ExprParen {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         expr: Box::new(f.fold_expr(*node.expr)),
     }
 }
@@ -1473,8 +1396,8 @@ where
 {
     ExprReference {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        and_token: Token![&](tokens_helper(f, &node.and_token.spans)),
-        mutability: (node.mutability).map(|it| Token![mut](tokens_helper(f, &it.span))),
+        and_token: node.and_token,
+        mutability: node.mutability,
         expr: Box::new(f.fold_expr(*node.expr)),
     }
 }
@@ -1485,9 +1408,9 @@ where
 {
     ExprRepeat {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        bracket_token: Bracket(tokens_helper(f, &node.bracket_token.span)),
+        bracket_token: node.bracket_token,
         expr: Box::new(f.fold_expr(*node.expr)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
         len: Box::new(f.fold_expr(*node.len)),
     }
 }
@@ -1498,7 +1421,7 @@ where
 {
     ExprReturn {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        return_token: Token![return](tokens_helper(f, &node.return_token.span)),
+        return_token: node.return_token,
         expr: (node.expr).map(|it| Box::new(f.fold_expr(*it))),
     }
 }
@@ -1511,9 +1434,9 @@ where
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         qself: (node.qself).map(|it| f.fold_qself(it)),
         path: f.fold_path(node.path),
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         fields: FoldHelper::lift(node.fields, |it| f.fold_field_value(it)),
-        dot2_token: (node.dot2_token).map(|it| Token![..](tokens_helper(f, &it.spans))),
+        dot2_token: node.dot2_token,
         rest: (node.rest).map(|it| Box::new(f.fold_expr(*it))),
     }
 }
@@ -1525,7 +1448,7 @@ where
     ExprTry {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         expr: Box::new(f.fold_expr(*node.expr)),
-        question_token: Token![?](tokens_helper(f, &node.question_token.spans)),
+        question_token: node.question_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1535,7 +1458,7 @@ where
 {
     ExprTryBlock {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        try_token: Token![try](tokens_helper(f, &node.try_token.span)),
+        try_token: node.try_token,
         block: f.fold_block(node.block),
     }
 }
@@ -1546,7 +1469,7 @@ where
 {
     ExprTuple {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         elems: FoldHelper::lift(node.elems, |it| f.fold_expr(it)),
     }
 }
@@ -1568,7 +1491,7 @@ where
 {
     ExprUnsafe {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        unsafe_token: Token![unsafe](tokens_helper(f, &node.unsafe_token.span)),
+        unsafe_token: node.unsafe_token,
         block: f.fold_block(node.block),
     }
 }
@@ -1580,7 +1503,7 @@ where
     ExprWhile {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         label: (node.label).map(|it| f.fold_label(it)),
-        while_token: Token![while](tokens_helper(f, &node.while_token.span)),
+        while_token: node.while_token,
         cond: Box::new(f.fold_expr(*node.cond)),
         body: f.fold_block(node.body),
     }
@@ -1592,7 +1515,7 @@ where
 {
     ExprYield {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        yield_token: Token![yield](tokens_helper(f, &node.yield_token.span)),
+        yield_token: node.yield_token,
         expr: (node.expr).map(|it| Box::new(f.fold_expr(*it))),
     }
 }
@@ -1606,7 +1529,7 @@ where
         vis: f.fold_visibility(node.vis),
         mutability: f.fold_field_mutability(node.mutability),
         ident: (node.ident).map(|it| f.fold_ident(it)),
-        colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),
+        colon_token: node.colon_token,
         ty: f.fold_type(node.ty),
     }
 }
@@ -1627,7 +1550,7 @@ where
     FieldPat {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         member: f.fold_member(node.member),
-        colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),
+        colon_token: node.colon_token,
         pat: Box::new(f.fold_pat(*node.pat)),
     }
 }
@@ -1639,7 +1562,7 @@ where
     FieldValue {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         member: f.fold_member(node.member),
-        colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),
+        colon_token: node.colon_token,
         expr: f.fold_expr(node.expr),
     }
 }
@@ -1660,7 +1583,7 @@ where
     F: Fold + ?Sized,
 {
     FieldsNamed {
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         named: FoldHelper::lift(node.named, |it| f.fold_field(it)),
     }
 }
@@ -1670,7 +1593,7 @@ where
     F: Fold + ?Sized,
 {
     FieldsUnnamed {
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         unnamed: FoldHelper::lift(node.unnamed, |it| f.fold_field(it)),
     }
 }
@@ -1725,7 +1648,7 @@ where
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
         sig: f.fold_signature(node.sig),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1736,7 +1659,7 @@ where
     ForeignItemMacro {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         mac: f.fold_macro(node.mac),
-        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1750,12 +1673,12 @@ where
     ForeignItemStatic {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        static_token: Token![static](tokens_helper(f, &node.static_token.span)),
+        static_token: node.static_token,
         mutability: f.fold_static_mutability(node.mutability),
         ident: f.fold_ident(node.ident),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         ty: Box::new(f.fold_type(*node.ty)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1766,10 +1689,10 @@ where
     ForeignItemType {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        type_token: Token![type](tokens_helper(f, &node.type_token.span)),
+        type_token: node.type_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1821,9 +1744,9 @@ where
     F: Fold + ?Sized,
 {
     Generics {
-        lt_token: (node.lt_token).map(|it| Token![<](tokens_helper(f, &it.spans))),
+        lt_token: node.lt_token,
         params: FoldHelper::lift(node.params, |it| f.fold_generic_param(it)),
-        gt_token: (node.gt_token).map(|it| Token![>](tokens_helper(f, &it.spans))),
+        gt_token: node.gt_token,
         where_clause: (node.where_clause).map(|it| f.fold_where_clause(it)),
     }
 }
@@ -1861,16 +1784,15 @@ where
     ImplItemConst {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        defaultness: (node.defaultness)
-            .map(|it| Token![default](tokens_helper(f, &it.span))),
-        const_token: Token![const](tokens_helper(f, &node.const_token.span)),
+        defaultness: node.defaultness,
+        const_token: node.const_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         ty: f.fold_type(node.ty),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         expr: f.fold_expr(node.expr),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1881,8 +1803,7 @@ where
     ImplItemFn {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        defaultness: (node.defaultness)
-            .map(|it| Token![default](tokens_helper(f, &it.span))),
+        defaultness: node.defaultness,
         sig: f.fold_signature(node.sig),
         block: f.fold_block(node.block),
     }
@@ -1895,7 +1816,7 @@ where
     ImplItemMacro {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         mac: f.fold_macro(node.mac),
-        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1906,14 +1827,13 @@ where
     ImplItemType {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        defaultness: (node.defaultness)
-            .map(|it| Token![default](tokens_helper(f, &it.span))),
-        type_token: Token![type](tokens_helper(f, &node.type_token.span)),
+        defaultness: node.defaultness,
+        type_token: node.type_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         ty: f.fold_type(node.ty),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1971,14 +1891,14 @@ where
     ItemConst {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        const_token: Token![const](tokens_helper(f, &node.const_token.span)),
+        const_token: node.const_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         ty: Box::new(f.fold_type(*node.ty)),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         expr: Box::new(f.fold_expr(*node.expr)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -1989,10 +1909,10 @@ where
     ItemEnum {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        enum_token: Token![enum](tokens_helper(f, &node.enum_token.span)),
+        enum_token: node.enum_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         variants: FoldHelper::lift(node.variants, |it| f.fold_variant(it)),
     }
 }
@@ -2004,15 +1924,11 @@ where
     ItemExternCrate {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        extern_token: Token![extern](tokens_helper(f, &node.extern_token.span)),
-        crate_token: Token![crate](tokens_helper(f, &node.crate_token.span)),
+        extern_token: node.extern_token,
+        crate_token: node.crate_token,
         ident: f.fold_ident(node.ident),
-        rename: (node.rename)
-            .map(|it| (
-                Token![as](tokens_helper(f, &(it).0.span)),
-                f.fold_ident((it).1),
-            )),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        rename: (node.rename).map(|it| ((it).0, f.fold_ident((it).1))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2034,9 +1950,9 @@ where
 {
     ItemForeignMod {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        unsafety: (node.unsafety).map(|it| Token![unsafe](tokens_helper(f, &it.span))),
+        unsafety: node.unsafety,
         abi: f.fold_abi(node.abi),
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         items: FoldHelper::lift(node.items, |it| f.fold_foreign_item(it)),
     }
 }
@@ -2047,19 +1963,13 @@ where
 {
     ItemImpl {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        defaultness: (node.defaultness)
-            .map(|it| Token![default](tokens_helper(f, &it.span))),
-        unsafety: (node.unsafety).map(|it| Token![unsafe](tokens_helper(f, &it.span))),
-        impl_token: Token![impl](tokens_helper(f, &node.impl_token.span)),
+        defaultness: node.defaultness,
+        unsafety: node.unsafety,
+        impl_token: node.impl_token,
         generics: f.fold_generics(node.generics),
-        trait_: (node.trait_)
-            .map(|it| (
-                ((it).0).map(|it| Token![!](tokens_helper(f, &it.spans))),
-                f.fold_path((it).1),
-                Token![for](tokens_helper(f, &(it).2.span)),
-            )),
+        trait_: (node.trait_).map(|it| ((it).0, f.fold_path((it).1), (it).2)),
         self_ty: Box::new(f.fold_type(*node.self_ty)),
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         items: FoldHelper::lift(node.items, |it| f.fold_impl_item(it)),
     }
 }
@@ -2072,7 +1982,7 @@ where
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         ident: (node.ident).map(|it| f.fold_ident(it)),
         mac: f.fold_macro(node.mac),
-        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2083,15 +1993,12 @@ where
     ItemMod {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        unsafety: (node.unsafety).map(|it| Token![unsafe](tokens_helper(f, &it.span))),
-        mod_token: Token![mod](tokens_helper(f, &node.mod_token.span)),
+        unsafety: node.unsafety,
+        mod_token: node.mod_token,
         ident: f.fold_ident(node.ident),
         content: (node.content)
-            .map(|it| (
-                Brace(tokens_helper(f, &(it).0.span)),
-                FoldHelper::lift((it).1, |it| f.fold_item(it)),
-            )),
-        semi: (node.semi).map(|it| Token![;](tokens_helper(f, &it.spans))),
+            .map(|it| ((it).0, FoldHelper::lift((it).1, |it| f.fold_item(it)))),
+        semi: node.semi,
     }
 }
 #[cfg(feature = "full")]
@@ -2102,14 +2009,14 @@ where
     ItemStatic {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        static_token: Token![static](tokens_helper(f, &node.static_token.span)),
+        static_token: node.static_token,
         mutability: f.fold_static_mutability(node.mutability),
         ident: f.fold_ident(node.ident),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         ty: Box::new(f.fold_type(*node.ty)),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         expr: Box::new(f.fold_expr(*node.expr)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2120,11 +2027,11 @@ where
     ItemStruct {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        struct_token: Token![struct](tokens_helper(f, &node.struct_token.span)),
+        struct_token: node.struct_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
         fields: f.fold_fields(node.fields),
-        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2135,18 +2042,18 @@ where
     ItemTrait {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        unsafety: (node.unsafety).map(|it| Token![unsafe](tokens_helper(f, &it.span))),
-        auto_token: (node.auto_token).map(|it| Token![auto](tokens_helper(f, &it.span))),
+        unsafety: node.unsafety,
+        auto_token: node.auto_token,
         restriction: (node.restriction).map(|it| f.fold_impl_restriction(it)),
-        trait_token: Token![trait](tokens_helper(f, &node.trait_token.span)),
+        trait_token: node.trait_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),
+        colon_token: node.colon_token,
         supertraits: FoldHelper::lift(
             node.supertraits,
             |it| f.fold_type_param_bound(it),
         ),
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         items: FoldHelper::lift(node.items, |it| f.fold_trait_item(it)),
     }
 }
@@ -2158,12 +2065,12 @@ where
     ItemTraitAlias {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        trait_token: Token![trait](tokens_helper(f, &node.trait_token.span)),
+        trait_token: node.trait_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_type_param_bound(it)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2174,12 +2081,12 @@ where
     ItemType {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        type_token: Token![type](tokens_helper(f, &node.type_token.span)),
+        type_token: node.type_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         ty: Box::new(f.fold_type(*node.ty)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2190,7 +2097,7 @@ where
     ItemUnion {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        union_token: Token![union](tokens_helper(f, &node.union_token.span)),
+        union_token: node.union_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
         fields: f.fold_fields_named(node.fields),
@@ -2204,11 +2111,10 @@ where
     ItemUse {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         vis: f.fold_visibility(node.vis),
-        use_token: Token![use](tokens_helper(f, &node.use_token.span)),
-        leading_colon: (node.leading_colon)
-            .map(|it| Token![::](tokens_helper(f, &it.spans))),
+        use_token: node.use_token,
+        leading_colon: node.leading_colon,
         tree: f.fold_use_tree(node.tree),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2218,7 +2124,7 @@ where
 {
     Label {
         name: f.fold_lifetime(node.name),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
     }
 }
 pub fn fold_lifetime<F>(f: &mut F, node: Lifetime) -> Lifetime
@@ -2238,7 +2144,7 @@ where
     LifetimeParam {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         lifetime: f.fold_lifetime(node.lifetime),
-        colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),
+        colon_token: node.colon_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_lifetime(it)),
     }
 }
@@ -2327,10 +2233,10 @@ where
 {
     Local {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        let_token: Token![let](tokens_helper(f, &node.let_token.span)),
+        let_token: node.let_token,
         pat: f.fold_pat(node.pat),
         init: (node.init).map(|it| f.fold_local_init(it)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2339,13 +2245,9 @@ where
     F: Fold + ?Sized,
 {
     LocalInit {
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         expr: Box::new(f.fold_expr(*node.expr)),
-        diverge: (node.diverge)
-            .map(|it| (
-                Token![else](tokens_helper(f, &(it).0.span)),
-                Box::new(f.fold_expr(*(it).1)),
-            )),
+        diverge: (node.diverge).map(|it| ((it).0, Box::new(f.fold_expr(*(it).1)))),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2355,7 +2257,7 @@ where
 {
     Macro {
         path: f.fold_path(node.path),
-        bang_token: Token![!](tokens_helper(f, &node.bang_token.spans)),
+        bang_token: node.bang_token,
         delimiter: f.fold_macro_delimiter(node.delimiter),
         tokens: node.tokens,
     }
@@ -2366,15 +2268,9 @@ where
     F: Fold + ?Sized,
 {
     match node {
-        MacroDelimiter::Paren(_binding_0) => {
-            MacroDelimiter::Paren(Paren(tokens_helper(f, &_binding_0.span)))
-        }
-        MacroDelimiter::Brace(_binding_0) => {
-            MacroDelimiter::Brace(Brace(tokens_helper(f, &_binding_0.span)))
-        }
-        MacroDelimiter::Bracket(_binding_0) => {
-            MacroDelimiter::Bracket(Bracket(tokens_helper(f, &_binding_0.span)))
-        }
+        MacroDelimiter::Paren(_binding_0) => MacroDelimiter::Paren(_binding_0),
+        MacroDelimiter::Brace(_binding_0) => MacroDelimiter::Brace(_binding_0),
+        MacroDelimiter::Bracket(_binding_0) => MacroDelimiter::Bracket(_binding_0),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2418,7 +2314,7 @@ where
 {
     MetaNameValue {
         path: f.fold_path(node.path),
-        eq_token: Token![=](tokens_helper(f, &node.eq_token.spans)),
+        eq_token: node.eq_token,
         value: f.fold_expr(node.value),
     }
 }
@@ -2431,7 +2327,7 @@ where
     F: Fold + ?Sized,
 {
     ParenthesizedGenericArguments {
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         inputs: FoldHelper::lift(node.inputs, |it| f.fold_type(it)),
         output: f.fold_return_type(node.output),
     }
@@ -2470,14 +2366,10 @@ where
 {
     PatIdent {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        by_ref: (node.by_ref).map(|it| Token![ref](tokens_helper(f, &it.span))),
-        mutability: (node.mutability).map(|it| Token![mut](tokens_helper(f, &it.span))),
+        by_ref: node.by_ref,
+        mutability: node.mutability,
         ident: f.fold_ident(node.ident),
-        subpat: (node.subpat)
-            .map(|it| (
-                Token![@](tokens_helper(f, &(it).0.spans)),
-                Box::new(f.fold_pat(*(it).1)),
-            )),
+        subpat: (node.subpat).map(|it| ((it).0, Box::new(f.fold_pat(*(it).1)))),
     }
 }
 #[cfg(feature = "full")]
@@ -2487,8 +2379,7 @@ where
 {
     PatOr {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        leading_vert: (node.leading_vert)
-            .map(|it| Token![|](tokens_helper(f, &it.spans))),
+        leading_vert: node.leading_vert,
         cases: FoldHelper::lift(node.cases, |it| f.fold_pat(it)),
     }
 }
@@ -2499,7 +2390,7 @@ where
 {
     PatParen {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         pat: Box::new(f.fold_pat(*node.pat)),
     }
 }
@@ -2510,8 +2401,8 @@ where
 {
     PatReference {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        and_token: Token![&](tokens_helper(f, &node.and_token.spans)),
-        mutability: (node.mutability).map(|it| Token![mut](tokens_helper(f, &it.span))),
+        and_token: node.and_token,
+        mutability: node.mutability,
         pat: Box::new(f.fold_pat(*node.pat)),
     }
 }
@@ -2522,7 +2413,7 @@ where
 {
     PatRest {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        dot2_token: Token![..](tokens_helper(f, &node.dot2_token.spans)),
+        dot2_token: node.dot2_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2532,7 +2423,7 @@ where
 {
     PatSlice {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        bracket_token: Bracket(tokens_helper(f, &node.bracket_token.span)),
+        bracket_token: node.bracket_token,
         elems: FoldHelper::lift(node.elems, |it| f.fold_pat(it)),
     }
 }
@@ -2545,7 +2436,7 @@ where
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         qself: (node.qself).map(|it| f.fold_qself(it)),
         path: f.fold_path(node.path),
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         fields: FoldHelper::lift(node.fields, |it| f.fold_field_pat(it)),
         rest: (node.rest).map(|it| f.fold_pat_rest(it)),
     }
@@ -2557,7 +2448,7 @@ where
 {
     PatTuple {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         elems: FoldHelper::lift(node.elems, |it| f.fold_pat(it)),
     }
 }
@@ -2570,7 +2461,7 @@ where
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         qself: (node.qself).map(|it| f.fold_qself(it)),
         path: f.fold_path(node.path),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         elems: FoldHelper::lift(node.elems, |it| f.fold_pat(it)),
     }
 }
@@ -2582,7 +2473,7 @@ where
     PatType {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         pat: Box::new(f.fold_pat(*node.pat)),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         ty: Box::new(f.fold_type(*node.ty)),
     }
 }
@@ -2593,7 +2484,7 @@ where
 {
     PatWild {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        underscore_token: Token![_](tokens_helper(f, &node.underscore_token.spans)),
+        underscore_token: node.underscore_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2602,8 +2493,7 @@ where
     F: Fold + ?Sized,
 {
     Path {
-        leading_colon: (node.leading_colon)
-            .map(|it| Token![::](tokens_helper(f, &it.spans))),
+        leading_colon: node.leading_colon,
         segments: FoldHelper::lift(node.segments, |it| f.fold_path_segment(it)),
     }
 }
@@ -2646,7 +2536,7 @@ where
 {
     PredicateLifetime {
         lifetime: f.fold_lifetime(node.lifetime),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_lifetime(it)),
     }
 }
@@ -2658,7 +2548,7 @@ where
     PredicateType {
         lifetimes: (node.lifetimes).map(|it| f.fold_bound_lifetimes(it)),
         bounded_ty: f.fold_type(node.bounded_ty),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_type_param_bound(it)),
     }
 }
@@ -2668,11 +2558,11 @@ where
     F: Fold + ?Sized,
 {
     QSelf {
-        lt_token: Token![<](tokens_helper(f, &node.lt_token.spans)),
+        lt_token: node.lt_token,
         ty: Box::new(f.fold_type(*node.ty)),
         position: node.position,
-        as_token: (node.as_token).map(|it| Token![as](tokens_helper(f, &it.span))),
-        gt_token: Token![>](tokens_helper(f, &node.gt_token.spans)),
+        as_token: node.as_token,
+        gt_token: node.gt_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2681,12 +2571,8 @@ where
     F: Fold + ?Sized,
 {
     match node {
-        RangeLimits::HalfOpen(_binding_0) => {
-            RangeLimits::HalfOpen(Token![..](tokens_helper(f, &_binding_0.spans)))
-        }
-        RangeLimits::Closed(_binding_0) => {
-            RangeLimits::Closed(Token![..=](tokens_helper(f, &_binding_0.spans)))
-        }
+        RangeLimits::HalfOpen(_binding_0) => RangeLimits::HalfOpen(_binding_0),
+        RangeLimits::Closed(_binding_0) => RangeLimits::Closed(_binding_0),
     }
 }
 #[cfg(feature = "full")]
@@ -2697,13 +2583,10 @@ where
     Receiver {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         reference: (node.reference)
-            .map(|it| (
-                Token![&](tokens_helper(f, &(it).0.spans)),
-                ((it).1).map(|it| f.fold_lifetime(it)),
-            )),
-        mutability: (node.mutability).map(|it| Token![mut](tokens_helper(f, &it.span))),
-        self_token: Token![self](tokens_helper(f, &node.self_token.span)),
-        colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),
+            .map(|it| ((it).0, ((it).1).map(|it| f.fold_lifetime(it)))),
+        mutability: node.mutability,
+        self_token: node.self_token,
+        colon_token: node.colon_token,
         ty: Box::new(f.fold_type(*node.ty)),
     }
 }
@@ -2715,10 +2598,7 @@ where
     match node {
         ReturnType::Default => ReturnType::Default,
         ReturnType::Type(_binding_0, _binding_1) => {
-            ReturnType::Type(
-                Token![->](tokens_helper(f, &_binding_0.spans)),
-                Box::new(f.fold_type(*_binding_1)),
-            )
+            ReturnType::Type(_binding_0, Box::new(f.fold_type(*_binding_1)))
         }
     }
 }
@@ -2728,14 +2608,14 @@ where
     F: Fold + ?Sized,
 {
     Signature {
-        constness: (node.constness).map(|it| Token![const](tokens_helper(f, &it.span))),
-        asyncness: (node.asyncness).map(|it| Token![async](tokens_helper(f, &it.span))),
-        unsafety: (node.unsafety).map(|it| Token![unsafe](tokens_helper(f, &it.span))),
+        constness: node.constness,
+        asyncness: node.asyncness,
+        unsafety: node.unsafety,
         abi: (node.abi).map(|it| f.fold_abi(it)),
-        fn_token: Token![fn](tokens_helper(f, &node.fn_token.span)),
+        fn_token: node.fn_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         inputs: FoldHelper::lift(node.inputs, |it| f.fold_fn_arg(it)),
         variadic: (node.variadic).map(|it| f.fold_variadic(it)),
         output: f.fold_return_type(node.output),
@@ -2753,9 +2633,7 @@ where
     F: Fold + ?Sized,
 {
     match node {
-        StaticMutability::Mut(_binding_0) => {
-            StaticMutability::Mut(Token![mut](tokens_helper(f, &_binding_0.span)))
-        }
+        StaticMutability::Mut(_binding_0) => StaticMutability::Mut(_binding_0),
         StaticMutability::None => StaticMutability::None,
     }
 }
@@ -2768,10 +2646,7 @@ where
         Stmt::Local(_binding_0) => Stmt::Local(f.fold_local(_binding_0)),
         Stmt::Item(_binding_0) => Stmt::Item(f.fold_item(_binding_0)),
         Stmt::Expr(_binding_0, _binding_1) => {
-            Stmt::Expr(
-                f.fold_expr(_binding_0),
-                (_binding_1).map(|it| Token![;](tokens_helper(f, &it.spans))),
-            )
+            Stmt::Expr(f.fold_expr(_binding_0), _binding_1)
         }
         Stmt::Macro(_binding_0) => Stmt::Macro(f.fold_stmt_macro(_binding_0)),
     }
@@ -2784,7 +2659,7 @@ where
     StmtMacro {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         mac: f.fold_macro(node.mac),
-        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2793,7 +2668,7 @@ where
     F: Fold + ?Sized,
 {
     TraitBound {
-        paren_token: (node.paren_token).map(|it| Paren(tokens_helper(f, &it.span))),
+        paren_token: node.paren_token,
         modifier: f.fold_trait_bound_modifier(node.modifier),
         lifetimes: (node.lifetimes).map(|it| f.fold_bound_lifetimes(it)),
         path: f.fold_path(node.path),
@@ -2809,9 +2684,7 @@ where
 {
     match node {
         TraitBoundModifier::None => TraitBoundModifier::None,
-        TraitBoundModifier::Maybe(_binding_0) => {
-            TraitBoundModifier::Maybe(Token![?](tokens_helper(f, &_binding_0.spans)))
-        }
+        TraitBoundModifier::Maybe(_binding_0) => TraitBoundModifier::Maybe(_binding_0),
     }
 }
 #[cfg(feature = "full")]
@@ -2840,14 +2713,13 @@ where
 {
     TraitItemConst {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        const_token: Token![const](tokens_helper(f, &node.const_token.span)),
+        const_token: node.const_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        colon_token: Token![:](tokens_helper(f, &node.colon_token.spans)),
+        colon_token: node.colon_token,
         ty: f.fold_type(node.ty),
-        default: (node.default)
-            .map(|it| (Token![=](tokens_helper(f, &(it).0.spans)), f.fold_expr((it).1))),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        default: (node.default).map(|it| ((it).0, f.fold_expr((it).1))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2859,7 +2731,7 @@ where
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         sig: f.fold_signature(node.sig),
         default: (node.default).map(|it| f.fold_block(it)),
-        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2870,7 +2742,7 @@ where
     TraitItemMacro {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         mac: f.fold_macro(node.mac),
-        semi_token: (node.semi_token).map(|it| Token![;](tokens_helper(f, &it.spans))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(feature = "full")]
@@ -2880,14 +2752,13 @@ where
 {
     TraitItemType {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        type_token: Token![type](tokens_helper(f, &node.type_token.span)),
+        type_token: node.type_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
-        colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),
+        colon_token: node.colon_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_type_param_bound(it)),
-        default: (node.default)
-            .map(|it| (Token![=](tokens_helper(f, &(it).0.spans)), f.fold_type((it).1))),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        default: (node.default).map(|it| ((it).0, f.fold_type((it).1))),
+        semi_token: node.semi_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2923,9 +2794,9 @@ where
     F: Fold + ?Sized,
 {
     TypeArray {
-        bracket_token: Bracket(tokens_helper(f, &node.bracket_token.span)),
+        bracket_token: node.bracket_token,
         elem: Box::new(f.fold_type(*node.elem)),
-        semi_token: Token![;](tokens_helper(f, &node.semi_token.spans)),
+        semi_token: node.semi_token,
         len: f.fold_expr(node.len),
     }
 }
@@ -2936,10 +2807,10 @@ where
 {
     TypeBareFn {
         lifetimes: (node.lifetimes).map(|it| f.fold_bound_lifetimes(it)),
-        unsafety: (node.unsafety).map(|it| Token![unsafe](tokens_helper(f, &it.span))),
+        unsafety: node.unsafety,
         abi: (node.abi).map(|it| f.fold_abi(it)),
-        fn_token: Token![fn](tokens_helper(f, &node.fn_token.span)),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        fn_token: node.fn_token,
+        paren_token: node.paren_token,
         inputs: FoldHelper::lift(node.inputs, |it| f.fold_bare_fn_arg(it)),
         variadic: (node.variadic).map(|it| f.fold_bare_variadic(it)),
         output: f.fold_return_type(node.output),
@@ -2951,7 +2822,7 @@ where
     F: Fold + ?Sized,
 {
     TypeGroup {
-        group_token: Group(tokens_helper(f, &node.group_token.span)),
+        group_token: node.group_token,
         elem: Box::new(f.fold_type(*node.elem)),
     }
 }
@@ -2961,7 +2832,7 @@ where
     F: Fold + ?Sized,
 {
     TypeImplTrait {
-        impl_token: Token![impl](tokens_helper(f, &node.impl_token.span)),
+        impl_token: node.impl_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_type_param_bound(it)),
     }
 }
@@ -2971,7 +2842,7 @@ where
     F: Fold + ?Sized,
 {
     TypeInfer {
-        underscore_token: Token![_](tokens_helper(f, &node.underscore_token.spans)),
+        underscore_token: node.underscore_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2989,7 +2860,7 @@ where
     F: Fold + ?Sized,
 {
     TypeNever {
-        bang_token: Token![!](tokens_helper(f, &node.bang_token.spans)),
+        bang_token: node.bang_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3000,9 +2871,9 @@ where
     TypeParam {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         ident: f.fold_ident(node.ident),
-        colon_token: (node.colon_token).map(|it| Token![:](tokens_helper(f, &it.spans))),
+        colon_token: node.colon_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_type_param_bound(it)),
-        eq_token: (node.eq_token).map(|it| Token![=](tokens_helper(f, &it.spans))),
+        eq_token: node.eq_token,
         default: (node.default).map(|it| f.fold_type(it)),
     }
 }
@@ -3027,7 +2898,7 @@ where
     F: Fold + ?Sized,
 {
     TypeParen {
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         elem: Box::new(f.fold_type(*node.elem)),
     }
 }
@@ -3047,10 +2918,9 @@ where
     F: Fold + ?Sized,
 {
     TypePtr {
-        star_token: Token![*](tokens_helper(f, &node.star_token.spans)),
-        const_token: (node.const_token)
-            .map(|it| Token![const](tokens_helper(f, &it.span))),
-        mutability: (node.mutability).map(|it| Token![mut](tokens_helper(f, &it.span))),
+        star_token: node.star_token,
+        const_token: node.const_token,
+        mutability: node.mutability,
         elem: Box::new(f.fold_type(*node.elem)),
     }
 }
@@ -3060,9 +2930,9 @@ where
     F: Fold + ?Sized,
 {
     TypeReference {
-        and_token: Token![&](tokens_helper(f, &node.and_token.spans)),
+        and_token: node.and_token,
         lifetime: (node.lifetime).map(|it| f.fold_lifetime(it)),
-        mutability: (node.mutability).map(|it| Token![mut](tokens_helper(f, &it.span))),
+        mutability: node.mutability,
         elem: Box::new(f.fold_type(*node.elem)),
     }
 }
@@ -3072,7 +2942,7 @@ where
     F: Fold + ?Sized,
 {
     TypeSlice {
-        bracket_token: Bracket(tokens_helper(f, &node.bracket_token.span)),
+        bracket_token: node.bracket_token,
         elem: Box::new(f.fold_type(*node.elem)),
     }
 }
@@ -3082,7 +2952,7 @@ where
     F: Fold + ?Sized,
 {
     TypeTraitObject {
-        dyn_token: (node.dyn_token).map(|it| Token![dyn](tokens_helper(f, &it.span))),
+        dyn_token: node.dyn_token,
         bounds: FoldHelper::lift(node.bounds, |it| f.fold_type_param_bound(it)),
     }
 }
@@ -3092,7 +2962,7 @@ where
     F: Fold + ?Sized,
 {
     TypeTuple {
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
+        paren_token: node.paren_token,
         elems: FoldHelper::lift(node.elems, |it| f.fold_type(it)),
     }
 }
@@ -3102,15 +2972,9 @@ where
     F: Fold + ?Sized,
 {
     match node {
-        UnOp::Deref(_binding_0) => {
-            UnOp::Deref(Token![*](tokens_helper(f, &_binding_0.spans)))
-        }
-        UnOp::Not(_binding_0) => {
-            UnOp::Not(Token![!](tokens_helper(f, &_binding_0.spans)))
-        }
-        UnOp::Neg(_binding_0) => {
-            UnOp::Neg(Token![-](tokens_helper(f, &_binding_0.spans)))
-        }
+        UnOp::Deref(_binding_0) => UnOp::Deref(_binding_0),
+        UnOp::Not(_binding_0) => UnOp::Not(_binding_0),
+        UnOp::Neg(_binding_0) => UnOp::Neg(_binding_0),
     }
 }
 #[cfg(feature = "full")]
@@ -3119,7 +2983,7 @@ where
     F: Fold + ?Sized,
 {
     UseGlob {
-        star_token: Token![*](tokens_helper(f, &node.star_token.spans)),
+        star_token: node.star_token,
     }
 }
 #[cfg(feature = "full")]
@@ -3128,7 +2992,7 @@ where
     F: Fold + ?Sized,
 {
     UseGroup {
-        brace_token: Brace(tokens_helper(f, &node.brace_token.span)),
+        brace_token: node.brace_token,
         items: FoldHelper::lift(node.items, |it| f.fold_use_tree(it)),
     }
 }
@@ -3148,7 +3012,7 @@ where
 {
     UsePath {
         ident: f.fold_ident(node.ident),
-        colon2_token: Token![::](tokens_helper(f, &node.colon2_token.spans)),
+        colon2_token: node.colon2_token,
         tree: Box::new(f.fold_use_tree(*node.tree)),
     }
 }
@@ -3159,7 +3023,7 @@ where
 {
     UseRename {
         ident: f.fold_ident(node.ident),
-        as_token: Token![as](tokens_helper(f, &node.as_token.span)),
+        as_token: node.as_token,
         rename: f.fold_ident(node.rename),
     }
 }
@@ -3183,13 +3047,9 @@ where
 {
     Variadic {
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
-        pat: (node.pat)
-            .map(|it| (
-                Box::new(f.fold_pat(*(it).0)),
-                Token![:](tokens_helper(f, &(it).1.spans)),
-            )),
-        dots: Token![...](tokens_helper(f, &node.dots.spans)),
-        comma: (node.comma).map(|it| Token![,](tokens_helper(f, &it.spans))),
+        pat: (node.pat).map(|it| (Box::new(f.fold_pat(*(it).0)), (it).1)),
+        dots: node.dots,
+        comma: node.comma,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3201,8 +3061,7 @@ where
         attrs: FoldHelper::lift(node.attrs, |it| f.fold_attribute(it)),
         ident: f.fold_ident(node.ident),
         fields: f.fold_fields(node.fields),
-        discriminant: (node.discriminant)
-            .map(|it| (Token![=](tokens_helper(f, &(it).0.spans)), f.fold_expr((it).1))),
+        discriminant: (node.discriminant).map(|it| ((it).0, f.fold_expr((it).1))),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3211,9 +3070,9 @@ where
     F: Fold + ?Sized,
 {
     VisRestricted {
-        pub_token: Token![pub](tokens_helper(f, &node.pub_token.span)),
-        paren_token: Paren(tokens_helper(f, &node.paren_token.span)),
-        in_token: (node.in_token).map(|it| Token![in](tokens_helper(f, &it.span))),
+        pub_token: node.pub_token,
+        paren_token: node.paren_token,
+        in_token: node.in_token,
         path: Box::new(f.fold_path(*node.path)),
     }
 }
@@ -3223,9 +3082,7 @@ where
     F: Fold + ?Sized,
 {
     match node {
-        Visibility::Public(_binding_0) => {
-            Visibility::Public(Token![pub](tokens_helper(f, &_binding_0.span)))
-        }
+        Visibility::Public(_binding_0) => Visibility::Public(_binding_0),
         Visibility::Restricted(_binding_0) => {
             Visibility::Restricted(f.fold_vis_restricted(_binding_0))
         }
@@ -3238,7 +3095,7 @@ where
     F: Fold + ?Sized,
 {
     WhereClause {
-        where_token: Token![where](tokens_helper(f, &node.where_token.span)),
+        where_token: node.where_token,
         predicates: FoldHelper::lift(node.predicates, |it| f.fold_where_predicate(it)),
     }
 }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -3,8 +3,6 @@
 
 #![allow(unused_variables)]
 #[cfg(any(feature = "full", feature = "derive"))]
-use crate::gen::helper::visit::*;
-#[cfg(any(feature = "full", feature = "derive"))]
 use crate::punctuated::Punctuated;
 use crate::*;
 use proc_macro2::Span;
@@ -758,7 +756,7 @@ pub fn visit_abi<'ast, V>(v: &mut V, node: &'ast Abi)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.extern_token.span);
+    skip!(node.extern_token);
     if let Some(it) = &node.name {
         v.visit_lit_str(it);
     }
@@ -771,18 +769,13 @@ pub fn visit_angle_bracketed_generic_arguments<'ast, V>(
 where
     V: Visit<'ast> + ?Sized,
 {
-    if let Some(it) = &node.colon2_token {
-        tokens_helper(v, &it.spans);
-    }
-    tokens_helper(v, &node.lt_token.spans);
+    skip!(node.colon2_token);
+    skip!(node.lt_token);
     for el in Punctuated::pairs(&node.args) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_generic_argument(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
-    tokens_helper(v, &node.gt_token.spans);
+    skip!(node.gt_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_arm<'ast, V>(v: &mut V, node: &'ast Arm)
@@ -794,14 +787,12 @@ where
     }
     v.visit_pat(&node.pat);
     if let Some(it) = &node.guard {
-        tokens_helper(v, &(it).0.span);
+        skip!((it).0);
         v.visit_expr(&*(it).1);
     }
-    tokens_helper(v, &node.fat_arrow_token.spans);
+    skip!(node.fat_arrow_token);
     v.visit_expr(&*node.body);
-    if let Some(it) = &node.comma {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.comma);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_assoc_const<'ast, V>(v: &mut V, node: &'ast AssocConst)
@@ -812,7 +803,7 @@ where
     if let Some(it) = &node.generics {
         v.visit_angle_bracketed_generic_arguments(it);
     }
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr(&node.value);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -824,7 +815,7 @@ where
     if let Some(it) = &node.generics {
         v.visit_angle_bracketed_generic_arguments(it);
     }
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_type(&node.ty);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -835,7 +826,7 @@ where
     match node {
         AttrStyle::Outer => {}
         AttrStyle::Inner(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -844,9 +835,9 @@ pub fn visit_attribute<'ast, V>(v: &mut V, node: &'ast Attribute)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.pound_token.spans);
+    skip!(node.pound_token);
     v.visit_attr_style(&node.style);
-    tokens_helper(v, &node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_meta(&node.meta);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -859,7 +850,7 @@ where
     }
     if let Some(it) = &node.name {
         v.visit_ident(&(it).0);
-        tokens_helper(v, &(it).1.spans);
+        skip!((it).1);
     }
     v.visit_type(&node.ty);
 }
@@ -873,12 +864,10 @@ where
     }
     if let Some(it) = &node.name {
         v.visit_ident(&(it).0);
-        tokens_helper(v, &(it).1.spans);
+        skip!((it).1);
     }
-    tokens_helper(v, &node.dots.spans);
-    if let Some(it) = &node.comma {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.dots);
+    skip!(node.comma);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_bin_op<'ast, V>(v: &mut V, node: &'ast BinOp)
@@ -887,88 +876,88 @@ where
 {
     match node {
         BinOp::Add(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Sub(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Mul(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Div(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Rem(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::And(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Or(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitXor(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitAnd(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitOr(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Shl(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Shr(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Eq(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Lt(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Le(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Ne(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Ge(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Gt(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::AddAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::SubAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::MulAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::DivAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::RemAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitXorAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitAndAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitOrAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::ShlAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::ShrAssign(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -977,7 +966,7 @@ pub fn visit_block<'ast, V>(v: &mut V, node: &'ast Block)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for it in &node.stmts {
         v.visit_stmt(it);
     }
@@ -987,16 +976,13 @@ pub fn visit_bound_lifetimes<'ast, V>(v: &mut V, node: &'ast BoundLifetimes)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.for_token.span);
-    tokens_helper(v, &node.lt_token.spans);
+    skip!(node.for_token);
+    skip!(node.lt_token);
     for el in Punctuated::pairs(&node.lifetimes) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_generic_param(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
-    tokens_helper(v, &node.gt_token.spans);
+    skip!(node.gt_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_const_param<'ast, V>(v: &mut V, node: &'ast ConstParam)
@@ -1006,13 +992,11 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.const_token.span);
+    skip!(node.const_token);
     v.visit_ident(&node.ident);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type(&node.ty);
-    if let Some(it) = &node.eq_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.eq_token);
     if let Some(it) = &node.default {
         v.visit_expr(it);
     }
@@ -1026,13 +1010,10 @@ where
     if let Some(it) = &node.generics {
         v.visit_angle_bracketed_generic_arguments(it);
     }
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type_param_bound(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "derive")]
@@ -1057,14 +1038,11 @@ pub fn visit_data_enum<'ast, V>(v: &mut V, node: &'ast DataEnum)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.enum_token.span);
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.enum_token);
+    skip!(node.brace_token);
     for el in Punctuated::pairs(&node.variants) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_variant(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "derive")]
@@ -1072,18 +1050,16 @@ pub fn visit_data_struct<'ast, V>(v: &mut V, node: &'ast DataStruct)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.struct_token.span);
+    skip!(node.struct_token);
     v.visit_fields(&node.fields);
-    if let Some(it) = &node.semi_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "derive")]
 pub fn visit_data_union<'ast, V>(v: &mut V, node: &'ast DataUnion)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.union_token.span);
+    skip!(node.union_token);
     v.visit_fields_named(&node.fields);
 }
 #[cfg(feature = "derive")]
@@ -1232,13 +1208,10 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.bracket_token.span);
+    skip!(node.bracket_token);
     for el in Punctuated::pairs(&node.elems) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_expr(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -1250,7 +1223,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.left);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr(&*node.right);
 }
 #[cfg(feature = "full")]
@@ -1261,10 +1234,8 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.async_token.span);
-    if let Some(it) = &node.capture {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.async_token);
+    skip!(node.capture);
     v.visit_block(&node.block);
 }
 #[cfg(feature = "full")]
@@ -1276,8 +1247,8 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.base);
-    tokens_helper(v, &node.dot_token.spans);
-    tokens_helper(v, &node.await_token.span);
+    skip!(node.dot_token);
+    skip!(node.await_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_expr_binary<'ast, V>(v: &mut V, node: &'ast ExprBinary)
@@ -1312,7 +1283,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.break_token.span);
+    skip!(node.break_token);
     if let Some(it) = &node.label {
         v.visit_lifetime(it);
     }
@@ -1329,13 +1300,10 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.func);
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.args) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_expr(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1347,7 +1315,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.as_token.span);
+    skip!(node.as_token);
     v.visit_type(&*node.ty);
 }
 #[cfg(feature = "full")]
@@ -1361,27 +1329,16 @@ where
     if let Some(it) = &node.lifetimes {
         v.visit_bound_lifetimes(it);
     }
-    if let Some(it) = &node.constness {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.movability {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.asyncness {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.capture {
-        tokens_helper(v, &it.span);
-    }
-    tokens_helper(v, &node.or1_token.spans);
+    skip!(node.constness);
+    skip!(node.movability);
+    skip!(node.asyncness);
+    skip!(node.capture);
+    skip!(node.or1_token);
     for el in Punctuated::pairs(&node.inputs) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_pat(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
-    tokens_helper(v, &node.or2_token.spans);
+    skip!(node.or2_token);
     v.visit_return_type(&node.output);
     v.visit_expr(&*node.body);
 }
@@ -1393,7 +1350,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.const_token.span);
+    skip!(node.const_token);
     v.visit_block(&node.block);
 }
 #[cfg(feature = "full")]
@@ -1404,7 +1361,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.continue_token.span);
+    skip!(node.continue_token);
     if let Some(it) = &node.label {
         v.visit_lifetime(it);
     }
@@ -1418,7 +1375,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.base);
-    tokens_helper(v, &node.dot_token.spans);
+    skip!(node.dot_token);
     v.visit_member(&node.member);
 }
 #[cfg(feature = "full")]
@@ -1432,9 +1389,9 @@ where
     if let Some(it) = &node.label {
         v.visit_label(it);
     }
-    tokens_helper(v, &node.for_token.span);
+    skip!(node.for_token);
     v.visit_pat(&*node.pat);
-    tokens_helper(v, &node.in_token.span);
+    skip!(node.in_token);
     v.visit_expr(&*node.expr);
     v.visit_block(&node.body);
 }
@@ -1446,7 +1403,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.group_token.span);
+    skip!(node.group_token);
     v.visit_expr(&*node.expr);
 }
 #[cfg(feature = "full")]
@@ -1457,11 +1414,11 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.if_token.span);
+    skip!(node.if_token);
     v.visit_expr(&*node.cond);
     v.visit_block(&node.then_branch);
     if let Some(it) = &node.else_branch {
-        tokens_helper(v, &(it).0.span);
+        skip!((it).0);
         v.visit_expr(&*(it).1);
     }
 }
@@ -1474,7 +1431,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_expr(&*node.index);
 }
 #[cfg(feature = "full")]
@@ -1485,7 +1442,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.underscore_token.spans);
+    skip!(node.underscore_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_let<'ast, V>(v: &mut V, node: &'ast ExprLet)
@@ -1495,9 +1452,9 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.let_token.span);
+    skip!(node.let_token);
     v.visit_pat(&*node.pat);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr(&*node.expr);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1521,7 +1478,7 @@ where
     if let Some(it) = &node.label {
         v.visit_label(it);
     }
-    tokens_helper(v, &node.loop_token.span);
+    skip!(node.loop_token);
     v.visit_block(&node.body);
 }
 #[cfg(feature = "full")]
@@ -1542,9 +1499,9 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.match_token.span);
+    skip!(node.match_token);
     v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for it in &node.arms {
         v.visit_arm(it);
     }
@@ -1558,18 +1515,15 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.receiver);
-    tokens_helper(v, &node.dot_token.spans);
+    skip!(node.dot_token);
     v.visit_ident(&node.method);
     if let Some(it) = &node.turbofish {
         v.visit_angle_bracketed_generic_arguments(it);
     }
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.args) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_expr(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1580,7 +1534,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     v.visit_expr(&*node.expr);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1620,10 +1574,8 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.and_token.spans);
-    if let Some(it) = &node.mutability {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.and_token);
+    skip!(node.mutability);
     v.visit_expr(&*node.expr);
 }
 #[cfg(feature = "full")]
@@ -1634,9 +1586,9 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
     v.visit_expr(&*node.len);
 }
 #[cfg(feature = "full")]
@@ -1647,7 +1599,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.return_token.span);
+    skip!(node.return_token);
     if let Some(it) = &node.expr {
         v.visit_expr(&**it);
     }
@@ -1664,17 +1616,12 @@ where
         v.visit_qself(it);
     }
     v.visit_path(&node.path);
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for el in Punctuated::pairs(&node.fields) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_field_value(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
-    if let Some(it) = &node.dot2_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.dot2_token);
     if let Some(it) = &node.rest {
         v.visit_expr(&**it);
     }
@@ -1688,7 +1635,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.question_token.spans);
+    skip!(node.question_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_try_block<'ast, V>(v: &mut V, node: &'ast ExprTryBlock)
@@ -1698,7 +1645,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.try_token.span);
+    skip!(node.try_token);
     v.visit_block(&node.block);
 }
 #[cfg(feature = "full")]
@@ -1709,13 +1656,10 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.elems) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_expr(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1737,7 +1681,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.unsafe_token.span);
+    skip!(node.unsafe_token);
     v.visit_block(&node.block);
 }
 #[cfg(feature = "full")]
@@ -1751,7 +1695,7 @@ where
     if let Some(it) = &node.label {
         v.visit_label(it);
     }
-    tokens_helper(v, &node.while_token.span);
+    skip!(node.while_token);
     v.visit_expr(&*node.cond);
     v.visit_block(&node.body);
 }
@@ -1763,7 +1707,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.yield_token.span);
+    skip!(node.yield_token);
     if let Some(it) = &node.expr {
         v.visit_expr(&**it);
     }
@@ -1781,9 +1725,7 @@ where
     if let Some(it) = &node.ident {
         v.visit_ident(it);
     }
-    if let Some(it) = &node.colon_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.colon_token);
     v.visit_type(&node.ty);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1804,9 +1746,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_member(&node.member);
-    if let Some(it) = &node.colon_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.colon_token);
     v.visit_pat(&*node.pat);
 }
 #[cfg(feature = "full")]
@@ -1818,9 +1758,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_member(&node.member);
-    if let Some(it) = &node.colon_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.colon_token);
     v.visit_expr(&node.expr);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1843,13 +1781,10 @@ pub fn visit_fields_named<'ast, V>(v: &mut V, node: &'ast FieldsNamed)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for el in Punctuated::pairs(&node.named) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_field(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1857,13 +1792,10 @@ pub fn visit_fields_unnamed<'ast, V>(v: &mut V, node: &'ast FieldsUnnamed)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.unnamed) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_field(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -1926,7 +1858,7 @@ where
     }
     v.visit_visibility(&node.vis);
     v.visit_signature(&node.sig);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_foreign_item_macro<'ast, V>(v: &mut V, node: &'ast ForeignItemMacro)
@@ -1937,9 +1869,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_macro(&node.mac);
-    if let Some(it) = &node.semi_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_foreign_item_static<'ast, V>(v: &mut V, node: &'ast ForeignItemStatic)
@@ -1950,12 +1880,12 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.static_token.span);
+    skip!(node.static_token);
     v.visit_static_mutability(&node.mutability);
     v.visit_ident(&node.ident);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type(&*node.ty);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_foreign_item_type<'ast, V>(v: &mut V, node: &'ast ForeignItemType)
@@ -1966,10 +1896,10 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.type_token.span);
+    skip!(node.type_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_generic_argument<'ast, V>(v: &mut V, node: &'ast GenericArgument)
@@ -2019,19 +1949,12 @@ pub fn visit_generics<'ast, V>(v: &mut V, node: &'ast Generics)
 where
     V: Visit<'ast> + ?Sized,
 {
-    if let Some(it) = &node.lt_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.lt_token);
     for el in Punctuated::pairs(&node.params) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_generic_param(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
-    if let Some(it) = &node.gt_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.gt_token);
     if let Some(it) = &node.where_clause {
         v.visit_where_clause(it);
     }
@@ -2074,17 +1997,15 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    if let Some(it) = &node.defaultness {
-        tokens_helper(v, &it.span);
-    }
-    tokens_helper(v, &node.const_token.span);
+    skip!(node.defaultness);
+    skip!(node.const_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type(&node.ty);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr(&node.expr);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_impl_item_fn<'ast, V>(v: &mut V, node: &'ast ImplItemFn)
@@ -2095,9 +2016,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    if let Some(it) = &node.defaultness {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.defaultness);
     v.visit_signature(&node.sig);
     v.visit_block(&node.block);
 }
@@ -2110,9 +2029,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_macro(&node.mac);
-    if let Some(it) = &node.semi_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_impl_item_type<'ast, V>(v: &mut V, node: &'ast ImplItemType)
@@ -2123,15 +2040,13 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    if let Some(it) = &node.defaultness {
-        tokens_helper(v, &it.span);
-    }
-    tokens_helper(v, &node.type_token.span);
+    skip!(node.defaultness);
+    skip!(node.type_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_type(&node.ty);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_impl_restriction<'ast, V>(v: &mut V, node: &'ast ImplRestriction)
@@ -2213,14 +2128,14 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.const_token.span);
+    skip!(node.const_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type(&*node.ty);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_enum<'ast, V>(v: &mut V, node: &'ast ItemEnum)
@@ -2231,16 +2146,13 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.enum_token.span);
+    skip!(node.enum_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for el in Punctuated::pairs(&node.variants) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_variant(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2252,14 +2164,14 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.extern_token.span);
-    tokens_helper(v, &node.crate_token.span);
+    skip!(node.extern_token);
+    skip!(node.crate_token);
     v.visit_ident(&node.ident);
     if let Some(it) = &node.rename {
-        tokens_helper(v, &(it).0.span);
+        skip!((it).0);
         v.visit_ident(&(it).1);
     }
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_fn<'ast, V>(v: &mut V, node: &'ast ItemFn)
@@ -2281,11 +2193,9 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    if let Some(it) = &node.unsafety {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.unsafety);
     v.visit_abi(&node.abi);
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for it in &node.items {
         v.visit_foreign_item(it);
     }
@@ -2298,23 +2208,17 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    if let Some(it) = &node.defaultness {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.unsafety {
-        tokens_helper(v, &it.span);
-    }
-    tokens_helper(v, &node.impl_token.span);
+    skip!(node.defaultness);
+    skip!(node.unsafety);
+    skip!(node.impl_token);
     v.visit_generics(&node.generics);
     if let Some(it) = &node.trait_ {
-        if let Some(it) = &(it).0 {
-            tokens_helper(v, &it.spans);
-        }
+        skip!((it).0);
         v.visit_path(&(it).1);
-        tokens_helper(v, &(it).2.span);
+        skip!((it).2);
     }
     v.visit_type(&*node.self_ty);
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for it in &node.items {
         v.visit_impl_item(it);
     }
@@ -2331,9 +2235,7 @@ where
         v.visit_ident(it);
     }
     v.visit_macro(&node.mac);
-    if let Some(it) = &node.semi_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_mod<'ast, V>(v: &mut V, node: &'ast ItemMod)
@@ -2344,20 +2246,16 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    if let Some(it) = &node.unsafety {
-        tokens_helper(v, &it.span);
-    }
-    tokens_helper(v, &node.mod_token.span);
+    skip!(node.unsafety);
+    skip!(node.mod_token);
     v.visit_ident(&node.ident);
     if let Some(it) = &node.content {
-        tokens_helper(v, &(it).0.span);
+        skip!((it).0);
         for it in &(it).1 {
             v.visit_item(it);
         }
     }
-    if let Some(it) = &node.semi {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_static<'ast, V>(v: &mut V, node: &'ast ItemStatic)
@@ -2368,14 +2266,14 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.static_token.span);
+    skip!(node.static_token);
     v.visit_static_mutability(&node.mutability);
     v.visit_ident(&node.ident);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type(&*node.ty);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr(&*node.expr);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_struct<'ast, V>(v: &mut V, node: &'ast ItemStruct)
@@ -2386,13 +2284,11 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.struct_token.span);
+    skip!(node.struct_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
     v.visit_fields(&node.fields);
-    if let Some(it) = &node.semi_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_trait<'ast, V>(v: &mut V, node: &'ast ItemTrait)
@@ -2403,29 +2299,20 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    if let Some(it) = &node.unsafety {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.auto_token {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.unsafety);
+    skip!(node.auto_token);
     if let Some(it) = &node.restriction {
         v.visit_impl_restriction(it);
     }
-    tokens_helper(v, &node.trait_token.span);
+    skip!(node.trait_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    if let Some(it) = &node.colon_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.colon_token);
     for el in Punctuated::pairs(&node.supertraits) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type_param_bound(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for it in &node.items {
         v.visit_trait_item(it);
     }
@@ -2439,18 +2326,15 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.trait_token.span);
+    skip!(node.trait_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type_param_bound(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_type<'ast, V>(v: &mut V, node: &'ast ItemType)
@@ -2461,12 +2345,12 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.type_token.span);
+    skip!(node.type_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_type(&*node.ty);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_union<'ast, V>(v: &mut V, node: &'ast ItemUnion)
@@ -2477,7 +2361,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.union_token.span);
+    skip!(node.union_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
     v.visit_fields_named(&node.fields);
@@ -2491,12 +2375,10 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    tokens_helper(v, &node.use_token.span);
-    if let Some(it) = &node.leading_colon {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.use_token);
+    skip!(node.leading_colon);
     v.visit_use_tree(&node.tree);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_label<'ast, V>(v: &mut V, node: &'ast Label)
@@ -2504,7 +2386,7 @@ where
     V: Visit<'ast> + ?Sized,
 {
     v.visit_lifetime(&node.name);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
 }
 pub fn visit_lifetime<'ast, V>(v: &mut V, node: &'ast Lifetime)
 where
@@ -2522,15 +2404,10 @@ where
         v.visit_attribute(it);
     }
     v.visit_lifetime(&node.lifetime);
-    if let Some(it) = &node.colon_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.colon_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_lifetime(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 pub fn visit_lit<'ast, V>(v: &mut V, node: &'ast Lit)
@@ -2603,22 +2480,22 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.let_token.span);
+    skip!(node.let_token);
     v.visit_pat(&node.pat);
     if let Some(it) = &node.init {
         v.visit_local_init(it);
     }
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_local_init<'ast, V>(v: &mut V, node: &'ast LocalInit)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr(&*node.expr);
     if let Some(it) = &node.diverge {
-        tokens_helper(v, &(it).0.span);
+        skip!((it).0);
         v.visit_expr(&*(it).1);
     }
 }
@@ -2628,7 +2505,7 @@ where
     V: Visit<'ast> + ?Sized,
 {
     v.visit_path(&node.path);
-    tokens_helper(v, &node.bang_token.spans);
+    skip!(node.bang_token);
     v.visit_macro_delimiter(&node.delimiter);
     skip!(node.tokens);
 }
@@ -2639,13 +2516,13 @@ where
 {
     match node {
         MacroDelimiter::Paren(_binding_0) => {
-            tokens_helper(v, &_binding_0.span);
+            skip!(_binding_0);
         }
         MacroDelimiter::Brace(_binding_0) => {
-            tokens_helper(v, &_binding_0.span);
+            skip!(_binding_0);
         }
         MacroDelimiter::Bracket(_binding_0) => {
-            tokens_helper(v, &_binding_0.span);
+            skip!(_binding_0);
         }
     }
 }
@@ -2695,7 +2572,7 @@ where
     V: Visit<'ast> + ?Sized,
 {
     v.visit_path(&node.path);
-    tokens_helper(v, &node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr(&node.value);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2706,13 +2583,10 @@ pub fn visit_parenthesized_generic_arguments<'ast, V>(
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.inputs) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
     v.visit_return_type(&node.output);
 }
@@ -2783,15 +2657,11 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    if let Some(it) = &node.by_ref {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.mutability {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.by_ref);
+    skip!(node.mutability);
     v.visit_ident(&node.ident);
     if let Some(it) = &node.subpat {
-        tokens_helper(v, &(it).0.spans);
+        skip!((it).0);
         v.visit_pat(&*(it).1);
     }
 }
@@ -2803,15 +2673,10 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    if let Some(it) = &node.leading_vert {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.leading_vert);
     for el in Punctuated::pairs(&node.cases) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_pat(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2822,7 +2687,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     v.visit_pat(&*node.pat);
 }
 #[cfg(feature = "full")]
@@ -2833,10 +2698,8 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.and_token.spans);
-    if let Some(it) = &node.mutability {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.and_token);
+    skip!(node.mutability);
     v.visit_pat(&*node.pat);
 }
 #[cfg(feature = "full")]
@@ -2847,7 +2710,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.dot2_token.spans);
+    skip!(node.dot2_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_pat_slice<'ast, V>(v: &mut V, node: &'ast PatSlice)
@@ -2857,13 +2720,10 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.bracket_token.span);
+    skip!(node.bracket_token);
     for el in Punctuated::pairs(&node.elems) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_pat(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2878,13 +2738,10 @@ where
         v.visit_qself(it);
     }
     v.visit_path(&node.path);
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for el in Punctuated::pairs(&node.fields) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_field_pat(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
     if let Some(it) = &node.rest {
         v.visit_pat_rest(it);
@@ -2898,13 +2755,10 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.elems) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_pat(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2919,13 +2773,10 @@ where
         v.visit_qself(it);
     }
     v.visit_path(&node.path);
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.elems) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_pat(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2937,7 +2788,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_pat(&*node.pat);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type(&*node.ty);
 }
 #[cfg(feature = "full")]
@@ -2948,22 +2799,17 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.underscore_token.spans);
+    skip!(node.underscore_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_path<'ast, V>(v: &mut V, node: &'ast Path)
 where
     V: Visit<'ast> + ?Sized,
 {
-    if let Some(it) = &node.leading_colon {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.leading_colon);
     for el in Punctuated::pairs(&node.segments) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_path_segment(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2995,13 +2841,10 @@ where
     V: Visit<'ast> + ?Sized,
 {
     v.visit_lifetime(&node.lifetime);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_lifetime(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3013,13 +2856,10 @@ where
         v.visit_bound_lifetimes(it);
     }
     v.visit_type(&node.bounded_ty);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type_param_bound(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3027,13 +2867,11 @@ pub fn visit_qself<'ast, V>(v: &mut V, node: &'ast QSelf)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.lt_token.spans);
+    skip!(node.lt_token);
     v.visit_type(&*node.ty);
     skip!(node.position);
-    if let Some(it) = &node.as_token {
-        tokens_helper(v, &it.span);
-    }
-    tokens_helper(v, &node.gt_token.spans);
+    skip!(node.as_token);
+    skip!(node.gt_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_range_limits<'ast, V>(v: &mut V, node: &'ast RangeLimits)
@@ -3042,10 +2880,10 @@ where
 {
     match node {
         RangeLimits::HalfOpen(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         RangeLimits::Closed(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -3058,18 +2896,14 @@ where
         v.visit_attribute(it);
     }
     if let Some(it) = &node.reference {
-        tokens_helper(v, &(it).0.spans);
+        skip!((it).0);
         if let Some(it) = &(it).1 {
             v.visit_lifetime(it);
         }
     }
-    if let Some(it) = &node.mutability {
-        tokens_helper(v, &it.span);
-    }
-    tokens_helper(v, &node.self_token.span);
-    if let Some(it) = &node.colon_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.mutability);
+    skip!(node.self_token);
+    skip!(node.colon_token);
     v.visit_type(&*node.ty);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3080,7 +2914,7 @@ where
     match node {
         ReturnType::Default => {}
         ReturnType::Type(_binding_0, _binding_1) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
             v.visit_type(&**_binding_1);
         }
     }
@@ -3090,28 +2924,19 @@ pub fn visit_signature<'ast, V>(v: &mut V, node: &'ast Signature)
 where
     V: Visit<'ast> + ?Sized,
 {
-    if let Some(it) = &node.constness {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.asyncness {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.unsafety {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.constness);
+    skip!(node.asyncness);
+    skip!(node.unsafety);
     if let Some(it) = &node.abi {
         v.visit_abi(it);
     }
-    tokens_helper(v, &node.fn_token.span);
+    skip!(node.fn_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.inputs) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_fn_arg(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
     if let Some(it) = &node.variadic {
         v.visit_variadic(it);
@@ -3129,7 +2954,7 @@ where
 {
     match node {
         StaticMutability::Mut(_binding_0) => {
-            tokens_helper(v, &_binding_0.span);
+            skip!(_binding_0);
         }
         StaticMutability::None => {}
     }
@@ -3148,9 +2973,7 @@ where
         }
         Stmt::Expr(_binding_0, _binding_1) => {
             v.visit_expr(_binding_0);
-            if let Some(it) = _binding_1 {
-                tokens_helper(v, &it.spans);
-            }
+            skip!(_binding_1);
         }
         Stmt::Macro(_binding_0) => {
             v.visit_stmt_macro(_binding_0);
@@ -3166,18 +2989,14 @@ where
         v.visit_attribute(it);
     }
     v.visit_macro(&node.mac);
-    if let Some(it) = &node.semi_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_trait_bound<'ast, V>(v: &mut V, node: &'ast TraitBound)
 where
     V: Visit<'ast> + ?Sized,
 {
-    if let Some(it) = &node.paren_token {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.paren_token);
     v.visit_trait_bound_modifier(&node.modifier);
     if let Some(it) = &node.lifetimes {
         v.visit_bound_lifetimes(it);
@@ -3192,7 +3011,7 @@ where
     match node {
         TraitBoundModifier::None => {}
         TraitBoundModifier::Maybe(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -3227,16 +3046,16 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.const_token.span);
+    skip!(node.const_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    tokens_helper(v, &node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type(&node.ty);
     if let Some(it) = &node.default {
-        tokens_helper(v, &(it).0.spans);
+        skip!((it).0);
         v.visit_expr(&(it).1);
     }
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_trait_item_fn<'ast, V>(v: &mut V, node: &'ast TraitItemFn)
@@ -3250,9 +3069,7 @@ where
     if let Some(it) = &node.default {
         v.visit_block(it);
     }
-    if let Some(it) = &node.semi_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_trait_item_macro<'ast, V>(v: &mut V, node: &'ast TraitItemMacro)
@@ -3263,9 +3080,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_macro(&node.mac);
-    if let Some(it) = &node.semi_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_trait_item_type<'ast, V>(v: &mut V, node: &'ast TraitItemType)
@@ -3275,24 +3090,19 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    tokens_helper(v, &node.type_token.span);
+    skip!(node.type_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
-    if let Some(it) = &node.colon_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.colon_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type_param_bound(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
     if let Some(it) = &node.default {
-        tokens_helper(v, &(it).0.spans);
+        skip!((it).0);
         v.visit_type(&(it).1);
     }
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_type<'ast, V>(v: &mut V, node: &'ast Type)
@@ -3352,9 +3162,9 @@ pub fn visit_type_array<'ast, V>(v: &mut V, node: &'ast TypeArray)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_type(&*node.elem);
-    tokens_helper(v, &node.semi_token.spans);
+    skip!(node.semi_token);
     v.visit_expr(&node.len);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3365,20 +3175,15 @@ where
     if let Some(it) = &node.lifetimes {
         v.visit_bound_lifetimes(it);
     }
-    if let Some(it) = &node.unsafety {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.unsafety);
     if let Some(it) = &node.abi {
         v.visit_abi(it);
     }
-    tokens_helper(v, &node.fn_token.span);
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.fn_token);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.inputs) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_bare_fn_arg(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
     if let Some(it) = &node.variadic {
         v.visit_bare_variadic(it);
@@ -3390,7 +3195,7 @@ pub fn visit_type_group<'ast, V>(v: &mut V, node: &'ast TypeGroup)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.group_token.span);
+    skip!(node.group_token);
     v.visit_type(&*node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3398,13 +3203,10 @@ pub fn visit_type_impl_trait<'ast, V>(v: &mut V, node: &'ast TypeImplTrait)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.impl_token.span);
+    skip!(node.impl_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type_param_bound(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3412,7 +3214,7 @@ pub fn visit_type_infer<'ast, V>(v: &mut V, node: &'ast TypeInfer)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.underscore_token.spans);
+    skip!(node.underscore_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_type_macro<'ast, V>(v: &mut V, node: &'ast TypeMacro)
@@ -3426,7 +3228,7 @@ pub fn visit_type_never<'ast, V>(v: &mut V, node: &'ast TypeNever)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.bang_token.spans);
+    skip!(node.bang_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_type_param<'ast, V>(v: &mut V, node: &'ast TypeParam)
@@ -3437,19 +3239,12 @@ where
         v.visit_attribute(it);
     }
     v.visit_ident(&node.ident);
-    if let Some(it) = &node.colon_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.colon_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type_param_bound(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
-    if let Some(it) = &node.eq_token {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.eq_token);
     if let Some(it) = &node.default {
         v.visit_type(it);
     }
@@ -3476,7 +3271,7 @@ pub fn visit_type_paren<'ast, V>(v: &mut V, node: &'ast TypeParen)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     v.visit_type(&*node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3494,13 +3289,9 @@ pub fn visit_type_ptr<'ast, V>(v: &mut V, node: &'ast TypePtr)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.star_token.spans);
-    if let Some(it) = &node.const_token {
-        tokens_helper(v, &it.span);
-    }
-    if let Some(it) = &node.mutability {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.star_token);
+    skip!(node.const_token);
+    skip!(node.mutability);
     v.visit_type(&*node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3508,13 +3299,11 @@ pub fn visit_type_reference<'ast, V>(v: &mut V, node: &'ast TypeReference)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.and_token.spans);
+    skip!(node.and_token);
     if let Some(it) = &node.lifetime {
         v.visit_lifetime(it);
     }
-    if let Some(it) = &node.mutability {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.mutability);
     v.visit_type(&*node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3522,7 +3311,7 @@ pub fn visit_type_slice<'ast, V>(v: &mut V, node: &'ast TypeSlice)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_type(&*node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3530,15 +3319,10 @@ pub fn visit_type_trait_object<'ast, V>(v: &mut V, node: &'ast TypeTraitObject)
 where
     V: Visit<'ast> + ?Sized,
 {
-    if let Some(it) = &node.dyn_token {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.dyn_token);
     for el in Punctuated::pairs(&node.bounds) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type_param_bound(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3546,13 +3330,10 @@ pub fn visit_type_tuple<'ast, V>(v: &mut V, node: &'ast TypeTuple)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.paren_token.span);
+    skip!(node.paren_token);
     for el in Punctuated::pairs(&node.elems) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_type(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3562,13 +3343,13 @@ where
 {
     match node {
         UnOp::Deref(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         UnOp::Not(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
         UnOp::Neg(_binding_0) => {
-            tokens_helper(v, &_binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -3577,20 +3358,17 @@ pub fn visit_use_glob<'ast, V>(v: &mut V, node: &'ast UseGlob)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.star_token.spans);
+    skip!(node.star_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_use_group<'ast, V>(v: &mut V, node: &'ast UseGroup)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.brace_token.span);
+    skip!(node.brace_token);
     for el in Punctuated::pairs(&node.items) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_use_tree(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -3606,7 +3384,7 @@ where
     V: Visit<'ast> + ?Sized,
 {
     v.visit_ident(&node.ident);
-    tokens_helper(v, &node.colon2_token.spans);
+    skip!(node.colon2_token);
     v.visit_use_tree(&*node.tree);
 }
 #[cfg(feature = "full")]
@@ -3615,7 +3393,7 @@ where
     V: Visit<'ast> + ?Sized,
 {
     v.visit_ident(&node.ident);
-    tokens_helper(v, &node.as_token.span);
+    skip!(node.as_token);
     v.visit_ident(&node.rename);
 }
 #[cfg(feature = "full")]
@@ -3651,12 +3429,10 @@ where
     }
     if let Some(it) = &node.pat {
         v.visit_pat(&*(it).0);
-        tokens_helper(v, &(it).1.spans);
+        skip!((it).1);
     }
-    tokens_helper(v, &node.dots.spans);
-    if let Some(it) = &node.comma {
-        tokens_helper(v, &it.spans);
-    }
+    skip!(node.dots);
+    skip!(node.comma);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_variant<'ast, V>(v: &mut V, node: &'ast Variant)
@@ -3669,7 +3445,7 @@ where
     v.visit_ident(&node.ident);
     v.visit_fields(&node.fields);
     if let Some(it) = &node.discriminant {
-        tokens_helper(v, &(it).0.spans);
+        skip!((it).0);
         v.visit_expr(&(it).1);
     }
 }
@@ -3678,11 +3454,9 @@ pub fn visit_vis_restricted<'ast, V>(v: &mut V, node: &'ast VisRestricted)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.pub_token.span);
-    tokens_helper(v, &node.paren_token.span);
-    if let Some(it) = &node.in_token {
-        tokens_helper(v, &it.span);
-    }
+    skip!(node.pub_token);
+    skip!(node.paren_token);
+    skip!(node.in_token);
     v.visit_path(&*node.path);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3692,7 +3466,7 @@ where
 {
     match node {
         Visibility::Public(_binding_0) => {
-            tokens_helper(v, &_binding_0.span);
+            skip!(_binding_0);
         }
         Visibility::Restricted(_binding_0) => {
             v.visit_vis_restricted(_binding_0);
@@ -3705,13 +3479,10 @@ pub fn visit_where_clause<'ast, V>(v: &mut V, node: &'ast WhereClause)
 where
     V: Visit<'ast> + ?Sized,
 {
-    tokens_helper(v, &node.where_token.span);
+    skip!(node.where_token);
     for el in Punctuated::pairs(&node.predicates) {
-        let (it, p) = el.into_tuple();
+        let it = el.value();
         v.visit_where_predicate(it);
-        if let Some(p) = p {
-            tokens_helper(v, &p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -3,8 +3,6 @@
 
 #![allow(unused_variables)]
 #[cfg(any(feature = "full", feature = "derive"))]
-use crate::gen::helper::visit_mut::*;
-#[cfg(any(feature = "full", feature = "derive"))]
 use crate::punctuated::Punctuated;
 use crate::*;
 use proc_macro2::Span;
@@ -759,7 +757,7 @@ pub fn visit_abi_mut<V>(v: &mut V, node: &mut Abi)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.extern_token.span);
+    skip!(node.extern_token);
     if let Some(it) = &mut node.name {
         v.visit_lit_str_mut(it);
     }
@@ -772,18 +770,13 @@ pub fn visit_angle_bracketed_generic_arguments_mut<V>(
 where
     V: VisitMut + ?Sized,
 {
-    if let Some(it) = &mut node.colon2_token {
-        tokens_helper(v, &mut it.spans);
-    }
-    tokens_helper(v, &mut node.lt_token.spans);
-    for el in Punctuated::pairs_mut(&mut node.args) {
-        let (it, p) = el.into_tuple();
+    skip!(node.colon2_token);
+    skip!(node.lt_token);
+    for mut el in Punctuated::pairs_mut(&mut node.args) {
+        let it = el.value_mut();
         v.visit_generic_argument_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
-    tokens_helper(v, &mut node.gt_token.spans);
+    skip!(node.gt_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_arm_mut<V>(v: &mut V, node: &mut Arm)
@@ -795,14 +788,12 @@ where
     }
     v.visit_pat_mut(&mut node.pat);
     if let Some(it) = &mut node.guard {
-        tokens_helper(v, &mut (it).0.span);
+        skip!((it).0);
         v.visit_expr_mut(&mut *(it).1);
     }
-    tokens_helper(v, &mut node.fat_arrow_token.spans);
+    skip!(node.fat_arrow_token);
     v.visit_expr_mut(&mut *node.body);
-    if let Some(it) = &mut node.comma {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.comma);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_assoc_const_mut<V>(v: &mut V, node: &mut AssocConst)
@@ -813,7 +804,7 @@ where
     if let Some(it) = &mut node.generics {
         v.visit_angle_bracketed_generic_arguments_mut(it);
     }
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr_mut(&mut node.value);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -825,7 +816,7 @@ where
     if let Some(it) = &mut node.generics {
         v.visit_angle_bracketed_generic_arguments_mut(it);
     }
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_type_mut(&mut node.ty);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -836,7 +827,7 @@ where
     match node {
         AttrStyle::Outer => {}
         AttrStyle::Inner(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -845,9 +836,9 @@ pub fn visit_attribute_mut<V>(v: &mut V, node: &mut Attribute)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.pound_token.spans);
+    skip!(node.pound_token);
     v.visit_attr_style_mut(&mut node.style);
-    tokens_helper(v, &mut node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_meta_mut(&mut node.meta);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -860,7 +851,7 @@ where
     }
     if let Some(it) = &mut node.name {
         v.visit_ident_mut(&mut (it).0);
-        tokens_helper(v, &mut (it).1.spans);
+        skip!((it).1);
     }
     v.visit_type_mut(&mut node.ty);
 }
@@ -874,12 +865,10 @@ where
     }
     if let Some(it) = &mut node.name {
         v.visit_ident_mut(&mut (it).0);
-        tokens_helper(v, &mut (it).1.spans);
+        skip!((it).1);
     }
-    tokens_helper(v, &mut node.dots.spans);
-    if let Some(it) = &mut node.comma {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.dots);
+    skip!(node.comma);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_bin_op_mut<V>(v: &mut V, node: &mut BinOp)
@@ -888,88 +877,88 @@ where
 {
     match node {
         BinOp::Add(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Sub(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Mul(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Div(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Rem(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::And(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Or(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitXor(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitAnd(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitOr(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Shl(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Shr(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Eq(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Lt(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Le(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Ne(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Ge(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::Gt(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::AddAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::SubAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::MulAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::DivAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::RemAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitXorAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitAndAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::BitOrAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::ShlAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         BinOp::ShrAssign(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -978,7 +967,7 @@ pub fn visit_block_mut<V>(v: &mut V, node: &mut Block)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.brace_token.span);
+    skip!(node.brace_token);
     for it in &mut node.stmts {
         v.visit_stmt_mut(it);
     }
@@ -988,16 +977,13 @@ pub fn visit_bound_lifetimes_mut<V>(v: &mut V, node: &mut BoundLifetimes)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.for_token.span);
-    tokens_helper(v, &mut node.lt_token.spans);
-    for el in Punctuated::pairs_mut(&mut node.lifetimes) {
-        let (it, p) = el.into_tuple();
+    skip!(node.for_token);
+    skip!(node.lt_token);
+    for mut el in Punctuated::pairs_mut(&mut node.lifetimes) {
+        let it = el.value_mut();
         v.visit_generic_param_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
-    tokens_helper(v, &mut node.gt_token.spans);
+    skip!(node.gt_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_const_param_mut<V>(v: &mut V, node: &mut ConstParam)
@@ -1007,13 +993,11 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.const_token.span);
+    skip!(node.const_token);
     v.visit_ident_mut(&mut node.ident);
-    tokens_helper(v, &mut node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type_mut(&mut node.ty);
-    if let Some(it) = &mut node.eq_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.eq_token);
     if let Some(it) = &mut node.default {
         v.visit_expr_mut(it);
     }
@@ -1027,13 +1011,10 @@ where
     if let Some(it) = &mut node.generics {
         v.visit_angle_bracketed_generic_arguments_mut(it);
     }
-    tokens_helper(v, &mut node.colon_token.spans);
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.colon_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_type_param_bound_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "derive")]
@@ -1058,14 +1039,11 @@ pub fn visit_data_enum_mut<V>(v: &mut V, node: &mut DataEnum)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.enum_token.span);
-    tokens_helper(v, &mut node.brace_token.span);
-    for el in Punctuated::pairs_mut(&mut node.variants) {
-        let (it, p) = el.into_tuple();
+    skip!(node.enum_token);
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.variants) {
+        let it = el.value_mut();
         v.visit_variant_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "derive")]
@@ -1073,18 +1051,16 @@ pub fn visit_data_struct_mut<V>(v: &mut V, node: &mut DataStruct)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.struct_token.span);
+    skip!(node.struct_token);
     v.visit_fields_mut(&mut node.fields);
-    if let Some(it) = &mut node.semi_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "derive")]
 pub fn visit_data_union_mut<V>(v: &mut V, node: &mut DataUnion)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.union_token.span);
+    skip!(node.union_token);
     v.visit_fields_named_mut(&mut node.fields);
 }
 #[cfg(feature = "derive")]
@@ -1233,13 +1209,10 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.bracket_token.span);
-    for el in Punctuated::pairs_mut(&mut node.elems) {
-        let (it, p) = el.into_tuple();
+    skip!(node.bracket_token);
+    for mut el in Punctuated::pairs_mut(&mut node.elems) {
+        let it = el.value_mut();
         v.visit_expr_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -1251,7 +1224,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_expr_mut(&mut *node.left);
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr_mut(&mut *node.right);
 }
 #[cfg(feature = "full")]
@@ -1262,10 +1235,8 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.async_token.span);
-    if let Some(it) = &mut node.capture {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.async_token);
+    skip!(node.capture);
     v.visit_block_mut(&mut node.block);
 }
 #[cfg(feature = "full")]
@@ -1277,8 +1248,8 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_expr_mut(&mut *node.base);
-    tokens_helper(v, &mut node.dot_token.spans);
-    tokens_helper(v, &mut node.await_token.span);
+    skip!(node.dot_token);
+    skip!(node.await_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_expr_binary_mut<V>(v: &mut V, node: &mut ExprBinary)
@@ -1313,7 +1284,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.break_token.span);
+    skip!(node.break_token);
     if let Some(it) = &mut node.label {
         v.visit_lifetime_mut(it);
     }
@@ -1330,13 +1301,10 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_expr_mut(&mut *node.func);
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.args) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.args) {
+        let it = el.value_mut();
         v.visit_expr_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1348,7 +1316,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.as_token.span);
+    skip!(node.as_token);
     v.visit_type_mut(&mut *node.ty);
 }
 #[cfg(feature = "full")]
@@ -1362,27 +1330,16 @@ where
     if let Some(it) = &mut node.lifetimes {
         v.visit_bound_lifetimes_mut(it);
     }
-    if let Some(it) = &mut node.constness {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.movability {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.asyncness {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.capture {
-        tokens_helper(v, &mut it.span);
-    }
-    tokens_helper(v, &mut node.or1_token.spans);
-    for el in Punctuated::pairs_mut(&mut node.inputs) {
-        let (it, p) = el.into_tuple();
+    skip!(node.constness);
+    skip!(node.movability);
+    skip!(node.asyncness);
+    skip!(node.capture);
+    skip!(node.or1_token);
+    for mut el in Punctuated::pairs_mut(&mut node.inputs) {
+        let it = el.value_mut();
         v.visit_pat_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
-    tokens_helper(v, &mut node.or2_token.spans);
+    skip!(node.or2_token);
     v.visit_return_type_mut(&mut node.output);
     v.visit_expr_mut(&mut *node.body);
 }
@@ -1394,7 +1351,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.const_token.span);
+    skip!(node.const_token);
     v.visit_block_mut(&mut node.block);
 }
 #[cfg(feature = "full")]
@@ -1405,7 +1362,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.continue_token.span);
+    skip!(node.continue_token);
     if let Some(it) = &mut node.label {
         v.visit_lifetime_mut(it);
     }
@@ -1419,7 +1376,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_expr_mut(&mut *node.base);
-    tokens_helper(v, &mut node.dot_token.spans);
+    skip!(node.dot_token);
     v.visit_member_mut(&mut node.member);
 }
 #[cfg(feature = "full")]
@@ -1433,9 +1390,9 @@ where
     if let Some(it) = &mut node.label {
         v.visit_label_mut(it);
     }
-    tokens_helper(v, &mut node.for_token.span);
+    skip!(node.for_token);
     v.visit_pat_mut(&mut *node.pat);
-    tokens_helper(v, &mut node.in_token.span);
+    skip!(node.in_token);
     v.visit_expr_mut(&mut *node.expr);
     v.visit_block_mut(&mut node.body);
 }
@@ -1447,7 +1404,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.group_token.span);
+    skip!(node.group_token);
     v.visit_expr_mut(&mut *node.expr);
 }
 #[cfg(feature = "full")]
@@ -1458,11 +1415,11 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.if_token.span);
+    skip!(node.if_token);
     v.visit_expr_mut(&mut *node.cond);
     v.visit_block_mut(&mut node.then_branch);
     if let Some(it) = &mut node.else_branch {
-        tokens_helper(v, &mut (it).0.span);
+        skip!((it).0);
         v.visit_expr_mut(&mut *(it).1);
     }
 }
@@ -1475,7 +1432,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_expr_mut(&mut *node.index);
 }
 #[cfg(feature = "full")]
@@ -1486,7 +1443,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.underscore_token.spans);
+    skip!(node.underscore_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_let_mut<V>(v: &mut V, node: &mut ExprLet)
@@ -1496,9 +1453,9 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.let_token.span);
+    skip!(node.let_token);
     v.visit_pat_mut(&mut *node.pat);
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr_mut(&mut *node.expr);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1522,7 +1479,7 @@ where
     if let Some(it) = &mut node.label {
         v.visit_label_mut(it);
     }
-    tokens_helper(v, &mut node.loop_token.span);
+    skip!(node.loop_token);
     v.visit_block_mut(&mut node.body);
 }
 #[cfg(feature = "full")]
@@ -1543,9 +1500,9 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.match_token.span);
+    skip!(node.match_token);
     v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.brace_token.span);
+    skip!(node.brace_token);
     for it in &mut node.arms {
         v.visit_arm_mut(it);
     }
@@ -1559,18 +1516,15 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_expr_mut(&mut *node.receiver);
-    tokens_helper(v, &mut node.dot_token.spans);
+    skip!(node.dot_token);
     v.visit_ident_mut(&mut node.method);
     if let Some(it) = &mut node.turbofish {
         v.visit_angle_bracketed_generic_arguments_mut(it);
     }
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.args) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.args) {
+        let it = el.value_mut();
         v.visit_expr_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1581,7 +1535,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.paren_token.span);
+    skip!(node.paren_token);
     v.visit_expr_mut(&mut *node.expr);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1621,10 +1575,8 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.and_token.spans);
-    if let Some(it) = &mut node.mutability {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.and_token);
+    skip!(node.mutability);
     v.visit_expr_mut(&mut *node.expr);
 }
 #[cfg(feature = "full")]
@@ -1635,9 +1587,9 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
     v.visit_expr_mut(&mut *node.len);
 }
 #[cfg(feature = "full")]
@@ -1648,7 +1600,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.return_token.span);
+    skip!(node.return_token);
     if let Some(it) = &mut node.expr {
         v.visit_expr_mut(&mut **it);
     }
@@ -1665,17 +1617,12 @@ where
         v.visit_qself_mut(it);
     }
     v.visit_path_mut(&mut node.path);
-    tokens_helper(v, &mut node.brace_token.span);
-    for el in Punctuated::pairs_mut(&mut node.fields) {
-        let (it, p) = el.into_tuple();
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.fields) {
+        let it = el.value_mut();
         v.visit_field_value_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
-    if let Some(it) = &mut node.dot2_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.dot2_token);
     if let Some(it) = &mut node.rest {
         v.visit_expr_mut(&mut **it);
     }
@@ -1689,7 +1636,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.question_token.spans);
+    skip!(node.question_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_expr_try_block_mut<V>(v: &mut V, node: &mut ExprTryBlock)
@@ -1699,7 +1646,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.try_token.span);
+    skip!(node.try_token);
     v.visit_block_mut(&mut node.block);
 }
 #[cfg(feature = "full")]
@@ -1710,13 +1657,10 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.elems) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.elems) {
+        let it = el.value_mut();
         v.visit_expr_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1738,7 +1682,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.unsafe_token.span);
+    skip!(node.unsafe_token);
     v.visit_block_mut(&mut node.block);
 }
 #[cfg(feature = "full")]
@@ -1752,7 +1696,7 @@ where
     if let Some(it) = &mut node.label {
         v.visit_label_mut(it);
     }
-    tokens_helper(v, &mut node.while_token.span);
+    skip!(node.while_token);
     v.visit_expr_mut(&mut *node.cond);
     v.visit_block_mut(&mut node.body);
 }
@@ -1764,7 +1708,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.yield_token.span);
+    skip!(node.yield_token);
     if let Some(it) = &mut node.expr {
         v.visit_expr_mut(&mut **it);
     }
@@ -1782,9 +1726,7 @@ where
     if let Some(it) = &mut node.ident {
         v.visit_ident_mut(it);
     }
-    if let Some(it) = &mut node.colon_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.colon_token);
     v.visit_type_mut(&mut node.ty);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1805,9 +1747,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_member_mut(&mut node.member);
-    if let Some(it) = &mut node.colon_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.colon_token);
     v.visit_pat_mut(&mut *node.pat);
 }
 #[cfg(feature = "full")]
@@ -1819,9 +1759,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_member_mut(&mut node.member);
-    if let Some(it) = &mut node.colon_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.colon_token);
     v.visit_expr_mut(&mut node.expr);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1844,13 +1782,10 @@ pub fn visit_fields_named_mut<V>(v: &mut V, node: &mut FieldsNamed)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.brace_token.span);
-    for el in Punctuated::pairs_mut(&mut node.named) {
-        let (it, p) = el.into_tuple();
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.named) {
+        let it = el.value_mut();
         v.visit_field_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1858,13 +1793,10 @@ pub fn visit_fields_unnamed_mut<V>(v: &mut V, node: &mut FieldsUnnamed)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.unnamed) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.unnamed) {
+        let it = el.value_mut();
         v.visit_field_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -1927,7 +1859,7 @@ where
     }
     v.visit_visibility_mut(&mut node.vis);
     v.visit_signature_mut(&mut node.sig);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_foreign_item_macro_mut<V>(v: &mut V, node: &mut ForeignItemMacro)
@@ -1938,9 +1870,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_macro_mut(&mut node.mac);
-    if let Some(it) = &mut node.semi_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_foreign_item_static_mut<V>(v: &mut V, node: &mut ForeignItemStatic)
@@ -1951,12 +1881,12 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.static_token.span);
+    skip!(node.static_token);
     v.visit_static_mutability_mut(&mut node.mutability);
     v.visit_ident_mut(&mut node.ident);
-    tokens_helper(v, &mut node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type_mut(&mut *node.ty);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_foreign_item_type_mut<V>(v: &mut V, node: &mut ForeignItemType)
@@ -1967,10 +1897,10 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.type_token.span);
+    skip!(node.type_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_generic_argument_mut<V>(v: &mut V, node: &mut GenericArgument)
@@ -2020,19 +1950,12 @@ pub fn visit_generics_mut<V>(v: &mut V, node: &mut Generics)
 where
     V: VisitMut + ?Sized,
 {
-    if let Some(it) = &mut node.lt_token {
-        tokens_helper(v, &mut it.spans);
-    }
-    for el in Punctuated::pairs_mut(&mut node.params) {
-        let (it, p) = el.into_tuple();
+    skip!(node.lt_token);
+    for mut el in Punctuated::pairs_mut(&mut node.params) {
+        let it = el.value_mut();
         v.visit_generic_param_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
-    if let Some(it) = &mut node.gt_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.gt_token);
     if let Some(it) = &mut node.where_clause {
         v.visit_where_clause_mut(it);
     }
@@ -2077,17 +2000,15 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    if let Some(it) = &mut node.defaultness {
-        tokens_helper(v, &mut it.span);
-    }
-    tokens_helper(v, &mut node.const_token.span);
+    skip!(node.defaultness);
+    skip!(node.const_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type_mut(&mut node.ty);
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr_mut(&mut node.expr);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_impl_item_fn_mut<V>(v: &mut V, node: &mut ImplItemFn)
@@ -2098,9 +2019,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    if let Some(it) = &mut node.defaultness {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.defaultness);
     v.visit_signature_mut(&mut node.sig);
     v.visit_block_mut(&mut node.block);
 }
@@ -2113,9 +2032,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_macro_mut(&mut node.mac);
-    if let Some(it) = &mut node.semi_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_impl_item_type_mut<V>(v: &mut V, node: &mut ImplItemType)
@@ -2126,15 +2043,13 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    if let Some(it) = &mut node.defaultness {
-        tokens_helper(v, &mut it.span);
-    }
-    tokens_helper(v, &mut node.type_token.span);
+    skip!(node.defaultness);
+    skip!(node.type_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_type_mut(&mut node.ty);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_impl_restriction_mut<V>(v: &mut V, node: &mut ImplRestriction)
@@ -2216,14 +2131,14 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.const_token.span);
+    skip!(node.const_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type_mut(&mut *node.ty);
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_enum_mut<V>(v: &mut V, node: &mut ItemEnum)
@@ -2234,16 +2149,13 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.enum_token.span);
+    skip!(node.enum_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.brace_token.span);
-    for el in Punctuated::pairs_mut(&mut node.variants) {
-        let (it, p) = el.into_tuple();
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.variants) {
+        let it = el.value_mut();
         v.visit_variant_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2255,14 +2167,14 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.extern_token.span);
-    tokens_helper(v, &mut node.crate_token.span);
+    skip!(node.extern_token);
+    skip!(node.crate_token);
     v.visit_ident_mut(&mut node.ident);
     if let Some(it) = &mut node.rename {
-        tokens_helper(v, &mut (it).0.span);
+        skip!((it).0);
         v.visit_ident_mut(&mut (it).1);
     }
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_fn_mut<V>(v: &mut V, node: &mut ItemFn)
@@ -2284,11 +2196,9 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    if let Some(it) = &mut node.unsafety {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.unsafety);
     v.visit_abi_mut(&mut node.abi);
-    tokens_helper(v, &mut node.brace_token.span);
+    skip!(node.brace_token);
     for it in &mut node.items {
         v.visit_foreign_item_mut(it);
     }
@@ -2301,23 +2211,17 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    if let Some(it) = &mut node.defaultness {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.unsafety {
-        tokens_helper(v, &mut it.span);
-    }
-    tokens_helper(v, &mut node.impl_token.span);
+    skip!(node.defaultness);
+    skip!(node.unsafety);
+    skip!(node.impl_token);
     v.visit_generics_mut(&mut node.generics);
     if let Some(it) = &mut node.trait_ {
-        if let Some(it) = &mut (it).0 {
-            tokens_helper(v, &mut it.spans);
-        }
+        skip!((it).0);
         v.visit_path_mut(&mut (it).1);
-        tokens_helper(v, &mut (it).2.span);
+        skip!((it).2);
     }
     v.visit_type_mut(&mut *node.self_ty);
-    tokens_helper(v, &mut node.brace_token.span);
+    skip!(node.brace_token);
     for it in &mut node.items {
         v.visit_impl_item_mut(it);
     }
@@ -2334,9 +2238,7 @@ where
         v.visit_ident_mut(it);
     }
     v.visit_macro_mut(&mut node.mac);
-    if let Some(it) = &mut node.semi_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_mod_mut<V>(v: &mut V, node: &mut ItemMod)
@@ -2347,20 +2249,16 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    if let Some(it) = &mut node.unsafety {
-        tokens_helper(v, &mut it.span);
-    }
-    tokens_helper(v, &mut node.mod_token.span);
+    skip!(node.unsafety);
+    skip!(node.mod_token);
     v.visit_ident_mut(&mut node.ident);
     if let Some(it) = &mut node.content {
-        tokens_helper(v, &mut (it).0.span);
+        skip!((it).0);
         for it in &mut (it).1 {
             v.visit_item_mut(it);
         }
     }
-    if let Some(it) = &mut node.semi {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_static_mut<V>(v: &mut V, node: &mut ItemStatic)
@@ -2371,14 +2269,14 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.static_token.span);
+    skip!(node.static_token);
     v.visit_static_mutability_mut(&mut node.mutability);
     v.visit_ident_mut(&mut node.ident);
-    tokens_helper(v, &mut node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type_mut(&mut *node.ty);
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr_mut(&mut *node.expr);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_struct_mut<V>(v: &mut V, node: &mut ItemStruct)
@@ -2389,13 +2287,11 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.struct_token.span);
+    skip!(node.struct_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
     v.visit_fields_mut(&mut node.fields);
-    if let Some(it) = &mut node.semi_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_trait_mut<V>(v: &mut V, node: &mut ItemTrait)
@@ -2406,29 +2302,20 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    if let Some(it) = &mut node.unsafety {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.auto_token {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.unsafety);
+    skip!(node.auto_token);
     if let Some(it) = &mut node.restriction {
         v.visit_impl_restriction_mut(it);
     }
-    tokens_helper(v, &mut node.trait_token.span);
+    skip!(node.trait_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    if let Some(it) = &mut node.colon_token {
-        tokens_helper(v, &mut it.spans);
-    }
-    for el in Punctuated::pairs_mut(&mut node.supertraits) {
-        let (it, p) = el.into_tuple();
+    skip!(node.colon_token);
+    for mut el in Punctuated::pairs_mut(&mut node.supertraits) {
+        let it = el.value_mut();
         v.visit_type_param_bound_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
-    tokens_helper(v, &mut node.brace_token.span);
+    skip!(node.brace_token);
     for it in &mut node.items {
         v.visit_trait_item_mut(it);
     }
@@ -2442,18 +2329,15 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.trait_token.span);
+    skip!(node.trait_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.eq_token.spans);
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.eq_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_type_param_bound_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_type_mut<V>(v: &mut V, node: &mut ItemType)
@@ -2464,12 +2348,12 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.type_token.span);
+    skip!(node.type_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_type_mut(&mut *node.ty);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_item_union_mut<V>(v: &mut V, node: &mut ItemUnion)
@@ -2480,7 +2364,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.union_token.span);
+    skip!(node.union_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
     v.visit_fields_named_mut(&mut node.fields);
@@ -2494,12 +2378,10 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_visibility_mut(&mut node.vis);
-    tokens_helper(v, &mut node.use_token.span);
-    if let Some(it) = &mut node.leading_colon {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.use_token);
+    skip!(node.leading_colon);
     v.visit_use_tree_mut(&mut node.tree);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_label_mut<V>(v: &mut V, node: &mut Label)
@@ -2507,7 +2389,7 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_lifetime_mut(&mut node.name);
-    tokens_helper(v, &mut node.colon_token.spans);
+    skip!(node.colon_token);
 }
 pub fn visit_lifetime_mut<V>(v: &mut V, node: &mut Lifetime)
 where
@@ -2525,15 +2407,10 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_lifetime_mut(&mut node.lifetime);
-    if let Some(it) = &mut node.colon_token {
-        tokens_helper(v, &mut it.spans);
-    }
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.colon_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_lifetime_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 pub fn visit_lit_mut<V>(v: &mut V, node: &mut Lit)
@@ -2606,22 +2483,22 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.let_token.span);
+    skip!(node.let_token);
     v.visit_pat_mut(&mut node.pat);
     if let Some(it) = &mut node.init {
         v.visit_local_init_mut(it);
     }
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_local_init_mut<V>(v: &mut V, node: &mut LocalInit)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr_mut(&mut *node.expr);
     if let Some(it) = &mut node.diverge {
-        tokens_helper(v, &mut (it).0.span);
+        skip!((it).0);
         v.visit_expr_mut(&mut *(it).1);
     }
 }
@@ -2631,7 +2508,7 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_path_mut(&mut node.path);
-    tokens_helper(v, &mut node.bang_token.spans);
+    skip!(node.bang_token);
     v.visit_macro_delimiter_mut(&mut node.delimiter);
     skip!(node.tokens);
 }
@@ -2642,13 +2519,13 @@ where
 {
     match node {
         MacroDelimiter::Paren(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.span);
+            skip!(_binding_0);
         }
         MacroDelimiter::Brace(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.span);
+            skip!(_binding_0);
         }
         MacroDelimiter::Bracket(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.span);
+            skip!(_binding_0);
         }
     }
 }
@@ -2698,7 +2575,7 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_path_mut(&mut node.path);
-    tokens_helper(v, &mut node.eq_token.spans);
+    skip!(node.eq_token);
     v.visit_expr_mut(&mut node.value);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2709,13 +2586,10 @@ pub fn visit_parenthesized_generic_arguments_mut<V>(
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.inputs) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.inputs) {
+        let it = el.value_mut();
         v.visit_type_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
     v.visit_return_type_mut(&mut node.output);
 }
@@ -2786,15 +2660,11 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    if let Some(it) = &mut node.by_ref {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.mutability {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.by_ref);
+    skip!(node.mutability);
     v.visit_ident_mut(&mut node.ident);
     if let Some(it) = &mut node.subpat {
-        tokens_helper(v, &mut (it).0.spans);
+        skip!((it).0);
         v.visit_pat_mut(&mut *(it).1);
     }
 }
@@ -2806,15 +2676,10 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    if let Some(it) = &mut node.leading_vert {
-        tokens_helper(v, &mut it.spans);
-    }
-    for el in Punctuated::pairs_mut(&mut node.cases) {
-        let (it, p) = el.into_tuple();
+    skip!(node.leading_vert);
+    for mut el in Punctuated::pairs_mut(&mut node.cases) {
+        let it = el.value_mut();
         v.visit_pat_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2825,7 +2690,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.paren_token.span);
+    skip!(node.paren_token);
     v.visit_pat_mut(&mut *node.pat);
 }
 #[cfg(feature = "full")]
@@ -2836,10 +2701,8 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.and_token.spans);
-    if let Some(it) = &mut node.mutability {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.and_token);
+    skip!(node.mutability);
     v.visit_pat_mut(&mut *node.pat);
 }
 #[cfg(feature = "full")]
@@ -2850,7 +2713,7 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.dot2_token.spans);
+    skip!(node.dot2_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_pat_slice_mut<V>(v: &mut V, node: &mut PatSlice)
@@ -2860,13 +2723,10 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.bracket_token.span);
-    for el in Punctuated::pairs_mut(&mut node.elems) {
-        let (it, p) = el.into_tuple();
+    skip!(node.bracket_token);
+    for mut el in Punctuated::pairs_mut(&mut node.elems) {
+        let it = el.value_mut();
         v.visit_pat_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2881,13 +2741,10 @@ where
         v.visit_qself_mut(it);
     }
     v.visit_path_mut(&mut node.path);
-    tokens_helper(v, &mut node.brace_token.span);
-    for el in Punctuated::pairs_mut(&mut node.fields) {
-        let (it, p) = el.into_tuple();
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.fields) {
+        let it = el.value_mut();
         v.visit_field_pat_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
     if let Some(it) = &mut node.rest {
         v.visit_pat_rest_mut(it);
@@ -2901,13 +2758,10 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.elems) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.elems) {
+        let it = el.value_mut();
         v.visit_pat_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2922,13 +2776,10 @@ where
         v.visit_qself_mut(it);
     }
     v.visit_path_mut(&mut node.path);
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.elems) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.elems) {
+        let it = el.value_mut();
         v.visit_pat_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -2940,7 +2791,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_pat_mut(&mut *node.pat);
-    tokens_helper(v, &mut node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type_mut(&mut *node.ty);
 }
 #[cfg(feature = "full")]
@@ -2951,22 +2802,17 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.underscore_token.spans);
+    skip!(node.underscore_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_path_mut<V>(v: &mut V, node: &mut Path)
 where
     V: VisitMut + ?Sized,
 {
-    if let Some(it) = &mut node.leading_colon {
-        tokens_helper(v, &mut it.spans);
-    }
-    for el in Punctuated::pairs_mut(&mut node.segments) {
-        let (it, p) = el.into_tuple();
+    skip!(node.leading_colon);
+    for mut el in Punctuated::pairs_mut(&mut node.segments) {
+        let it = el.value_mut();
         v.visit_path_segment_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2998,13 +2844,10 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_lifetime_mut(&mut node.lifetime);
-    tokens_helper(v, &mut node.colon_token.spans);
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.colon_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_lifetime_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3016,13 +2859,10 @@ where
         v.visit_bound_lifetimes_mut(it);
     }
     v.visit_type_mut(&mut node.bounded_ty);
-    tokens_helper(v, &mut node.colon_token.spans);
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.colon_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_type_param_bound_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3030,13 +2870,11 @@ pub fn visit_qself_mut<V>(v: &mut V, node: &mut QSelf)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.lt_token.spans);
+    skip!(node.lt_token);
     v.visit_type_mut(&mut *node.ty);
     skip!(node.position);
-    if let Some(it) = &mut node.as_token {
-        tokens_helper(v, &mut it.span);
-    }
-    tokens_helper(v, &mut node.gt_token.spans);
+    skip!(node.as_token);
+    skip!(node.gt_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_range_limits_mut<V>(v: &mut V, node: &mut RangeLimits)
@@ -3045,10 +2883,10 @@ where
 {
     match node {
         RangeLimits::HalfOpen(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         RangeLimits::Closed(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -3061,18 +2899,14 @@ where
         v.visit_attribute_mut(it);
     }
     if let Some(it) = &mut node.reference {
-        tokens_helper(v, &mut (it).0.spans);
+        skip!((it).0);
         if let Some(it) = &mut (it).1 {
             v.visit_lifetime_mut(it);
         }
     }
-    if let Some(it) = &mut node.mutability {
-        tokens_helper(v, &mut it.span);
-    }
-    tokens_helper(v, &mut node.self_token.span);
-    if let Some(it) = &mut node.colon_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.mutability);
+    skip!(node.self_token);
+    skip!(node.colon_token);
     v.visit_type_mut(&mut *node.ty);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3083,7 +2917,7 @@ where
     match node {
         ReturnType::Default => {}
         ReturnType::Type(_binding_0, _binding_1) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
             v.visit_type_mut(&mut **_binding_1);
         }
     }
@@ -3093,28 +2927,19 @@ pub fn visit_signature_mut<V>(v: &mut V, node: &mut Signature)
 where
     V: VisitMut + ?Sized,
 {
-    if let Some(it) = &mut node.constness {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.asyncness {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.unsafety {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.constness);
+    skip!(node.asyncness);
+    skip!(node.unsafety);
     if let Some(it) = &mut node.abi {
         v.visit_abi_mut(it);
     }
-    tokens_helper(v, &mut node.fn_token.span);
+    skip!(node.fn_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.inputs) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.inputs) {
+        let it = el.value_mut();
         v.visit_fn_arg_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
     if let Some(it) = &mut node.variadic {
         v.visit_variadic_mut(it);
@@ -3132,7 +2957,7 @@ where
 {
     match node {
         StaticMutability::Mut(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.span);
+            skip!(_binding_0);
         }
         StaticMutability::None => {}
     }
@@ -3151,9 +2976,7 @@ where
         }
         Stmt::Expr(_binding_0, _binding_1) => {
             v.visit_expr_mut(_binding_0);
-            if let Some(it) = _binding_1 {
-                tokens_helper(v, &mut it.spans);
-            }
+            skip!(_binding_1);
         }
         Stmt::Macro(_binding_0) => {
             v.visit_stmt_macro_mut(_binding_0);
@@ -3169,18 +2992,14 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_macro_mut(&mut node.mac);
-    if let Some(it) = &mut node.semi_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_trait_bound_mut<V>(v: &mut V, node: &mut TraitBound)
 where
     V: VisitMut + ?Sized,
 {
-    if let Some(it) = &mut node.paren_token {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.paren_token);
     v.visit_trait_bound_modifier_mut(&mut node.modifier);
     if let Some(it) = &mut node.lifetimes {
         v.visit_bound_lifetimes_mut(it);
@@ -3195,7 +3014,7 @@ where
     match node {
         TraitBoundModifier::None => {}
         TraitBoundModifier::Maybe(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -3230,16 +3049,16 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.const_token.span);
+    skip!(node.const_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    tokens_helper(v, &mut node.colon_token.spans);
+    skip!(node.colon_token);
     v.visit_type_mut(&mut node.ty);
     if let Some(it) = &mut node.default {
-        tokens_helper(v, &mut (it).0.spans);
+        skip!((it).0);
         v.visit_expr_mut(&mut (it).1);
     }
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_trait_item_fn_mut<V>(v: &mut V, node: &mut TraitItemFn)
@@ -3253,9 +3072,7 @@ where
     if let Some(it) = &mut node.default {
         v.visit_block_mut(it);
     }
-    if let Some(it) = &mut node.semi_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_trait_item_macro_mut<V>(v: &mut V, node: &mut TraitItemMacro)
@@ -3266,9 +3083,7 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_macro_mut(&mut node.mac);
-    if let Some(it) = &mut node.semi_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_trait_item_type_mut<V>(v: &mut V, node: &mut TraitItemType)
@@ -3278,24 +3093,19 @@ where
     for it in &mut node.attrs {
         v.visit_attribute_mut(it);
     }
-    tokens_helper(v, &mut node.type_token.span);
+    skip!(node.type_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
-    if let Some(it) = &mut node.colon_token {
-        tokens_helper(v, &mut it.spans);
-    }
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.colon_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_type_param_bound_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
     if let Some(it) = &mut node.default {
-        tokens_helper(v, &mut (it).0.spans);
+        skip!((it).0);
         v.visit_type_mut(&mut (it).1);
     }
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_type_mut<V>(v: &mut V, node: &mut Type)
@@ -3355,9 +3165,9 @@ pub fn visit_type_array_mut<V>(v: &mut V, node: &mut TypeArray)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_type_mut(&mut *node.elem);
-    tokens_helper(v, &mut node.semi_token.spans);
+    skip!(node.semi_token);
     v.visit_expr_mut(&mut node.len);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3368,20 +3178,15 @@ where
     if let Some(it) = &mut node.lifetimes {
         v.visit_bound_lifetimes_mut(it);
     }
-    if let Some(it) = &mut node.unsafety {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.unsafety);
     if let Some(it) = &mut node.abi {
         v.visit_abi_mut(it);
     }
-    tokens_helper(v, &mut node.fn_token.span);
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.inputs) {
-        let (it, p) = el.into_tuple();
+    skip!(node.fn_token);
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.inputs) {
+        let it = el.value_mut();
         v.visit_bare_fn_arg_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
     if let Some(it) = &mut node.variadic {
         v.visit_bare_variadic_mut(it);
@@ -3393,7 +3198,7 @@ pub fn visit_type_group_mut<V>(v: &mut V, node: &mut TypeGroup)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.group_token.span);
+    skip!(node.group_token);
     v.visit_type_mut(&mut *node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3401,13 +3206,10 @@ pub fn visit_type_impl_trait_mut<V>(v: &mut V, node: &mut TypeImplTrait)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.impl_token.span);
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.impl_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_type_param_bound_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3415,7 +3217,7 @@ pub fn visit_type_infer_mut<V>(v: &mut V, node: &mut TypeInfer)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.underscore_token.spans);
+    skip!(node.underscore_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_type_macro_mut<V>(v: &mut V, node: &mut TypeMacro)
@@ -3429,7 +3231,7 @@ pub fn visit_type_never_mut<V>(v: &mut V, node: &mut TypeNever)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.bang_token.spans);
+    skip!(node.bang_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_type_param_mut<V>(v: &mut V, node: &mut TypeParam)
@@ -3440,19 +3242,12 @@ where
         v.visit_attribute_mut(it);
     }
     v.visit_ident_mut(&mut node.ident);
-    if let Some(it) = &mut node.colon_token {
-        tokens_helper(v, &mut it.spans);
-    }
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.colon_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_type_param_bound_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
-    if let Some(it) = &mut node.eq_token {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.eq_token);
     if let Some(it) = &mut node.default {
         v.visit_type_mut(it);
     }
@@ -3479,7 +3274,7 @@ pub fn visit_type_paren_mut<V>(v: &mut V, node: &mut TypeParen)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.paren_token.span);
+    skip!(node.paren_token);
     v.visit_type_mut(&mut *node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3497,13 +3292,9 @@ pub fn visit_type_ptr_mut<V>(v: &mut V, node: &mut TypePtr)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.star_token.spans);
-    if let Some(it) = &mut node.const_token {
-        tokens_helper(v, &mut it.span);
-    }
-    if let Some(it) = &mut node.mutability {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.star_token);
+    skip!(node.const_token);
+    skip!(node.mutability);
     v.visit_type_mut(&mut *node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3511,13 +3302,11 @@ pub fn visit_type_reference_mut<V>(v: &mut V, node: &mut TypeReference)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.and_token.spans);
+    skip!(node.and_token);
     if let Some(it) = &mut node.lifetime {
         v.visit_lifetime_mut(it);
     }
-    if let Some(it) = &mut node.mutability {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.mutability);
     v.visit_type_mut(&mut *node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3525,7 +3314,7 @@ pub fn visit_type_slice_mut<V>(v: &mut V, node: &mut TypeSlice)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.bracket_token.span);
+    skip!(node.bracket_token);
     v.visit_type_mut(&mut *node.elem);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3533,15 +3322,10 @@ pub fn visit_type_trait_object_mut<V>(v: &mut V, node: &mut TypeTraitObject)
 where
     V: VisitMut + ?Sized,
 {
-    if let Some(it) = &mut node.dyn_token {
-        tokens_helper(v, &mut it.span);
-    }
-    for el in Punctuated::pairs_mut(&mut node.bounds) {
-        let (it, p) = el.into_tuple();
+    skip!(node.dyn_token);
+    for mut el in Punctuated::pairs_mut(&mut node.bounds) {
+        let it = el.value_mut();
         v.visit_type_param_bound_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3549,13 +3333,10 @@ pub fn visit_type_tuple_mut<V>(v: &mut V, node: &mut TypeTuple)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.paren_token.span);
-    for el in Punctuated::pairs_mut(&mut node.elems) {
-        let (it, p) = el.into_tuple();
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.elems) {
+        let it = el.value_mut();
         v.visit_type_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3565,13 +3346,13 @@ where
 {
     match node {
         UnOp::Deref(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         UnOp::Not(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
         UnOp::Neg(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.spans);
+            skip!(_binding_0);
         }
     }
 }
@@ -3580,20 +3361,17 @@ pub fn visit_use_glob_mut<V>(v: &mut V, node: &mut UseGlob)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.star_token.spans);
+    skip!(node.star_token);
 }
 #[cfg(feature = "full")]
 pub fn visit_use_group_mut<V>(v: &mut V, node: &mut UseGroup)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.brace_token.span);
-    for el in Punctuated::pairs_mut(&mut node.items) {
-        let (it, p) = el.into_tuple();
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.items) {
+        let it = el.value_mut();
         v.visit_use_tree_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(feature = "full")]
@@ -3609,7 +3387,7 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_ident_mut(&mut node.ident);
-    tokens_helper(v, &mut node.colon2_token.spans);
+    skip!(node.colon2_token);
     v.visit_use_tree_mut(&mut *node.tree);
 }
 #[cfg(feature = "full")]
@@ -3618,7 +3396,7 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_ident_mut(&mut node.ident);
-    tokens_helper(v, &mut node.as_token.span);
+    skip!(node.as_token);
     v.visit_ident_mut(&mut node.rename);
 }
 #[cfg(feature = "full")]
@@ -3654,12 +3432,10 @@ where
     }
     if let Some(it) = &mut node.pat {
         v.visit_pat_mut(&mut *(it).0);
-        tokens_helper(v, &mut (it).1.spans);
+        skip!((it).1);
     }
-    tokens_helper(v, &mut node.dots.spans);
-    if let Some(it) = &mut node.comma {
-        tokens_helper(v, &mut it.spans);
-    }
+    skip!(node.dots);
+    skip!(node.comma);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_variant_mut<V>(v: &mut V, node: &mut Variant)
@@ -3672,7 +3448,7 @@ where
     v.visit_ident_mut(&mut node.ident);
     v.visit_fields_mut(&mut node.fields);
     if let Some(it) = &mut node.discriminant {
-        tokens_helper(v, &mut (it).0.spans);
+        skip!((it).0);
         v.visit_expr_mut(&mut (it).1);
     }
 }
@@ -3681,11 +3457,9 @@ pub fn visit_vis_restricted_mut<V>(v: &mut V, node: &mut VisRestricted)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.pub_token.span);
-    tokens_helper(v, &mut node.paren_token.span);
-    if let Some(it) = &mut node.in_token {
-        tokens_helper(v, &mut it.span);
-    }
+    skip!(node.pub_token);
+    skip!(node.paren_token);
+    skip!(node.in_token);
     v.visit_path_mut(&mut *node.path);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -3695,7 +3469,7 @@ where
 {
     match node {
         Visibility::Public(_binding_0) => {
-            tokens_helper(v, &mut _binding_0.span);
+            skip!(_binding_0);
         }
         Visibility::Restricted(_binding_0) => {
             v.visit_vis_restricted_mut(_binding_0);
@@ -3708,13 +3482,10 @@ pub fn visit_where_clause_mut<V>(v: &mut V, node: &mut WhereClause)
 where
     V: VisitMut + ?Sized,
 {
-    tokens_helper(v, &mut node.where_token.span);
-    for el in Punctuated::pairs_mut(&mut node.predicates) {
-        let (it, p) = el.into_tuple();
+    skip!(node.where_token);
+    for mut el in Punctuated::pairs_mut(&mut node.predicates) {
+        let it = el.value_mut();
         v.visit_where_predicate_mut(it);
-        if let Some(p) = p {
-            tokens_helper(v, &mut p.spans);
-        }
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen_helper.rs
+++ b/src/gen_helper.rs
@@ -1,8 +1,6 @@
 #[cfg(feature = "fold")]
 pub(crate) mod fold {
-    use crate::fold::Fold;
     use crate::punctuated::{Pair, Punctuated};
-    use proc_macro2::Span;
 
     pub(crate) trait FoldHelper {
         type Item;
@@ -31,127 +29,6 @@ pub(crate) mod fold {
                 .map(Pair::into_tuple)
                 .map(|(t, u)| Pair::new(f(t), u))
                 .collect()
-        }
-    }
-
-    pub(crate) fn tokens_helper<F: Fold + ?Sized, S: Spans>(folder: &mut F, spans: &S) -> S {
-        spans.fold(folder)
-    }
-
-    pub(crate) trait Spans {
-        fn fold<F: Fold + ?Sized>(&self, folder: &mut F) -> Self;
-    }
-
-    impl Spans for Span {
-        fn fold<F: Fold + ?Sized>(&self, folder: &mut F) -> Self {
-            folder.fold_span(*self)
-        }
-    }
-
-    impl Spans for [Span; 1] {
-        fn fold<F: Fold + ?Sized>(&self, folder: &mut F) -> Self {
-            [folder.fold_span(self[0])]
-        }
-    }
-
-    impl Spans for [Span; 2] {
-        fn fold<F: Fold + ?Sized>(&self, folder: &mut F) -> Self {
-            [folder.fold_span(self[0]), folder.fold_span(self[1])]
-        }
-    }
-
-    impl Spans for [Span; 3] {
-        fn fold<F: Fold + ?Sized>(&self, folder: &mut F) -> Self {
-            [
-                folder.fold_span(self[0]),
-                folder.fold_span(self[1]),
-                folder.fold_span(self[2]),
-            ]
-        }
-    }
-}
-
-#[cfg(feature = "visit")]
-pub(crate) mod visit {
-    use crate::visit::Visit;
-    use proc_macro2::Span;
-
-    pub(crate) fn tokens_helper<'ast, V: Visit<'ast> + ?Sized, S: Spans>(
-        visitor: &mut V,
-        spans: &S,
-    ) {
-        spans.visit(visitor);
-    }
-
-    pub(crate) trait Spans {
-        fn visit<'ast, V: Visit<'ast> + ?Sized>(&self, visitor: &mut V);
-    }
-
-    impl Spans for Span {
-        fn visit<'ast, V: Visit<'ast> + ?Sized>(&self, visitor: &mut V) {
-            visitor.visit_span(self);
-        }
-    }
-
-    impl Spans for [Span; 1] {
-        fn visit<'ast, V: Visit<'ast> + ?Sized>(&self, visitor: &mut V) {
-            visitor.visit_span(&self[0]);
-        }
-    }
-
-    impl Spans for [Span; 2] {
-        fn visit<'ast, V: Visit<'ast> + ?Sized>(&self, visitor: &mut V) {
-            visitor.visit_span(&self[0]);
-            visitor.visit_span(&self[1]);
-        }
-    }
-
-    impl Spans for [Span; 3] {
-        fn visit<'ast, V: Visit<'ast> + ?Sized>(&self, visitor: &mut V) {
-            visitor.visit_span(&self[0]);
-            visitor.visit_span(&self[1]);
-            visitor.visit_span(&self[2]);
-        }
-    }
-}
-
-#[cfg(feature = "visit-mut")]
-pub(crate) mod visit_mut {
-    use crate::visit_mut::VisitMut;
-    use proc_macro2::Span;
-
-    pub(crate) fn tokens_helper<V: VisitMut + ?Sized, S: Spans>(visitor: &mut V, spans: &mut S) {
-        spans.visit_mut(visitor);
-    }
-
-    pub(crate) trait Spans {
-        fn visit_mut<V: VisitMut + ?Sized>(&mut self, visitor: &mut V);
-    }
-
-    impl Spans for Span {
-        fn visit_mut<V: VisitMut + ?Sized>(&mut self, visitor: &mut V) {
-            visitor.visit_span_mut(self);
-        }
-    }
-
-    impl Spans for [Span; 1] {
-        fn visit_mut<V: VisitMut + ?Sized>(&mut self, visitor: &mut V) {
-            visitor.visit_span_mut(&mut self[0]);
-        }
-    }
-
-    impl Spans for [Span; 2] {
-        fn visit_mut<V: VisitMut + ?Sized>(&mut self, visitor: &mut V) {
-            visitor.visit_span_mut(&mut self[0]);
-            visitor.visit_span_mut(&mut self[1]);
-        }
-    }
-
-    impl Spans for [Span; 3] {
-        fn visit_mut<V: VisitMut + ?Sized>(&mut self, visitor: &mut V) {
-            visitor.visit_span_mut(&mut self[0]);
-            visitor.visit_span_mut(&mut self[1]);
-            visitor.visit_span_mut(&mut self[2]);
         }
     }
 }


### PR DESCRIPTION
From the lack of engagement in #462, I am skeptical that anyone really needs any of `fold_span`, `visit_span`, or `visit_span_mut`.

Closes #462.