### PR TITLE
Do not provide a parse_quote macro when printing feature is off

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ pub mod parse;
 pub mod parse_macro_input;
 
 // Not public API except the `parse_quote!` macro.
-#[cfg(feature = "parsing")]
+#[cfg(all(feature = "parsing", feature = "printing"))]
 #[doc(hidden)]
 pub mod parse_quote;
 

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -24,9 +24,8 @@
 /// }
 /// ```
 ///
-/// *This macro is available only if Syn is built with the `"parsing"` feature,
-/// although interpolation of syntax tree nodes into the quoted tokens is only
-/// supported if Syn is built with the `"printing"` feature as well.*
+/// *This macro is available only if Syn is built with both the `"parsing"` and
+/// `"printing"` features.*
 ///
 /// # Example
 ///


### PR DESCRIPTION
This reverts https://github.com/dtolnay/syn/commit/491680abaa83ee01739262e387bb0e9a7e71b530. #512 made `parse_quote!` call `quote!` via a re-export located in the syn crate instead of directly unhygienically, and the re-export only exists if syn's "printing" feature is on.