### PR TITLE
Improve error reporting in path parser

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -548,9 +548,9 @@ pub(crate) mod parsing {
                         segments.push_punct(punct);
                     }
                     if segments.is_empty() {
-                        return Err(input.error("expected path"));
+                        return Err(input.parse::<Ident>().unwrap_err());
                     } else if segments.trailing_punct() {
-                        return Err(input.error("expected path segment"));
+                        return Err(input.error("expected path segment after `::`"));
                     }
                     segments
                 },


### PR DESCRIPTION
Before:

```console
error: expected path
 --> dev/main.rs:4:8
  |
4 |     #![async]
  |        ^^^^^

error: unexpected end of input, expected path segment
 --> dev/main.rs:5:13
  |
5 |     #![foo::]
  |             ^
```

After:

```console
error: expected identifier, found keyword `async`
 --> dev/main.rs:4:8
  |
4 |     #![async]
  |        ^^^^^

error: unexpected end of input, expected path segment after `::`
 --> dev/main.rs:5:13
  |
5 |     #![foo::]
  |             ^
```