### PR TITLE
Force indexmap std support

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/syn"
 
 [dependencies]
-indexmap = { version = "1", features = ["serde-1"] }
+indexmap = { version = "1", features = ["serde-1", "std"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1.0.88", features = ["derive"] }
 


### PR DESCRIPTION
`indexmap` 1.9.3 (latest release) and older auto-detect the use of std by testing whether the current toolchain is able to compile a probe file containing `extern crate std;`. If it fails, `IndexMap` does not default the third generic parameter, causing builds of syn-codegen to fail.

In indexmap master, this is fixed by defaulting the `std` feature.