### PR TITLE
Add `require_ident` to `Path`

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -82,6 +82,26 @@ impl Path {
             None
         }
     }
+
+    /// Error if this does not contain only one segment.
+    ///
+    /// A path is considered an ident if:
+    ///
+    /// - the path has no leading colon,
+    /// - the number of path segments is 1, and
+    /// - the first path segment has no angle bracketed or parenthesized
+    ///   path arguments.
+    #[cfg(feature = "parsing")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
+    pub fn require_ident(&self) -> Result<&Ident> {
+        self.get_ident().ok_or_else(|| {
+            crate::error::new2(
+                self.segments.first().unwrap().ident.span(),
+                self.segments.last().unwrap().ident.span(),
+                "expected this path to be an identifier",
+            )
+        })
+    }
 }
 
 ast_struct! {


### PR DESCRIPTION
Parsing options inside a list is very commonplace:
```text
#[my_attr(path(linux = "path/to/file")]
          ^^^^ ^^^^^
          Here is our options
```

Although we have `get_ident`, we (at least I) would not like to handle `None`. Just like `require_path`, `require_list` and `require_key_value`, which I love.

```rust
match &*path.require_ident()?.to_string() {
    "linux" => { ... }
    "windows" => { ... }
    "macos" => { ... }
    other => return Err(Error::new(
        Span::call_site(),
        format!("platform `{other}` not supported")
    ))
}
```
