### PR TITLE
Fix useless re-exports section appearing in documentation at crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,7 @@ pub use crate::generics::{
 pub use crate::generics::{ImplGenerics, Turbofish, TypeGenerics};
 
 mod ident;
+#[doc(inline)]
 pub use crate::ident::Ident;
 
 #[cfg(feature = "full")]
@@ -388,9 +389,11 @@ pub use crate::item::{
 };
 
 mod lifetime;
+#[doc(inline)]
 pub use crate::lifetime::Lifetime;
 
 mod lit;
+#[doc(inline)]
 pub use crate::lit::{
     Lit, LitBool, LitByte, LitByteStr, LitChar, LitFloat, LitInt, LitStr, StrStyle,
 };


### PR DESCRIPTION
Consequence of https://github.com/rust-lang/rust/pull/112108.

![Screenshot from 2023-07-20 19-58-46](https://github.com/dtolnay/syn/assets/1940490/8cbf2c27-c835-4d7e-a7cf-2fd0961babc6)
