### PR TITLE
Unseal Spanned again

### DIFF
--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -93,7 +93,7 @@ use quote::spanned::Spanned as ToTokens;
 /// See the [module documentation] for an example.
 ///
 /// [module documentation]: self
-pub trait Spanned: private::Sealed {
+pub trait Spanned {
     /// Returns a `Span` covering the complete contents of this syntax tree
     /// node, or [`Span::call_site()`] if this node is empty.
     ///


### PR DESCRIPTION
Spanned was not sealed in syn 1.

Currently in syn 2 it is nominally sealed, but since quote::ToTokens isn't sealed, Spanned *can* be implemented for any foreign type, provided one is willing to provide a (possibly broken) implemntation of ToTokens.

This means that sealing Spanned has no semver advantage, and neither does it defend syn from any bad behaviour on the part of downstream implementors.

This is blocking at least one of my downstreams of syn from updating to syn 2.

See https://github.com/dtolnay/syn/issues/1441