### PR TITLE
Permit empty attr in syn::meta::parser

### DIFF
--- a/src/meta.rs
+++ b/src/meta.rs
@@ -129,7 +129,13 @@ use std::fmt::Display;
 /// }
 /// ```
 pub fn parser(logic: impl FnMut(ParseNestedMeta) -> Result<()>) -> impl Parser<Output = ()> {
-    |input: ParseStream| parse_nested_meta(input, logic)
+    |input: ParseStream| {
+        if input.is_empty() {
+            Ok(())
+        } else {
+            parse_nested_meta(input, logic)
+        }
+    }
 }
 
 /// Context for parsing a single property in the conventional syntax for


### PR DESCRIPTION
Closes #1460.