### PR TITLE
Preserve LexError's Display representation in syn::Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -404,7 +404,7 @@ impl std::error::Error for Error {}
 
 impl From<LexError> for Error {
     fn from(err: LexError) -> Self {
-        Error::new(err.span(), "lex error")
+        Error::new(err.span(), err)
     }
 }
 


### PR DESCRIPTION
This "lex error" message is from prior to https://github.com/rust-lang/rust/pull/68899 / https://github.com/dtolnay/proc-macro2/pull/265.