### PR TITLE
Work around doc breakage in generate-link-to-definition mode

### DIFF
--- a/src/ident.rs
+++ b/src/ident.rs
@@ -4,11 +4,12 @@ use crate::lookahead;
 pub use proc_macro2::Ident;
 
 #[cfg(feature = "parsing")]
-#[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
-#[doc(hidden)]
-#[allow(non_snake_case)]
-pub fn Ident(marker: lookahead::TokenMarker) -> Ident {
-    match marker {}
+pub_if_not_doc! {
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub fn Ident(marker: lookahead::TokenMarker) -> Ident {
+        match marker {}
+    }
 }
 
 macro_rules! ident_from_token {

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -113,11 +113,12 @@ impl Hash for Lifetime {
 }
 
 #[cfg(feature = "parsing")]
-#[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
-#[doc(hidden)]
-#[allow(non_snake_case)]
-pub fn Lifetime(marker: lookahead::TokenMarker) -> Lifetime {
-    match marker {}
+pub_if_not_doc! {
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub fn Lifetime(marker: lookahead::TokenMarker) -> Lifetime {
+        match marker {}
+    }
 }
 
 #[cfg(feature = "parsing")]

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -758,11 +758,12 @@ macro_rules! lit_extra_traits {
         }
 
         #[cfg(feature = "parsing")]
-        #[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
-        #[doc(hidden)]
-        #[allow(non_snake_case)]
-        pub fn $ty(marker: lookahead::TokenMarker) -> $ty {
-            match marker {}
+        pub_if_not_doc! {
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            pub fn $ty(marker: lookahead::TokenMarker) -> $ty {
+                match marker {}
+            }
         }
     };
 }
@@ -775,11 +776,12 @@ lit_extra_traits!(LitInt);
 lit_extra_traits!(LitFloat);
 
 #[cfg(feature = "parsing")]
-#[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
-#[doc(hidden)]
-#[allow(non_snake_case)]
-pub fn LitBool(marker: lookahead::TokenMarker) -> LitBool {
-    match marker {}
+pub_if_not_doc! {
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub fn LitBool(marker: lookahead::TokenMarker) -> LitBool {
+        match marker {}
+    }
 }
 
 ast_enum! {
@@ -796,11 +798,12 @@ ast_enum! {
 }
 
 #[cfg(feature = "parsing")]
-#[cfg(not(doc))] // Rustdoc bug: does not respect the doc(hidden)
-#[doc(hidden)]
-#[allow(non_snake_case)]
-pub fn Lit(marker: lookahead::TokenMarker) -> Lit {
-    match marker {}
+pub_if_not_doc! {
+    #[doc(hidden)]
+    #[allow(non_snake_case)]
+    pub fn Lit(marker: lookahead::TokenMarker) -> Lit {
+        match marker {}
+    }
 }
 
 #[cfg(feature = "parsing")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -166,3 +166,20 @@ macro_rules! check_keyword_matches {
     (enum enum) => {};
     (pub pub) => {};
 }
+
+// Rustdoc bug: does not respect the doc(hidden) on some items.
+#[cfg(all(doc, feature = "parsing"))]
+macro_rules! pub_if_not_doc {
+    ($(#[$m:meta])* pub $($item:tt)*) => {
+        $(#[$m])*
+        pub(crate) $($item)*
+    };
+}
+
+#[cfg(all(not(doc), feature = "parsing"))]
+macro_rules! pub_if_not_doc {
+    ($(#[$m:meta])* pub $($item:tt)*) => {
+        $(#[$m])*
+        pub $($item)*
+    };
+}


### PR DESCRIPTION
#1511 breaks the docs.rs doc build for [2.0.34](https://docs.rs/crate/syn/2.0.34/builds/912977) and [2.0.35](https://docs.rs/crate/syn/2.0.35/builds/913063). The documentation builds successfully as `cargo doc --all-features`, but not `RUSTDOCFLAGS='--generate-link-to-definition -Zunstable-options' cargo doc --all-features` as used by docs.rs.