### PR TITLE
Fix parsing of `x.0. await`

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1439,6 +1439,13 @@ pub(crate) mod parsing {
             {
                 let mut dot_token: Token![.] = input.parse()?;
 
+                let float_token: Option<LitFloat> = input.parse()?;
+                if let Some(float_token) = float_token {
+                    if multi_index(&mut e, &mut dot_token, float_token)? {
+                        continue;
+                    }
+                }
+
                 let await_token: Option<Token![await]> = input.parse()?;
                 if let Some(await_token) = await_token {
                     e = Expr::Await(ExprAwait {
@@ -1448,13 +1455,6 @@ pub(crate) mod parsing {
                         await_token,
                     });
                     continue;
-                }
-
-                let float_token: Option<LitFloat> = input.parse()?;
-                if let Some(float_token) = float_token {
-                    if multi_index(&mut e, &mut dot_token, float_token)? {
-                        continue;
-                    }
                 }
 
                 let member: Member = input.parse()?;

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -14,9 +14,6 @@ const REVISION: &str = "22f247c6f3ed388cb702d01c2ff27da658a8b353";
 
 #[rustfmt::skip]
 static EXCLUDE_FILES: &[&str] = &[
-    // TODO: `x.0. await`
-    "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/0137_await_expr.rs",
-
     // TODO: `const move || {}`
     "tests/ui/rfc-2632-const-trait-impl/const-closure-parse-not-item.rs",
 


### PR DESCRIPTION
Previously this would fail after trying to parse `await` as a `Member`.

```console
error: expected identifier or integer
 --> dev/main.rs:5:22
  |
5 |         let _ = x.0. await;
  |                      ^^^^^
```