### PR TITLE
Improve error message on missing `;` between statements

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -153,7 +153,7 @@ pub(crate) mod parsing {
                 if input.is_empty() {
                     break;
                 } else if requires_semicolon {
-                    return Err(input.error("unexpected token"));
+                    return Err(input.error("unexpected token, expected `;`"));
                 }
             }
             Ok(stmts)


### PR DESCRIPTION
Before:

```console
error: unexpected token
 --> dev/main.rs:5:13
  |
5 |         f() g()
  |             ^
```

After:

```console
error: unexpected token, expected `;`
 --> dev/main.rs:5:13
  |
5 |         f() g()
  |             ^
```