### PR TITLE
Fix error message on unexpected token after 'else'

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2142,9 +2142,9 @@ pub(crate) mod parsing {
         let else_token: Token![else] = input.parse()?;
 
         let lookahead = input.lookahead1();
-        let else_branch = if input.peek(Token![if]) {
+        let else_branch = if lookahead.peek(Token![if]) {
             input.parse().map(Expr::If)?
-        } else if input.peek(token::Brace) {
+        } else if lookahead.peek(token::Brace) {
             Expr::Block(ExprBlock {
                 attrs: Vec::new(),
                 label: None,


### PR DESCRIPTION
Fixes #1577.

**Before:**

```console
error: unexpected token
 --> dev/main.rs:4:40
  |
4 |     fn main() { let x = if true {} else; }
  |                                        ^
```

**After:**

```console
error: expected `if` or curly braces
 --> dev/main.rs:4:40
  |
4 |     fn main() { let x = if true {} else; }
  |                                        ^
```