### PR TITLE
Improve error message when parsing Ident encounters keyword

### DIFF
--- a/src/ident.rs
+++ b/src/ident.rs
@@ -76,10 +76,16 @@ mod parsing {
             input.step(|cursor| {
                 if let Some((ident, rest)) = cursor.ident() {
                     if accept_as_ident(&ident) {
-                        return Ok((ident, rest));
+                        Ok((ident, rest))
+                    } else {
+                        Err(cursor.error(format_args!(
+                            "expected identifier, found keyword `{}`",
+                            ident,
+                        )))
                     }
+                } else {
+                    Err(cursor.error("expected identifier"))
                 }
-                Err(cursor.error("expected identifier"))
             })
         }
     }


### PR DESCRIPTION
Before:

```console
error: expected identifier
 --> dev/main.rs:4:8
  |
4 |     fn async() {}
  |        ^^^^^
```

After:

```console
error: expected identifier, found keyword `async`
 --> dev/main.rs:4:8
  |
4 |     fn async() {}
  |        ^^^^^
```

This lines up with how Rust's error reporting in macro_rules handles the same situation.

```rust
macro_rules! path {
    ($p:path) => {};
}

path!(async);
```

```console
error: expected identifier, found keyword `async`
 --> src/lib.rs:5:7
  |
5 | path!(async);
  |       ^^^^^ expected identifier, found keyword
```