### PR TITLE
Preserve existing allocations when cloning Punctuated

### DIFF
--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -369,6 +369,11 @@ where
             last: self.last.clone(),
         }
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        self.inner.clone_from(&other.inner);
+        self.last.clone_from(&other.last);
+    }
 }
 
 #[cfg(feature = "extra-traits")]


### PR DESCRIPTION
All of the types involved here (`Vec`, `Option`, `Box`) have optimized implementations of `clone_from`.