### PR TITLE
Absolute path to `bool` in `custom_punctuation.rs`

### DIFF
--- a/src/custom_punctuation.rs
+++ b/src/custom_punctuation.rs
@@ -114,7 +114,7 @@ macro_rules! custom_punctuation {
 macro_rules! impl_parse_for_custom_punctuation {
     ($ident:ident, $($tt:tt)+) => {
         impl $crate::token::CustomToken for $ident {
-            fn peek(cursor: $crate::buffer::Cursor) -> bool {
+            fn peek(cursor: $crate::buffer::Cursor) -> $crate::__private::bool {
                 $crate::__private::peek_punct(cursor, $crate::stringify_punct!($($tt)+))
             }
 


### PR DESCRIPTION
This should solve the following error
```rs
error[E0053]: method `peek` has an incompatible type for trait
  --> src/lib.rs:61:5
   |
61 |     custom_punctuation!(Neq, <>);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     expected `bool`, found a different `bool`
   |     help: change the output type to match the trait: `bool`
   |
   = note: expected signature `fn(syn::buffer::Cursor<'_>) -> bool`
              found signature `fn(syn::buffer::Cursor<'_>) -> bool`
```
that occurs when trying to define
```rs
mod kw {
    custom_token!(bool);
    custom_punctuation!(Neq, <>);
}
```