### PR TITLE
Add `cfg(not(doc))` to `doc(hidden)` functions

### DIFF
--- a/src/ident.rs
+++ b/src/ident.rs
@@ -4,6 +4,7 @@ use crate::lookahead;
 pub use proc_macro2::Ident;
 
 #[cfg(feature = "parsing")]
+#[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
 #[doc(hidden)]
 #[allow(non_snake_case)]
 pub fn Ident(marker: lookahead::TokenMarker) -> Ident {

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -113,6 +113,7 @@ impl Hash for Lifetime {
 }
 
 #[cfg(feature = "parsing")]
+#[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
 #[doc(hidden)]
 #[allow(non_snake_case)]
 pub fn Lifetime(marker: lookahead::TokenMarker) -> Lifetime {

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -758,6 +758,7 @@ macro_rules! lit_extra_traits {
         }
 
         #[cfg(feature = "parsing")]
+        #[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
         #[doc(hidden)]
         #[allow(non_snake_case)]
         pub fn $ty(marker: lookahead::TokenMarker) -> $ty {
@@ -774,6 +775,7 @@ lit_extra_traits!(LitInt);
 lit_extra_traits!(LitFloat);
 
 #[cfg(feature = "parsing")]
+#[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
 #[doc(hidden)]
 #[allow(non_snake_case)]
 pub fn LitBool(marker: lookahead::TokenMarker) -> LitBool {
@@ -794,6 +796,7 @@ ast_enum! {
 }
 
 #[cfg(feature = "parsing")]
+#[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
 #[doc(hidden)]
 #[allow(non_snake_case)]
 pub fn Lit(marker: lookahead::TokenMarker) -> Lit {


### PR DESCRIPTION
For some reason rustdoc is not respecting the `doc(hidden)` on these functions. See https://docs.rs/syn/2.0.27/syn/index.html#functions.

They were hidden correctly in https://docs.rs/syn/2.0.26/syn/index.html#functions so this must be related to #1490.

`cfg(doc)`/`cfg(not(doc))` is supported since Rust 1.41.