### PR TITLE
Suppress dead code lint on custom token's span field

### DIFF
--- a/src/custom_keyword.rs
+++ b/src/custom_keyword.rs
@@ -91,6 +91,7 @@ macro_rules! custom_keyword {
     ($ident:ident) => {
         #[allow(non_camel_case_types)]
         pub struct $ident {
+            #[allow(dead_code)]
             pub span: $crate::__private::Span,
         }
 

--- a/src/custom_punctuation.rs
+++ b/src/custom_punctuation.rs
@@ -78,6 +78,7 @@
 macro_rules! custom_punctuation {
     ($ident:ident, $($tt:tt)+) => {
         pub struct $ident {
+            #[allow(dead_code)]
             pub spans: $crate::custom_punctuation_repr!($($tt)+),
         }
 


### PR DESCRIPTION
`syn::custom_keyword!` produces potentially unused code if syn's "printing" feature is off, so that a ToTokens impl is not being generated.

This warning is new in nightly-2024-03-24 from https://github.com/rust-lang/rust/pull/119552.

```console
warning: field `span` is never read
    --> src/custom_keyword.rs:94:17
     |
94   |             pub span: $crate::__private::Span,
     |                 ^^^^
     |
    ::: src/expr.rs:1079:32
     |
1079 |         crate::custom_keyword!(builtin);
     |         -------------------------------
     |         |                      |
     |         |                      field in this struct
     |         in this macro invocation
     |
     = note: `#[warn(dead_code)]` on by default
     = note: this warning originates in the macro `crate::custom_keyword` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: field `span` is never read
    --> src/custom_keyword.rs:94:17
     |
94   |             pub span: $crate::__private::Span,
     |                 ^^^^
     |
    ::: src/expr.rs:1080:32
     |
1080 |         crate::custom_keyword!(raw);
     |         ---------------------------
     |         |                      |
     |         |                      field in this struct
     |         in this macro invocation
     |
     = note: this warning originates in the macro `crate::custom_keyword` (in Nightly builds, run with -Z macro-backtrace for more info)
```