### PR TITLE
Improve error location at eof in LitStr::parse

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -225,10 +225,11 @@ impl LitStr {
 
         // Parse string literal into a token stream with every span equal to the
         // original literal's span.
+        let span = self.span();
         let mut tokens = TokenStream::from_str(&self.value())?;
-        tokens = respan_token_stream(tokens, self.span());
+        tokens = respan_token_stream(tokens, span);
 
-        let result = parser.parse2(tokens)?;
+        let result = crate::parse::parse_scoped(parser, span, tokens)?;
 
         let suffix = self.suffix();
         if !suffix.is_empty() {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1268,7 +1268,6 @@ pub trait Parser: Sized {
 
     // Not public API.
     #[doc(hidden)]
-    #[cfg(any(feature = "full", feature = "derive"))]
     fn __parse_scoped(self, scope: Span, tokens: TokenStream) -> Result<Self::Output> {
         let _ = scope;
         self.parse2(tokens)
@@ -1300,7 +1299,6 @@ where
         }
     }
 
-    #[cfg(any(feature = "full", feature = "derive"))]
     fn __parse_scoped(self, scope: Span, tokens: TokenStream) -> Result<Self::Output> {
         let buf = TokenBuffer::new2(tokens);
         let cursor = buf.begin();
@@ -1316,7 +1314,6 @@ where
     }
 }
 
-#[cfg(any(feature = "full", feature = "derive"))]
 pub(crate) fn parse_scoped<F: Parser>(f: F, scope: Span, tokens: TokenStream) -> Result<F::Output> {
     f.__parse_scoped(scope, tokens)
 }


### PR DESCRIPTION
I noticed this in https://github.com/colin-kiegel/rust-derive-builder/pull/310. When using `litstr.parse()` on a string literal token whose contents are empty, there previously were not any tokens in which the span could be transferred to the inner parser. This is what the "scope" span is supposed to be for, which is also used for parsing the contents of empty delimiters, for the same reason.

**Before:**

```console
error: unexpected end of input, expected expression
 --> tests/compile-fail/deny_empty_default.rs:6:10
  |
6 | #[derive(Builder)]
  |          ^^^^^^^
  |
  = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
```

**After:**

```console
error: unexpected end of input, expected expression
 --> tests/compile-fail/deny_empty_default.rs:8:25
  |
8 |     #[builder(default = "")]
  |                         ^^
```