### PR TITLE
Enable getting span locations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ visit-mut = []
 fold = []
 clone-impls = []
 extra-traits = []
+span-locations = ["proc-macro2/span-locations"]
 proc-macro = ["proc-macro2/proc-macro", "quote/proc-macro"]
 test = ["syn-test-suite/all-features"]
 


### PR DESCRIPTION
Hi David,

I needed a way to extract location of the unsafe code to make use of that in the CI harness, and came up with this approach to enabling that. Here is a simple repo to validate the fork works: https://github.com/kromych/unsafe_travels.
