### PR TITLE
Impl Parse for PatType

### DIFF
--- a/src/pat.rs
+++ b/src/pat.rs
@@ -228,7 +228,7 @@ ast_struct! {
 pub(crate) mod parsing {
     use super::*;
     use crate::ext::IdentExt as _;
-    use crate::parse::{ParseBuffer, ParseStream, Result};
+    use crate::parse::{Parse, ParseBuffer, ParseStream, Result};
     use crate::path;
 
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
@@ -352,6 +352,18 @@ pub(crate) mod parsing {
         pub fn parse_multi_with_leading_vert(input: ParseStream) -> Result<Self> {
             let leading_vert: Option<Token![|]> = input.parse()?;
             multi_pat_impl(input, leading_vert)
+        }
+    }
+
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
+    impl Parse for PatType {
+        fn parse(input: ParseStream) -> Result<Self> {
+            Ok(PatType {
+                attrs: Vec::new(),
+                pat: Box::new(Pat::parse_single(input)?),
+                colon_token: input.parse()?,
+                ty: input.parse()?,
+            })
         }
     }
 


### PR DESCRIPTION
This makes `PatType` work with `parse_quote!`. Useful for initializing the left-hand side of a `Local`, or a `FnArg::Typed`.

Closes #1554.

```rust
// [dependencies]
// syn = { version = "2", features = ["full", "extra-traits"] }

use syn::{parse_quote, PatType};

fn main() {
    let pat: PatType = parse_quote! { ptr: usize };
    println!("{:#?}", pat);
}
```