### PR TITLE
Respect None-delimited group when parsing unary expr

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1368,6 +1368,10 @@ pub(crate) mod parsing {
     fn unary_expr(input: ParseStream, allow_struct: AllowStruct) -> Result<Expr> {
         let begin = input.fork();
         let attrs = input.call(expr_attrs)?;
+        if input.peek(token::Group) {
+            return trailer_expr(begin, attrs, input, allow_struct);
+        }
+
         if input.peek(Token![&]) {
             let and_token: Token![&] = input.parse()?;
             let raw: Option<kw::raw> = if input.peek(kw::raw)

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -221,21 +221,22 @@ fn test_macro_variable_unary() {
     // mimics the token stream corresponding to `$expr.method()` where expr is `&self`
     let inner = Group::new(Delimiter::None, quote!(&self));
     let tokens = quote!(#inner.method());
-    // FIXME
     snapshot!(tokens as Expr, @r###"
-    Expr::Reference {
-        expr: Expr::MethodCall {
-            receiver: Expr::Path {
-                path: Path {
-                    segments: [
-                        PathSegment {
-                            ident: "self",
-                        },
-                    ],
+    Expr::MethodCall {
+        receiver: Expr::Group {
+            expr: Expr::Reference {
+                expr: Expr::Path {
+                    path: Path {
+                        segments: [
+                            PathSegment {
+                                ident: "self",
+                            },
+                        ],
+                    },
                 },
             },
-            method: "method",
         },
+        method: "method",
     }
     "###);
 }

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -217,6 +217,30 @@ fn test_macro_variable_struct() {
 }
 
 #[test]
+fn test_macro_variable_unary() {
+    // mimics the token stream corresponding to `$expr.method()` where expr is `&self`
+    let inner = Group::new(Delimiter::None, quote!(&self));
+    let tokens = quote!(#inner.method());
+    // FIXME
+    snapshot!(tokens as Expr, @r###"
+    Expr::Reference {
+        expr: Expr::MethodCall {
+            receiver: Expr::Path {
+                path: Path {
+                    segments: [
+                        PathSegment {
+                            ident: "self",
+                        },
+                    ],
+                },
+            },
+            method: "method",
+        },
+    }
+    "###);
+}
+
+#[test]
 fn test_macro_variable_match_arm() {
     // mimics the token stream corresponding to `match v { _ => $expr }`
     let tokens = TokenStream::from_iter(vec![


### PR DESCRIPTION
Example input: `$expr.method()` where expr is `&self`.

**Before:** incorrect, this is `&(self.method())`

```rust
Expr::Reference {
    expr: Expr::MethodCall {
        receiver: Expr::Path {
            path: Path {
                segments: [
                    PathSegment {
                        ident: "self",
                    },
                ],
            },
        },
        method: "method",
    },
}
```

**After:** correct. `(&self).method()`

```rust
Expr::MethodCall {
    receiver: Expr::Group {
        expr: Expr::Reference {
            expr: Expr::Path {
                path: Path {
                    segments: [
                        PathSegment {
                            ident: "self",
                        },
                    ],
                },
            },
        },
    },
    method: "method",
}
```