### PR TITLE
Fix duplication of braces around const generic argument in non-full mode

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -697,6 +697,9 @@ pub(crate) mod printing {
                     #[cfg(feature = "full")]
                     Expr::Block(_) => expr.to_tokens(tokens),
 
+                    #[cfg(not(feature = "full"))]
+                    Expr::Verbatim(_) => expr.to_tokens(tokens),
+
                     // ERROR CORRECTION: Add braces to make sure that the
                     // generated code is valid.
                     _ => token::Brace::default().surround(tokens, |tokens| {


### PR DESCRIPTION
Fixes https://github.com/serde-rs/serde/issues/2414.

In non-"full" mode, syn parses `Generic<{ BAR as u8 }>` with a GenericArgument::Const containing Expr::Verbatim (because the data structures for Expr::Block are not available). But then, it wrongly printed that out as `Generic<{ { BAR as u8 } }>`, leading to bogus warnings in generated code.