### PR TITLE
Allow parsing `MetaNameValue` if the path part contains a keyword

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -650,7 +650,7 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for Meta {
         fn parse(input: ParseStream) -> Result<Self> {
-            let path = input.call(Path::parse_mod_style)?;
+            let path = input.call(meta::parse_meta_path)?;
             parse_meta_after_path(path, input)
         }
     }
@@ -658,7 +658,7 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for MetaList {
         fn parse(input: ParseStream) -> Result<Self> {
-            let path = input.call(Path::parse_mod_style)?;
+            let path = input.call(meta::parse_meta_path)?;
             parse_meta_list_after_path(path, input)
         }
     }
@@ -666,7 +666,7 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for MetaNameValue {
         fn parse(input: ParseStream) -> Result<Self> {
-            let path = input.call(Path::parse_mod_style)?;
+            let path = input.call(meta::parse_meta_path)?;
             parse_meta_name_value_after_path(path, input)
         }
     }

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -393,7 +393,7 @@ pub(crate) fn parse_nested_meta(
 }
 
 // Like Path::parse_mod_style, but accepts keywords in the path.
-fn parse_meta_path(input: ParseStream) -> Result<Path> {
+pub(crate) fn parse_meta_path(input: ParseStream) -> Result<Path> {
     Ok(Path {
         leading_colon: input.parse()?,
         segments: {

--- a/src/path.rs
+++ b/src/path.rs
@@ -531,7 +531,7 @@ pub(crate) mod parsing {
                 segments: {
                     let mut segments = Punctuated::new();
                     loop {
-                        if !input.peek(Ident)
+                        if !input.peek(Ident::peek_any)
                             && !input.peek(Token![super])
                             && !input.peek(Token![self])
                             && !input.peek(Token![Self])


### PR DESCRIPTION
This allows this to be parsed:

```rust
let attr: syn::MetaNameValue = syn::parse_quote!{
    as = "FooBar"
};
```

This aligns the code with `parse_meta_path` which already uses
`input.peek(Ident::peek_any)`.
https://github.com/dtolnay/syn/blob/25def51081b68538547f34a3494744a807be4203/src/meta.rs#L401

This allows parsing the `#[serde_as(as = "FooBar")]` attributes which
are used as part of the `serde_with` crate.

Thanks to @matthias-stemmler for finding the cause.
https://github.com/dtolnay/syn/issues/1408#issuecomment-1476691276