### PR TITLE
Reserve capacity before extending Punctuated

### DIFF
--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -506,7 +506,7 @@ where
     // Safety: Reserved capacity for at least one additional pair above.
     unsafe {
         let end = punctuated.inner.as_mut_ptr().add(len);
-        core::ptr::write(end, pair);
+        std::ptr::write(end, pair);
         punctuated.inner.set_len(len + 1);
     }
 }
@@ -529,7 +529,7 @@ unsafe fn extending_push_and_replace_last<T, P, I>(
     let last = punctuated.last.as_mut().unwrap();
 
     // Recycle the allocated Box by replacing its content instead of allocating a new one.
-    let last = core::mem::replace(last.as_mut(), item);
+    let last = std::mem::replace(last.as_mut(), item);
 
     extending_push(punctuated, (last, P::default()), i);
 }

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -222,10 +222,14 @@ impl<T, P> Punctuated<T, P> {
     where
         P: Default,
     {
-        if self.last.is_some() {
-            self.push_punct(Default::default());
+        if let Some(last) = self.last.as_mut() {
+            // Recycle the allocated Box by replacing its content instead of allocating a new one.
+            let last = std::mem::replace(last.as_mut(), value);
+
+            self.inner.push((last, P::default()));
+        } else {
+            self.last = Some(Box::new(value));
         }
-        self.push_value(value);
     }
 
     /// Inserts an element at position `index`.

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -447,19 +447,13 @@ where
 
         if let Some(first_value) = i.next() {
             if self.last.is_some() {
-                // Safety: `last` being `Some` is the if-condition.
-                unsafe {
-                    extending_push_and_replace_last(self, first_value, &i);
-                }
+                extending_push_and_replace_last(self, first_value, &i);
             } else {
                 self.last = Some(Box::new(first_value));
             }
 
             while let Some(value) = i.next() {
-                // Safety: The else-block above sets `last` to the first value if it is `None`.
-                unsafe {
-                    extending_push_and_replace_last(self, value, &i);
-                }
+                extending_push_and_replace_last(self, value, &i);
             }
         }
     }
@@ -491,7 +485,9 @@ where
     }
 }
 
-/// Push a pair bypassing last while reserving capacity for it and the next items in the iterators.
+/// Push a pair while reserving capacity for it and the next items in the iterators.
+///
+/// Assumes that `last` is `None`.
 fn extending_push<T, P, I>(punctuated: &mut Punctuated<T, P>, pair: (T, P), i: &I)
 where
     I: Iterator,
@@ -514,14 +510,11 @@ where
 // Push `last` and replace it with `item` while reserving enough capacity
 // for the pushed `last` and the next items in the iterator.
 //
-// # Safety:
+// # Panics
 // This function assumes that `last` is `Some`.
-// Calling it with `last` being `None` is undefined behavior.
-unsafe fn extending_push_and_replace_last<T, P, I>(
-    punctuated: &mut Punctuated<T, P>,
-    item: T,
-    i: &I,
-) where
+// Calling it with `last` being `None` causes a panic.
+fn extending_push_and_replace_last<T, P, I>(punctuated: &mut Punctuated<T, P>, item: T, i: &I)
+where
     I: Iterator,
     P: Default,
 {

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -521,8 +521,8 @@ unsafe fn extending_push_and_replace_last<T, P, I>(
     I: Iterator,
     P: Default,
 {
-    // Safety: The caller is responsible for making sure that `last` is not `None`.
-    let last = unsafe { punctuated.last.as_mut().unwrap_unchecked() };
+    // Unwrap: The caller is responsible for making sure that `last` is not `None`.
+    let last = punctuated.last.as_mut().unwrap();
 
     // Recycle the allocated Box by replacing its content instead of allocating a new one.
     let last = core::mem::replace(last.as_mut(), item);

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -15,11 +15,7 @@ macro_rules! errorf {
 
 macro_rules! punctuated {
     ($($e:expr,)+) => {{
-        let mut seq = ::syn::punctuated::Punctuated::new();
-        $(
-            seq.push($e);
-        )+
-        seq
+        ::syn::punctuated::Punctuated::from_iter([$($e),+])
     }};
 
     ($($e:expr),+) => {

--- a/tests/test_iterators.rs
+++ b/tests/test_iterators.rs
@@ -68,3 +68,31 @@ fn may_dangle() {
         }
     }
 }
+
+#[test]
+fn extend() {
+    let mut p: Punctuated<i32, Token![,]> = punctuated!(1, 2, 3);
+
+    // No punctuation at the end after calling extend on an empty iterator of items T.
+    p.extend(None::<i32>);
+    assert_eq!(p, punctuated!(1, 2, 3));
+
+    // But punctuation at the end after calling extend on an empty iterator of pairs.
+    // This behavior is not consistent and should be changed in a future breaking release
+    // to behave like above.
+    p.extend(None::<Pair<_, _>>);
+    let mut expected = punctuated!(1, 2, 3);
+    expected.push_punct(Default::default());
+    assert_eq!(p, expected);
+
+    p.extend([4, 5, 6]);
+    assert_eq!(p, punctuated!(1, 2, 3, 4, 5, 6));
+
+    p.extend([Pair::Punctuated(7, Default::default())]);
+    let mut expected = punctuated!(1, 2, 3, 4, 5, 6, 7);
+    expected.push_punct(Default::default());
+    assert_eq!(p, expected);
+
+    p.extend([Pair::Punctuated(8, Default::default()), Pair::End(9)]);
+    assert_eq!(p, punctuated!(1, 2, 3, 4, 5, 6, 7, 8, 9));
+}


### PR DESCRIPTION
While extending `Punctuated` from an iterator, use `size_hint` to reserve capacity before pushing to avoid repeated allocations.

I did also avoid unneeded allocations of a new `Box`.

There are also small optimizations like removing the check of `nomore` in the while loop and only checking if we did receive an `End`.

I did mention in a TODO comment that the behavior of `extend` from an iterator of pairs is not consistent with the behavior of `extend` from an iterator of items. You can also see it in the added test. I would recommend not adding a punctuation if the iterator is empty, but since that could be a braking change, I did not do it.

This is my first contribution and I did not find a CONTRIBUTING file. Therefore, please tell me if something is odd :)

Sorry for the typo in the branch name :/