### PR TITLE
Fix trivial difference between full and non-full expression parse errors

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1663,7 +1663,7 @@ pub(crate) mod parsing {
             }
             Ok(expr)
         } else {
-            Err(input.error("expected expression"))
+            Err(input.error("expected an expression"))
         }
     }
 


### PR DESCRIPTION
This silly difference causes serde_derive's UI test suite to fail depending on whether syn's "full" feature is turned on.

https://github.com/dtolnay/syn/blob/f79ba1540239f29e82b3011295755270ef05f66e/src/expr.rs#L1666

https://github.com/dtolnay/syn/blob/f79ba1540239f29e82b3011295755270ef05f66e/src/expr.rs#L1692

```console
test tests/ui/malformed/cut_off.rs ... mismatch

EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: unexpected end of input, expected an expression
 --> tests/ui/malformed/cut_off.rs:4:17
  |
4 | #[serde(rename =)]
  |                 ^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: unexpected end of input, expected expression
 --> tests/ui/malformed/cut_off.rs:4:17
  |
4 | #[serde(rename =)]
  |                 ^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
note: If the actual output is the correct output you can bless it by rerunning
      your test with the environment variable TRYBUILD=overwrite
```