### PR TITLE
Remove unneeded cfg

### DIFF
--- a/src/ident.rs
+++ b/src/ident.rs
@@ -3,7 +3,6 @@ use crate::lookahead;
 
 pub use proc_macro2::Ident;
 
-#[cfg(not(doc))] // rustdoc bug: https://github.com/rust-lang/rust/issues/105735
 #[cfg(feature = "parsing")]
 #[doc(hidden)]
 #[allow(non_snake_case)]


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/issues/105735 was fixed, this `cfg` is not necessary anymore.