### PR TITLE
Keep non-brace macro invocations in trailing expr position as Expr::Macro

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -371,14 +371,17 @@ pub(crate) mod parsing {
 
         let semi_token: Option<Token![;]> = input.parse()?;
 
-        if allow_nosemi.0 || semi_token.is_some() {
-            if let Expr::Macro(ExprMacro { attrs, mac }) = e {
+        match e {
+            Expr::Macro(ExprMacro { attrs, mac })
+                if semi_token.is_some() || mac.delimiter.is_brace() =>
+            {
                 return Ok(Stmt::Macro(StmtMacro {
                     attrs,
                     mac,
                     semi_token,
                 }));
             }
+            _ => {}
         }
 
         if semi_token.is_some() {

--- a/tests/test_stmt.rs
+++ b/tests/test_stmt.rs
@@ -213,19 +213,22 @@ fn test_macros() {
                     },
                     semi_token: Some,
                 },
-                Stmt::Macro {
-                    mac: Macro {
-                        path: Path {
-                            segments: [
-                                PathSegment {
-                                    ident: "vec",
-                                },
-                            ],
+                Stmt::Expr(
+                    Expr::Macro {
+                        mac: Macro {
+                            path: Path {
+                                segments: [
+                                    PathSegment {
+                                        ident: "vec",
+                                    },
+                                ],
+                            },
+                            delimiter: MacroDelimiter::Bracket,
+                            tokens: TokenStream(``),
                         },
-                        delimiter: MacroDelimiter::Bracket,
-                        tokens: TokenStream(``),
                     },
-                },
+                    None,
+                ),
             ],
         },
     })


### PR DESCRIPTION
Rust does not allow a stmt macro to be called with this syntax.

```rust
macro_rules! m {
    () => {
        struct S;
    }
}

fn main() {
    m!()
}
```

But if the call is written as `m!();` or `m! {}`, we'll continue to parse it as Stmt::Macro.