### PR TITLE
Fix infinite loop on attr surrounded by None-delimited group

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1354,23 +1354,8 @@ pub(crate) mod parsing {
     #[cfg(feature = "full")]
     fn expr_attrs(input: ParseStream) -> Result<Vec<Attribute>> {
         let mut attrs = Vec::new();
-        loop {
-            if input.peek(token::Group) {
-                let ahead = input.fork();
-                let group = crate::group::parse_group(&ahead)?;
-                if !group.content.peek(Token![#]) || group.content.peek2(Token![!]) {
-                    break;
-                }
-                let attr = group.content.call(attr::parsing::single_parse_outer)?;
-                if !group.content.is_empty() {
-                    break;
-                }
-                attrs.push(attr);
-            } else if input.peek(Token![#]) {
-                attrs.push(input.call(attr::parsing::single_parse_outer)?);
-            } else {
-                break;
-            }
+        while !input.peek(token::Group) && input.peek(Token![#]) {
+            attrs.push(input.call(attr::parsing::single_parse_outer)?);
         }
         Ok(attrs)
     }


### PR DESCRIPTION
The infinite loop can be reproduced like this:

```rust
use proc_macro2::{Delimiter, Group};
use quote::quote;

fn main() {
    let attr = Group::new(Delimiter::None, quote!(#[attr]));
    let tokens = quote!(#attr 0);
    syn::parse2::<syn::Expr>(tokens).unwrap();
}
```

The bug is from #853. Given nothing has hit this in 3.5 years, probably a group in that position does not need to be supported. But it should return an error instead of looping.