### PR TITLE
Using parse_parens, parse_braces, parse_brackets instead of macros.

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -628,21 +628,24 @@ pub(crate) mod parsing {
     }
 
     pub(crate) fn single_parse_inner(input: ParseStream) -> Result<Attribute> {
-        let content;
+        let pound_token = input.parse()?;
+        let style = AttrStyle::Inner(input.parse()?);
+        let Brackets { token: bracket_token, content } = parse_brackets(input)?;
         Ok(Attribute {
-            pound_token: input.parse()?,
-            style: AttrStyle::Inner(input.parse()?),
-            bracket_token: bracketed!(content in input),
+            pound_token,
+            style,
+            bracket_token,
             meta: content.parse()?,
         })
     }
 
     pub(crate) fn single_parse_outer(input: ParseStream) -> Result<Attribute> {
-        let content;
+        let pound_token = input.parse()?;
+        let Brackets { token: bracket_token, content } = parse_brackets(input)?;
         Ok(Attribute {
-            pound_token: input.parse()?,
+            pound_token,
             style: AttrStyle::Outer,
-            bracket_token: bracketed!(content in input),
+            bracket_token,
             meta: content.parse()?,
         })
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -157,6 +157,7 @@ ast_struct! {
 pub(crate) mod parsing {
     use super::*;
     use crate::ext::IdentExt;
+    use crate::group::{Parens, parse_parens};
     use crate::parse::{Parse, ParseStream, Result};
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
@@ -191,9 +192,9 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for FieldsNamed {
         fn parse(input: ParseStream) -> Result<Self> {
-            let content;
+            let Braces { token: brace_token, content } = parse_braces(input)?;
             Ok(FieldsNamed {
-                brace_token: braced!(content in input),
+                brace_token,
                 named: content.parse_terminated(Field::parse_named, Token![,])?,
             })
         }
@@ -202,9 +203,9 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for FieldsUnnamed {
         fn parse(input: ParseStream) -> Result<Self> {
-            let content;
+            let Parens { token: paren_token, content } = parse_parens(input)?;
             Ok(FieldsUnnamed {
-                paren_token: parenthesized!(content in input),
+                paren_token,
                 unnamed: content.parse_terminated(Field::parse_unnamed, Token![,])?,
             })
         }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -177,8 +177,7 @@ pub(crate) mod parsing {
     )> {
         let where_clause = input.parse()?;
 
-        let content;
-        let brace = braced!(content in input);
+        let Braces { token: brace, content } = parse_braces(input)?;
         let variants = content.parse_terminated(Variant::parse, Token![,])?;
 
         Ok((where_clause, brace, variants))

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1552,7 +1552,7 @@ pub(crate) mod parsing {
                     member: input.parse()?,
                 });
             } else if input.peek(token::Bracket) {
-                let Brackets { token: bracket_token, content } = parse_braces(input)?;
+                let Brackets { token: bracket_token, content } = parse_brackets(input)?;
                 e = Expr::Index(ExprIndex {
                     attrs: Vec::new(),
                     expr: Box::new(e),

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -533,6 +533,7 @@ ast_struct! {
 pub(crate) mod parsing {
     use super::*;
     use crate::ext::IdentExt;
+    use crate::group::{Parens, parse_parens};
     use crate::parse::{Parse, ParseStream, Result};
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
@@ -755,7 +756,9 @@ pub(crate) mod parsing {
 
             let content;
             let (paren_token, content) = if input.peek(token::Paren) {
-                (Some(parenthesized!(content in input)), &content)
+                let Parens { token, content: parens_content } = parse_parens(input)?;
+                content = parens_content;
+                (Some(token), &content)
             } else {
                 (None, input)
             };

--- a/src/group.rs
+++ b/src/group.rs
@@ -4,7 +4,6 @@ use crate::token;
 use proc_macro2::extra::DelimSpan;
 use proc_macro2::Delimiter;
 
-// Not public API.
 #[doc(hidden)]
 pub struct Parens<'a> {
     #[doc(hidden)]
@@ -13,7 +12,6 @@ pub struct Parens<'a> {
     pub content: ParseBuffer<'a>,
 }
 
-// Not public API.
 #[doc(hidden)]
 pub struct Braces<'a> {
     #[doc(hidden)]
@@ -22,7 +20,6 @@ pub struct Braces<'a> {
     pub content: ParseBuffer<'a>,
 }
 
-// Not public API.
 #[doc(hidden)]
 pub struct Brackets<'a> {
     #[doc(hidden)]
@@ -41,7 +38,6 @@ pub struct Group<'a> {
     pub content: ParseBuffer<'a>,
 }
 
-// Not public API.
 #[doc(hidden)]
 pub fn parse_parens<'a>(input: &ParseBuffer<'a>) -> Result<Parens<'a>> {
     parse_delimited(input, Delimiter::Parenthesis).map(|(span, content)| Parens {
@@ -50,7 +46,6 @@ pub fn parse_parens<'a>(input: &ParseBuffer<'a>) -> Result<Parens<'a>> {
     })
 }
 
-// Not public API.
 #[doc(hidden)]
 pub fn parse_braces<'a>(input: &ParseBuffer<'a>) -> Result<Braces<'a>> {
     parse_delimited(input, Delimiter::Brace).map(|(span, content)| Braces {
@@ -59,7 +54,6 @@ pub fn parse_braces<'a>(input: &ParseBuffer<'a>) -> Result<Braces<'a>> {
     })
 }
 
-// Not public API.
 #[doc(hidden)]
 pub fn parse_brackets<'a>(input: &ParseBuffer<'a>) -> Result<Brackets<'a>> {
     parse_delimited(input, Delimiter::Bracket).map(|(span, content)| Brackets {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,6 +306,8 @@ mod macros;
 #[cfg(feature = "parsing")]
 #[macro_use]
 mod group;
+#[cfg(feature = "parsing")]
+pub use crate::group::{Parens, Braces, Brackets, parse_parens, parse_braces, parse_brackets};
 
 #[macro_use]
 pub mod token;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -7,6 +7,7 @@ use crate::path::{Path, PathSegment};
 use crate::punctuated::Punctuated;
 use proc_macro2::Ident;
 use std::fmt::Display;
+use crate::group::{Parens, parse_parens};
 
 /// Make a parser that is usable with `parse_macro_input!` in a
 /// `#[proc_macro_attribute]` macro.
@@ -271,8 +272,7 @@ impl<'a> ParseNestedMeta<'a> {
         &self,
         logic: impl FnMut(ParseNestedMeta) -> Result<()>,
     ) -> Result<()> {
-        let content;
-        parenthesized!(content in self.input);
+        let Parens { token: _, content } = parse_parens(self.input)?;
         parse_nested_meta(&content, logic)
     }
 

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -227,6 +227,7 @@ ast_struct! {
 pub(crate) mod parsing {
     use super::*;
     use crate::ext::IdentExt;
+    use crate::group::{Parens, parse_parens};
     use crate::parse::{ParseBuffer, ParseStream, Result};
     use crate::path;
 
@@ -448,8 +449,7 @@ pub(crate) mod parsing {
         qself: Option<QSelf>,
         path: Path,
     ) -> Result<PatTupleStruct> {
-        let content;
-        let paren_token = parenthesized!(content in input);
+        let Parens { token: paren_token, content } = parse_parens(input)?;
 
         let mut elems = Punctuated::new();
         while !content.is_empty() {
@@ -472,8 +472,7 @@ pub(crate) mod parsing {
     }
 
     fn pat_struct(input: ParseStream, qself: Option<QSelf>, path: Path) -> Result<PatStruct> {
-        let content;
-        let brace_token = braced!(content in input);
+        let Braces { token: brace_token, content } = parse_braces(input)?;
 
         let mut fields = Punctuated::new();
         let mut rest = None;
@@ -603,8 +602,7 @@ pub(crate) mod parsing {
     }
 
     fn pat_paren_or_tuple(input: ParseStream) -> Result<Pat> {
-        let content;
-        let paren_token = parenthesized!(content in input);
+        let Parens { token: paren_token, content } = parse_parens(input)?;
 
         let mut elems = Punctuated::new();
         while !content.is_empty() {
@@ -719,8 +717,7 @@ pub(crate) mod parsing {
     }
 
     fn pat_slice(input: ParseStream) -> Result<PatSlice> {
-        let content;
-        let bracket_token = bracketed!(content in input);
+        let Brackets { token: bracket_token, content } = parse_brackets(input)?;
 
         let mut elems = Punctuated::new();
         while !content.is_empty() {
@@ -757,8 +754,7 @@ pub(crate) mod parsing {
         let begin = input.fork();
         input.parse::<Token![const]>()?;
 
-        let content;
-        braced!(content in input);
+        let Braces { token: _, content } = parse_braces(input)?;
         content.call(Attribute::parse_inner)?;
         content.call(Block::parse_within)?;
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -278,6 +278,7 @@ pub(crate) mod parsing {
     use super::*;
 
     use crate::ext::IdentExt;
+    use crate::group::{Parens, parse_parens};
     use crate::parse::{Parse, ParseStream, Result};
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
@@ -401,8 +402,7 @@ pub(crate) mod parsing {
             #[cfg(not(feature = "full"))]
             {
                 let begin = input.fork();
-                let content;
-                braced!(content in input);
+                let Braces { token: _, content } = parse_braces(input)?;
                 content.parse::<Expr>()?;
                 let verbatim = verbatim::between(&begin, input);
                 return Ok(Expr::Verbatim(verbatim));
@@ -460,9 +460,9 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for ParenthesizedGenericArguments {
         fn parse(input: ParseStream) -> Result<Self> {
-            let content;
+            let Parens { token: paren_token, content } = parse_parens(input)?;
             Ok(ParenthesizedGenericArguments {
-                paren_token: parenthesized!(content in input),
+                paren_token,
                 inputs: content.parse_terminated(Type::parse, Token![,])?,
                 output: input.call(ReturnType::without_plus)?,
             })

--- a/src/restriction.rs
+++ b/src/restriction.rs
@@ -59,6 +59,7 @@ ast_enum! {
 pub(crate) mod parsing {
     use super::*;
     use crate::ext::IdentExt;
+    use crate::group::{Parens, parse_parens};
     use crate::parse::discouraged::Speculative;
     use crate::parse::{Parse, ParseStream, Result};
 
@@ -91,8 +92,7 @@ pub(crate) mod parsing {
             if input.peek(token::Paren) {
                 let ahead = input.fork();
 
-                let content;
-                let paren_token = parenthesized!(content in ahead);
+                let Parens { token: paren_token, content } = parse_parens(&ahead)?;
                 if content.peek(Token![crate])
                     || content.peek(Token![self])
                     || content.peek(Token![super])

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -163,9 +163,9 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for Block {
         fn parse(input: ParseStream) -> Result<Self> {
-            let content;
+            let Braces { token: brace_token, content } = parse_braces(input)?;
             Ok(Block {
-                brace_token: braced!(content in input),
+                brace_token,
                 stmts: content.call(Block::parse_within)?,
             })
         }


### PR DESCRIPTION
I don't understand why we have macros parenthesized, braced and bracketed.
You cannot use '?' with them, because these macros return the ParseBuffer from expression, and in case of an error, they return it from the current function.
Simple functions are better, than macros.
```rust
let content;
if let Ok(_) = (|| Ok(bracketed!(content in input)))() { }
```
or 
```rust
if let Ok(_) = parse_braces(&input) { }
```
In first variant we have uninitialized variable.
Example from syn crate:
```rust
let content;
let (paren_token, content) = if input.peek(token::Paren) {
    (Some(parenthesized!(content in input)), &content)
} else {
    (None, input)
};
```
Perhaps we should remove these macros and make the listed functions and the values returned by them public?