### PR TITLE
Preserve attributes on verbatim Item in statement position

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -180,7 +180,8 @@ pub(crate) mod parsing {
     }
 
     fn parse_stmt(input: ParseStream, allow_nosemi: AllowNoSemi) -> Result<Stmt> {
-        let mut attrs = input.call(Attribute::parse_outer)?;
+        let begin = input.fork();
+        let attrs = input.call(Attribute::parse_outer)?;
 
         // brace-style macros; paren and bracket macros get parsed as
         // expression statements.
@@ -238,9 +239,7 @@ pub(crate) mod parsing {
             || input.peek(Token![macro])
             || is_item_macro
         {
-            let mut item: Item = input.parse()?;
-            attrs.extend(item.replace_attrs(Vec::new()));
-            item.replace_attrs(attrs);
+            let item = item::parsing::parse_rest_of_item(begin, attrs, input)?;
             Ok(Stmt::Item(item))
         } else {
             stmt_expr(input, allow_nosemi, attrs)


### PR DESCRIPTION
Previously, attributes would go missing, for example in the following case:

```rust
fn main() {
    #[cfg(...)]
    macro m() {...}
}
```

where there is `Stmt::Item` containing `Item::Verbatim`.