### PR TITLE
Fix call of proc_macro::Span::clone on the wrong thread

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -385,7 +385,7 @@ impl Clone for Error {
 impl Clone for ErrorMessage {
     fn clone(&self) -> Self {
         ErrorMessage {
-            span: self.span.clone(),
+            span: self.span,
             message: self.message.clone(),
         }
     }


### PR DESCRIPTION
The way #1315 was implemented is unsound if someone has a standard library implementation on which `proc_macro::Span`'s `Clone` impl is not just equivalent to its `Copy` impl, but involves accessing the span's thread-local data.

Reported by @joshlf.