### PR TITLE
Improve error message on empty parens inside parse_nested_meta

### DIFF
--- a/src/meta.rs
+++ b/src/meta.rs
@@ -401,6 +401,8 @@ fn parse_meta_path(input: ParseStream) -> Result<Path> {
             if input.peek(Ident::peek_any) {
                 let ident = Ident::parse_any(input)?;
                 segments.push_value(PathSegment::from(ident));
+            } else if input.is_empty() {
+                return Err(input.error("expected nested attribute"));
             } else if input.peek(Lit) {
                 return Err(input.error("unexpected literal in nested attribute, expected ident"));
             } else {


### PR DESCRIPTION
Before:

```console
error: unexpected end of input, unexpected token in nested attribute, expected ident
 --> test_suite/tests/regression/issue2415.rs:4:9
  |
4 | #[serde()]
  |         ^
```

After:

```console
error: unexpected end of input, expected nested attribute
 --> test_suite/tests/regression/issue2415.rs:4:9
  |
4 | #[serde()]
  |         ^
```