### PR TITLE
Include empty `stmts = []` in snapshots

### DIFF
--- a/codegen/src/snapshot.rs
+++ b/codegen/src/snapshot.rs
@@ -263,7 +263,9 @@ fn expand_impl_body(defs: &Definitions, node: &Node, name: &str, val: &Operand) 
                     let mut call = quote! {
                         formatter.field(#f, #format);
                     };
-                    if let Type::Vec(_) | Type::Punctuated(_) = ty {
+                    if node.ident == "Block" && f == "stmts" {
+                        // Format regardless of whether is_empty().
+                    } else if let Type::Vec(_) | Type::Punctuated(_) = ty {
                         call = quote! {
                             if !#val.#ident.is_empty() {
                                 #call

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -301,9 +301,7 @@ impl Debug for Lite<syn::BinOp> {
 impl Debug for Lite<syn::Block> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("Block");
-        if !self.value.stmts.is_empty() {
-            formatter.field("stmts", Lite(&self.value.stmts));
-        }
+        formatter.field("stmts", Lite(&self.value.stmts));
         formatter.finish()
     }
 }

--- a/tests/test_asyncness.rs
+++ b/tests/test_asyncness.rs
@@ -18,7 +18,9 @@ fn test_async_fn() {
             generics: Generics,
             output: ReturnType::Default,
         },
-        block: Block,
+        block: Block {
+            stmts: [],
+        },
     }
     "###);
 }
@@ -32,7 +34,9 @@ fn test_async_closure() {
         asyncness: Some,
         output: ReturnType::Default,
         body: Expr::Block {
-            block: Block,
+            block: Block {
+                stmts: [],
+            },
         },
     }
     "###);

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -243,7 +243,9 @@ fn test_fn_precedence_in_where_clause() {
             },
             output: ReturnType::Default,
         },
-        block: Block,
+        block: Block {
+            stmts: [],
+        },
     }
     "###);
 

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -38,7 +38,9 @@ fn test_macro_variable_attr() {
             generics: Generics,
             output: ReturnType::Default,
         },
-        block: Block,
+        block: Block {
+            stmts: [],
+        },
     }
     "###);
 }
@@ -320,7 +322,9 @@ fn test_impl_trait_trailing_plus() {
                 },
             ),
         },
-        block: Block,
+        block: Block {
+            stmts: [],
+        },
     }
     "###);
 }

--- a/tests/test_shebang.rs
+++ b/tests/test_shebang.rs
@@ -18,7 +18,9 @@ fn test_basic() {
                     generics: Generics,
                     output: ReturnType::Default,
                 },
-                block: Block,
+                block: Block {
+                    stmts: [],
+                },
             },
         ],
     }
@@ -55,7 +57,9 @@ fn test_comment() {
                     generics: Generics,
                     output: ReturnType::Default,
                 },
-                block: Block,
+                block: Block {
+                    stmts: [],
+                },
             },
         ],
     }

--- a/tests/test_stmt.rs
+++ b/tests/test_stmt.rs
@@ -78,7 +78,9 @@ fn test_none_group() {
             generics: Generics,
             output: ReturnType::Default,
         },
-        block: Block,
+        block: Block {
+            stmts: [],
+        },
     })
     "###);
 }
@@ -251,7 +253,9 @@ fn test_early_parse_loop() {
     [
         Stmt::Expr(
             Expr::Loop {
-                body: Block,
+                body: Block {
+                    stmts: [],
+                },
             },
             None,
         ),
@@ -278,7 +282,9 @@ fn test_early_parse_loop() {
                         ident: "a",
                     },
                 }),
-                body: Block,
+                body: Block {
+                    stmts: [],
+                },
             },
             None,
         ),


### PR DESCRIPTION
Just `block: Block` is disorienting. Render as `block: Block { stmts: [] }`.