### PR TITLE
Optimize syntax tree size of Punctuated (without allocation for empty Punctuated)

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -673,6 +673,16 @@ ast_struct! {
 }
 
 impl Expr {
+    #[cfg(feature = "parsing")]
+    const DUMMY: Self = Expr::Path(ExprPath {
+        attrs: Vec::new(),
+        qself: None,
+        path: Path {
+            leading_colon: None,
+            segments: Punctuated::new(),
+        },
+    });
+
     #[cfg(all(feature = "parsing", feature = "full"))]
     pub(crate) fn replace_attrs(&mut self, new: Vec<Attribute>) -> Vec<Attribute> {
         match self {
@@ -2700,26 +2710,15 @@ pub(crate) mod parsing {
         if trailing_dot {
             float_repr.truncate(float_repr.len() - 1);
         }
-        let mut dummy = Expr::Path(ExprPath {
-            attrs: Vec::new(),
-            qself: None,
-            path: Path {
-                leading_colon: None,
-                segments: Punctuated::new(),
-            },
-        });
         for part in float_repr.split('.') {
             let index = crate::parse_str(part).map_err(|err| Error::new(float.span(), err))?;
-            let base = mem::replace(e, dummy);
-            dummy = mem::replace(
-                e,
-                Expr::Field(ExprField {
-                    attrs: Vec::new(),
-                    base: Box::new(base),
-                    dot_token: Token![.](dot_token.span),
-                    member: Member::Unnamed(index),
-                }),
-            );
+            let base = mem::replace(e, Expr::DUMMY);
+            *e = Expr::Field(ExprField {
+                attrs: Vec::new(),
+                base: Box::new(base),
+                dot_token: Token![.](dot_token.span),
+                member: Member::Unnamed(index),
+            });
             *dot_token = Token![.](float.span());
         }
         Ok(!trailing_dot)

--- a/tests/test_size.rs
+++ b/tests/test_size.rs
@@ -8,25 +8,25 @@ use syn::{Expr, Item, Lit, Pat, Type};
 #[rustversion::attr(before(2022-11-24), ignore)]
 #[test]
 fn test_expr_size() {
-    assert_eq!(mem::size_of::<Expr>(), 176);
+    assert_eq!(mem::size_of::<Expr>(), 144);
 }
 
 #[rustversion::attr(before(2022-09-09), ignore)]
 #[test]
 fn test_item_size() {
-    assert_eq!(mem::size_of::<Item>(), 360);
+    assert_eq!(mem::size_of::<Item>(), 288);
 }
 
 #[rustversion::attr(before(2022-11-24), ignore)]
 #[test]
 fn test_type_size() {
-    assert_eq!(mem::size_of::<Type>(), 240);
+    assert_eq!(mem::size_of::<Type>(), 192);
 }
 
 #[rustversion::attr(before(2021-10-11), ignore)]
 #[test]
 fn test_pat_size() {
-    assert_eq!(mem::size_of::<Pat>(), 192);
+    assert_eq!(mem::size_of::<Pat>(), 136);
 }
 
 #[rustversion::attr(before(2022-09-09), ignore)]

--- a/tests/test_size.rs
+++ b/tests/test_size.rs
@@ -14,7 +14,7 @@ fn test_expr_size() {
 #[rustversion::attr(before(2022-09-09), ignore)]
 #[test]
 fn test_item_size() {
-    assert_eq!(mem::size_of::<Item>(), 288);
+    assert_eq!(mem::size_of::<Item>(), 304);
 }
 
 #[rustversion::attr(before(2022-11-24), ignore)]


### PR DESCRIPTION
Alternative attempt at #1406. Sadly this one has the same 20-30% improvement on syntax tree size and only 2-3% improvement on performance.