### PR TITLE
Make Expr::MethodCall available in non-"full" mode

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -266,7 +266,6 @@ impl Clone for Expr {
             Expr::Macro(v0) => Expr::Macro(v0.clone()),
             #[cfg(feature = "full")]
             Expr::Match(v0) => Expr::Match(v0.clone()),
-            #[cfg(feature = "full")]
             Expr::MethodCall(v0) => Expr::MethodCall(v0.clone()),
             Expr::Paren(v0) => Expr::Paren(v0.clone()),
             Expr::Path(v0) => Expr::Path(v0.clone()),
@@ -577,7 +576,7 @@ impl Clone for ExprMatch {
         }
     }
 }
-#[cfg(feature = "full")]
+#[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "clone-impls")))]
 impl Clone for ExprMethodCall {
     fn clone(&self) -> Self {

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -432,7 +432,6 @@ impl Debug for Expr {
             Expr::Macro(v0) => v0.debug(formatter, "Macro"),
             #[cfg(feature = "full")]
             Expr::Match(v0) => v0.debug(formatter, "Match"),
-            #[cfg(feature = "full")]
             Expr::MethodCall(v0) => v0.debug(formatter, "MethodCall"),
             Expr::Paren(v0) => v0.debug(formatter, "Paren"),
             Expr::Path(v0) => v0.debug(formatter, "Path"),
@@ -862,7 +861,7 @@ impl Debug for ExprMatch {
         self.debug(formatter, "ExprMatch")
     }
 }
-#[cfg(feature = "full")]
+#[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Debug for ExprMethodCall {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -285,7 +285,6 @@ impl PartialEq for Expr {
             (Expr::Macro(self0), Expr::Macro(other0)) => self0 == other0,
             #[cfg(feature = "full")]
             (Expr::Match(self0), Expr::Match(other0)) => self0 == other0,
-            #[cfg(feature = "full")]
             (Expr::MethodCall(self0), Expr::MethodCall(other0)) => self0 == other0,
             (Expr::Paren(self0), Expr::Paren(other0)) => self0 == other0,
             (Expr::Path(self0), Expr::Path(other0)) => self0 == other0,
@@ -560,10 +559,10 @@ impl PartialEq for ExprMatch {
         self.attrs == other.attrs && self.expr == other.expr && self.arms == other.arms
     }
 }
-#[cfg(feature = "full")]
+#[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Eq for ExprMethodCall {}
-#[cfg(feature = "full")]
+#[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for ExprMethodCall {
     fn eq(&self, other: &Self) -> bool {

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -204,7 +204,7 @@ pub trait Fold {
     fn fold_expr_match(&mut self, i: ExprMatch) -> ExprMatch {
         fold_expr_match(self, i)
     }
-    #[cfg(feature = "full")]
+    #[cfg(any(feature = "derive", feature = "full"))]
     fn fold_expr_method_call(&mut self, i: ExprMethodCall) -> ExprMethodCall {
         fold_expr_method_call(self, i)
     }
@@ -1041,7 +1041,7 @@ where
         Expr::Macro(_binding_0) => Expr::Macro(f.fold_expr_macro(_binding_0)),
         Expr::Match(_binding_0) => Expr::Match(full!(f.fold_expr_match(_binding_0))),
         Expr::MethodCall(_binding_0) => {
-            Expr::MethodCall(full!(f.fold_expr_method_call(_binding_0)))
+            Expr::MethodCall(f.fold_expr_method_call(_binding_0))
         }
         Expr::Paren(_binding_0) => Expr::Paren(f.fold_expr_paren(_binding_0)),
         Expr::Path(_binding_0) => Expr::Path(f.fold_expr_path(_binding_0)),
@@ -1343,7 +1343,7 @@ where
         arms: FoldHelper::lift(node.arms, |it| f.fold_arm(it)),
     }
 }
-#[cfg(feature = "full")]
+#[cfg(any(feature = "derive", feature = "full"))]
 pub fn fold_expr_method_call<F>(f: &mut F, node: ExprMethodCall) -> ExprMethodCall
 where
     F: Fold + ?Sized,

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -440,7 +440,6 @@ impl Hash for Expr {
                 state.write_u8(22u8);
                 v0.hash(state);
             }
-            #[cfg(feature = "full")]
             Expr::MethodCall(v0) => {
                 state.write_u8(23u8);
                 v0.hash(state);
@@ -798,7 +797,7 @@ impl Hash for ExprMatch {
         self.arms.hash(state);
     }
 }
-#[cfg(feature = "full")]
+#[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "extra-traits")))]
 impl Hash for ExprMethodCall {
     fn hash<H>(&self, state: &mut H)

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -203,7 +203,7 @@ pub trait Visit<'ast> {
     fn visit_expr_match(&mut self, i: &'ast ExprMatch) {
         visit_expr_match(self, i);
     }
-    #[cfg(feature = "full")]
+    #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_expr_method_call(&mut self, i: &'ast ExprMethodCall) {
         visit_expr_method_call(self, i);
     }
@@ -1152,7 +1152,7 @@ where
             full!(v.visit_expr_match(_binding_0));
         }
         Expr::MethodCall(_binding_0) => {
-            full!(v.visit_expr_method_call(_binding_0));
+            v.visit_expr_method_call(_binding_0);
         }
         Expr::Paren(_binding_0) => {
             v.visit_expr_paren(_binding_0);
@@ -1507,7 +1507,7 @@ where
         v.visit_arm(it);
     }
 }
-#[cfg(feature = "full")]
+#[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_expr_method_call<'ast, V>(v: &mut V, node: &'ast ExprMethodCall)
 where
     V: Visit<'ast> + ?Sized,

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -204,7 +204,7 @@ pub trait VisitMut {
     fn visit_expr_match_mut(&mut self, i: &mut ExprMatch) {
         visit_expr_match_mut(self, i);
     }
-    #[cfg(feature = "full")]
+    #[cfg(any(feature = "derive", feature = "full"))]
     fn visit_expr_method_call_mut(&mut self, i: &mut ExprMethodCall) {
         visit_expr_method_call_mut(self, i);
     }
@@ -1153,7 +1153,7 @@ where
             full!(v.visit_expr_match_mut(_binding_0));
         }
         Expr::MethodCall(_binding_0) => {
-            full!(v.visit_expr_method_call_mut(_binding_0));
+            v.visit_expr_method_call_mut(_binding_0);
         }
         Expr::Paren(_binding_0) => {
             v.visit_expr_paren_mut(_binding_0);
@@ -1508,7 +1508,7 @@ where
         v.visit_arm_mut(it);
     }
 }
-#[cfg(feature = "full")]
+#[cfg(any(feature = "derive", feature = "full"))]
 pub fn visit_expr_method_call_mut<V>(v: &mut V, node: &mut ExprMethodCall)
 where
     V: VisitMut + ?Sized,

--- a/src/path.rs
+++ b/src/path.rs
@@ -424,7 +424,10 @@ pub(crate) mod parsing {
             Self::do_parse(Some(colon2_token), input)
         }
 
-        fn do_parse(colon2_token: Option<Token![::]>, input: ParseStream) -> Result<Self> {
+        pub(crate) fn do_parse(
+            colon2_token: Option<Token![::]>,
+            input: ParseStream,
+        ) -> Result<Self> {
             Ok(AngleBracketedGenericArguments {
                 colon2_token,
                 lt_token: input.parse()?,

--- a/syn.json
+++ b/syn.json
@@ -1500,6 +1500,7 @@
       "ident": "ExprMethodCall",
       "features": {
         "any": [
+          "derive",
           "full"
         ]
       },


### PR DESCRIPTION
This appears in derive input in the case of const associated functions.

```rust
#[derive(Derive)]
pub enum E {
    V = CONFIG.compute_thing(),
}

struct Config { ... }

const CONFIG: Config = Config { ... };

impl Config {
    const fn compute_thing(&self) -> isize { ... }
}
```

Previously with syn in non-"full" mode, a method call expression such as `CONFIG.compute_thing()` would parse incorrectly as Expr::Call containing Expr::Field as the called function, rather than Expr::MethodCall containing Expr::Path as the receiver.