### PR TITLE
Don't use `parse_group` for a visibility.

### DIFF
--- a/src/restriction.rs
+++ b/src/restriction.rs
@@ -70,17 +70,6 @@ pub(crate) mod parsing {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
     impl Parse for Visibility {
         fn parse(input: ParseStream) -> Result<Self> {
-            // Recognize an empty None-delimited group, as produced by a $:vis
-            // matcher that matched no tokens.
-            if input.peek(token::Group) {
-                let ahead = input.fork();
-                let group = crate::group::parse_group(&ahead)?;
-                if group.content.is_empty() {
-                    input.advance_to(&ahead);
-                    return Ok(Visibility::Inherited);
-                }
-            }
-
             if input.peek(Token![pub]) {
                 Self::parse_pub(input)
             } else {


### PR DESCRIPTION
There is no need to explicitly handle an empty group, because the standard group ignoring code has the same effect.