### PR TITLE
Optimize Parse for Group

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -222,6 +222,16 @@ impl<'a> Cursor<'a> {
         None
     }
 
+    pub(crate) fn any_group_token(self) -> Option<(Group, Cursor<'a>)> {
+        if let Entry::Group(group, end_offset) = self.entry() {
+            let end_of_group = unsafe { self.ptr.add(*end_offset) };
+            let after_group = unsafe { Cursor::create(end_of_group, self.scope) };
+            return Some((group.clone(), after_group));
+        }
+
+        None
+    }
+
     /// If the cursor is pointing at a `Ident`, returns it along with a cursor
     /// pointing at the next `TokenTree`.
     pub fn ident(mut self) -> Option<(Ident, Cursor<'a>)> {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1150,10 +1150,8 @@ impl Parse for TokenTree {
 impl Parse for Group {
     fn parse(input: ParseStream) -> Result<Self> {
         input.step(|cursor| {
-            if let Some((inside, delimiter, span, rest)) = cursor.any_group() {
-                if delimiter != Delimiter::None {
-                    let mut group = Group::new(delimiter, inside.token_stream());
-                    group.set_span(span);
+            if let Some((group, rest)) = cursor.any_group_token() {
+                if group.delimiter() != Delimiter::None {
                     return Ok((group, rest));
                 }
             }


### PR DESCRIPTION
The new implementation simply increments the reference count on the existing `Group` token's contents, instead of collecting a whole new `TokenStream`. It also preserves the ability to access a meaningful `span_open()` and `span_close()`, which is lost by `Group::new` / `set_span`.