### PR TITLE
Support interpolated $:path followed by macro call or struct literal

### DIFF
--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -347,16 +347,18 @@ fn test_extended_interpolated_path() {
     let tokens = quote!(if #path {});
     snapshot!(tokens as Expr, @r###"
     Expr::If {
-        cond: Expr::Path {
-            path: Path {
-                segments: [
-                    PathSegment {
-                        ident: "a",
-                    },
-                    PathSegment {
-                        ident: "b",
-                    },
-                ],
+        cond: Expr::Group {
+            expr: Expr::Path {
+                path: Path {
+                    segments: [
+                        PathSegment {
+                            ident: "a",
+                        },
+                        PathSegment {
+                            ident: "b",
+                        },
+                    ],
+                },
             },
         },
         then_branch: Block {
@@ -400,36 +402,37 @@ fn test_extended_interpolated_path() {
     }
     "###);
 
-    // FIXME
     let nested = Group::new(Delimiter::None, quote!(a::b || true));
     let tokens = quote!(if #nested && false {});
     snapshot!(tokens as Expr, @r###"
     Expr::If {
         cond: Expr::Binary {
-            left: Expr::Path {
-                path: Path {
-                    segments: [
-                        PathSegment {
-                            ident: "a",
+            left: Expr::Group {
+                expr: Expr::Binary {
+                    left: Expr::Path {
+                        path: Path {
+                            segments: [
+                                PathSegment {
+                                    ident: "a",
+                                },
+                                PathSegment {
+                                    ident: "b",
+                                },
+                            ],
                         },
-                        PathSegment {
-                            ident: "b",
+                    },
+                    op: BinOp::Or,
+                    right: Expr::Lit {
+                        lit: Lit::Bool {
+                            value: true,
                         },
-                    ],
+                    },
                 },
             },
-            op: BinOp::Or,
-            right: Expr::Binary {
-                left: Expr::Lit {
-                    lit: Lit::Bool {
-                        value: true,
-                    },
-                },
-                op: BinOp::And,
-                right: Expr::Lit {
-                    lit: Lit::Bool {
-                        value: false,
-                    },
+            op: BinOp::And,
+            right: Expr::Lit {
+                lit: Lit::Bool {
+                    value: false,
                 },
             },
         },

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -399,4 +399,43 @@ fn test_extended_interpolated_path() {
         },
     }
     "###);
+
+    // FIXME
+    let nested = Group::new(Delimiter::None, quote!(a::b || true));
+    let tokens = quote!(if #nested && false {});
+    snapshot!(tokens as Expr, @r###"
+    Expr::If {
+        cond: Expr::Binary {
+            left: Expr::Path {
+                path: Path {
+                    segments: [
+                        PathSegment {
+                            ident: "a",
+                        },
+                        PathSegment {
+                            ident: "b",
+                        },
+                    ],
+                },
+            },
+            op: BinOp::Or,
+            right: Expr::Binary {
+                left: Expr::Lit {
+                    lit: Lit::Bool {
+                        value: true,
+                    },
+                },
+                op: BinOp::And,
+                right: Expr::Lit {
+                    lit: Lit::Bool {
+                        value: false,
+                    },
+                },
+            },
+        },
+        then_branch: Block {
+            stmts: [],
+        },
+    }
+    "###);
 }

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -339,3 +339,64 @@ fn test_ambiguous_label() {
         syn::parse2::<Stmt>(stmt).unwrap_err();
     }
 }
+
+#[test]
+fn test_extended_interpolated_path() {
+    let path = Group::new(Delimiter::None, quote!(a::b));
+
+    let tokens = quote!(if #path {});
+    snapshot!(tokens as Expr, @r###"
+    Expr::If {
+        cond: Expr::Path {
+            path: Path {
+                segments: [
+                    PathSegment {
+                        ident: "a",
+                    },
+                    PathSegment {
+                        ident: "b",
+                    },
+                ],
+            },
+        },
+        then_branch: Block {
+            stmts: [],
+        },
+    }
+    "###);
+
+    let tokens = quote!(#path {});
+    snapshot!(tokens as Expr, @r###"
+    Expr::Struct {
+        path: Path {
+            segments: [
+                PathSegment {
+                    ident: "a",
+                },
+                PathSegment {
+                    ident: "b",
+                },
+            ],
+        },
+    }
+    "###);
+
+    let tokens = quote!(#path :: c);
+    snapshot!(tokens as Expr, @r###"
+    Expr::Path {
+        path: Path {
+            segments: [
+                PathSegment {
+                    ident: "a",
+                },
+                PathSegment {
+                    ident: "b",
+                },
+                PathSegment {
+                    ident: "c",
+                },
+            ],
+        },
+    }
+    "###);
+}


### PR DESCRIPTION
Example of an input that previously behaved incorrectly:

```rust
let nested = Group::new(Delimiter::None, quote!(a::b || true));
let tokens = quote!(if #nested && false {});
syn::parse2::<syn::Expr>(tokens).unwrap()
```

**Before:** this has the wrong precedence. `a::b || (true && false)`

```rust
Expr::If {
    cond: Expr::Binary {
        left: Expr::Path {
            path: Path {
                segments: [
                    PathSegment {
                        ident: "a",
                    },
                    PathSegment {
                        ident: "b",
                    },
                ],
            },
        },
        op: BinOp::Or,
        right: Expr::Binary {
            left: Expr::Lit {
                lit: Lit::Bool {
                    value: true,
                },
            },
            op: BinOp::And,
            right: Expr::Lit {
                lit: Lit::Bool {
                    value: false,
                },
            },
        },
    },
    then_branch: Block {
        stmts: [],
    },
}
```

**After:** correct precedence. `(a::b || true) && false`

```rust
Expr::If {
    cond: Expr::Binary {
        left: Expr::Group {
            expr: Expr::Binary {
                left: Expr::Path {
                    path: Path {
                        segments: [
                            PathSegment {
                                ident: "a",
                            },
                            PathSegment {
                                ident: "b",
                            },
                        ],
                    },
                },
                op: BinOp::Or,
                right: Expr::Lit {
                    lit: Lit::Bool {
                        value: true,
                    },
                },
            },
        },
        op: BinOp::And,
        right: Expr::Lit {
            lit: Lit::Bool {
                value: false,
            },
        },
    },
    then_branch: Block {
        stmts: [],
    },
}
```
