### PR TITLE
Parse block expr as verbatim in non-full mode

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1691,6 +1691,16 @@ pub(crate) mod parsing {
         } else if input.is_empty() {
             Err(input.error("expected an expression"))
         } else {
+            if input.peek(token::Brace) {
+                let scan = input.fork();
+                let content;
+                braced!(content in scan);
+                if content.parse::<Expr>().is_ok() && content.is_empty() {
+                    let expr_block = verbatim::between(input, &scan);
+                    input.advance_to(&scan);
+                    return Ok(Expr::Verbatim(expr_block));
+                }
+            }
             Err(input.error("unsupported expression; enable syn's features=[\"full\"]"))
         }
     }


### PR DESCRIPTION
This commonly comes up in array sizes, when working with const generic parameters computed from a type parameter.

```rust
#![feature(generic_const_exprs)]

struct Foo<T: strum::EnumCount>
where
    [(); { T::COUNT }]:,
{
    foo: heapless::Vec<u8, { T::COUNT }>,
}
```

We can't parse them as Expr::Block because that data structure contains a field of type Vec\<Stmt\>, and Stmt is "full"-only.

But parsing as Expr::Verbatim will at least allow this where-clause to round trip.