### PR TITLE
Switch to using primitives in macro-generated code through std::primitive

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -6,6 +6,7 @@ pub use std::fmt::{self, Debug, Formatter};
 pub use std::hash::{Hash, Hasher};
 pub use std::marker::Copy;
 pub use std::option::Option::{None, Some};
+pub use std::primitive::{bool, str};
 pub use std::result::Result::{Err, Ok};
 pub use std::stringify;
 
@@ -33,15 +34,5 @@ pub use proc_macro::TokenStream;
 
 #[cfg(feature = "printing")]
 pub use quote::{ToTokens, TokenStreamExt};
-
-#[allow(non_camel_case_types)]
-pub type bool = help::Bool;
-#[allow(non_camel_case_types)]
-pub type str = help::Str;
-
-mod help {
-    pub type Bool = bool;
-    pub type Str = str;
-}
 
 pub struct private(pub(crate) ());


### PR DESCRIPTION
`std::primitive` has been stable since Rust 1.43.