### PR TITLE
Stricter parsing of string_continue escape in cooked byte string literal

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -1273,8 +1273,7 @@ mod value {
                         b'"' => b'"',
                         b'\r' | b'\n' => loop {
                             let byte = byte(v, 0);
-                            let ch = char::from_u32(u32::from(byte)).unwrap();
-                            if ch.is_whitespace() {
+                            if matches!(byte, b' ' | b'\t' | b'\n' | b'\r') {
                                 v = &v[1..];
                             } else {
                                 continue 'outer;


### PR DESCRIPTION
This applies the changes from #1381, which only touched string literals, to byte string literals as well.

```rust
println!("{:?}", syn::parse_str::<syn::LitByteStr>("b\"\\\n\x0b\x0c\x0a.\"").unwrap().value());
```

Before: `[46]`
Correct value: `[11, 12, 10, 46]`