### PR TITLE
Update docs.rs links to latest `syn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ contains some APIs that may be useful more generally.
   procedural macros enable only what they need, and do not pay in compile time
   for all the rest.
 
-[`syn::File`]: https://docs.rs/syn/1.0/syn/struct.File.html
-[`syn::Item`]: https://docs.rs/syn/1.0/syn/enum.Item.html
-[`syn::Expr`]: https://docs.rs/syn/1.0/syn/enum.Expr.html
-[`syn::Type`]: https://docs.rs/syn/1.0/syn/enum.Type.html
-[`syn::DeriveInput`]: https://docs.rs/syn/1.0/syn/struct.DeriveInput.html
-[parser functions]: https://docs.rs/syn/1.0/syn/parse/index.html
+[`syn::File`]: https://docs.rs/syn/latest/syn/struct.File.html
+[`syn::Item`]: https://docs.rs/syn/latest/syn/enum.Item.html
+[`syn::Expr`]: https://docs.rs/syn/latest/syn/enum.Expr.html
+[`syn::Type`]: https://docs.rs/syn/latest/syn/enum.Type.html
+[`syn::DeriveInput`]: https://docs.rs/syn/latest/syn/struct.DeriveInput.html
+[parser functions]: https://docs.rs/syn/latest/syn/parse/index.html
 
 *Version requirement: Syn supports rustc 1.56 and up.*
 

--- a/examples/trace-var/README.md
+++ b/examples/trace-var/README.md
@@ -42,7 +42,7 @@ n = 1
 The procedural macro uses a syntax tree [`Fold`] to rewrite every `let`
 statement and assignment expression in the following way:
 
-[`Fold`]: https://docs.rs/syn/1.0/syn/fold/trait.Fold.html
+[`Fold`]: https://docs.rs/syn/latest/syn/fold/trait.Fold.html
 
 ```rust
 // Before

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -13,9 +13,9 @@
 //!   of the [`visit`], [`visit_mut`], and [`fold`] modules can be generated
 //!   programmatically from a description of the syntax tree.
 //!
-//!   [`visit`]: https://docs.rs/syn/1.0/syn/visit/index.html
-//!   [`visit_mut`]: https://docs.rs/syn/1.0/syn/visit_mut/index.html
-//!   [`fold`]: https://docs.rs/syn/1.0/syn/fold/index.html
+//!   [`visit`]: https://docs.rs/syn/latest/syn/visit/index.html
+//!   [`visit_mut`]: https://docs.rs/syn/latest/syn/visit_mut/index.html
+//!   [`fold`]: https://docs.rs/syn/latest/syn/fold/index.html
 //!
 //! To make this type of code as easy as possible to implement in any language,
 //! every Syn release comes with a machine-readable description of that version


### PR DESCRIPTION
Hey @dtolnay, thanks for the contribution to the Rust community! :)
- Update legacy 1.0 docs.rs links and point it to latest `syn`