### PR TITLE
Turn on deny(unsafe_op_in_unsafe_fn)

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -128,11 +128,11 @@ impl<'a> Cursor<'a> {
         // past it, unless `ptr == scope`, which means that we're at the edge of
         // our cursor's scope. We should only have `ptr != scope` at the exit
         // from None-delimited groups entered with `ignore_none`.
-        while let Entry::End(_) = *ptr {
+        while let Entry::End(_) = unsafe { &*ptr } {
             if ptr == scope {
                 break;
             }
-            ptr = ptr.add(1);
+            ptr = unsafe { ptr.add(1) };
         }
 
         Cursor {
@@ -154,7 +154,7 @@ impl<'a> Cursor<'a> {
     /// If the cursor is looking at an `Entry::Group`, the bumped cursor will
     /// point at the first token in the group (with the same scope end).
     unsafe fn bump_ignore_group(self) -> Cursor<'a> {
-        Cursor::create(self.ptr.offset(1), self.scope)
+        unsafe { Cursor::create(self.ptr.offset(1), self.scope) }
     }
 
     /// While the cursor is looking at a `None`-delimited group, move it to look

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@
 // Syn types in rustdoc of other crates get linked to here.
 #![doc(html_root_url = "https://docs.rs/syn/2.0.42")]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(non_camel_case_types)]
 #![allow(
     clippy::bool_to_int_with_if,


### PR DESCRIPTION
This is allow-by-default for now in 2021 edition, but will become warn-by-default in 2024 edition.