### PR TITLE
Optimize syntax tree size of Punctuated

### DIFF
--- a/tests/test_size.rs
+++ b/tests/test_size.rs
@@ -8,25 +8,25 @@ use syn::{Expr, Item, Lit, Pat, Type};
 #[rustversion::attr(before(2022-11-24), ignore)]
 #[test]
 fn test_expr_size() {
-    assert_eq!(mem::size_of::<Expr>(), 176);
+    assert_eq!(mem::size_of::<Expr>(), 144);
 }
 
 #[rustversion::attr(before(2022-09-09), ignore)]
 #[test]
 fn test_item_size() {
-    assert_eq!(mem::size_of::<Item>(), 360);
+    assert_eq!(mem::size_of::<Item>(), 288);
 }
 
 #[rustversion::attr(before(2022-11-24), ignore)]
 #[test]
 fn test_type_size() {
-    assert_eq!(mem::size_of::<Type>(), 240);
+    assert_eq!(mem::size_of::<Type>(), 192);
 }
 
 #[rustversion::attr(before(2021-10-11), ignore)]
 #[test]
 fn test_pat_size() {
-    assert_eq!(mem::size_of::<Pat>(), 192);
+    assert_eq!(mem::size_of::<Pat>(), 136);
 }
 
 #[rustversion::attr(before(2022-09-09), ignore)]


### PR DESCRIPTION
This is a substantial improvement in the size of all the syntax tree types (`Expr`, `Item`, `Type`, `Pat`) by 20-30%.

It ends up only being a 2-3% performance improvement on benchmarks.