### PR TITLE
Restore compatibility with rustc 1.56 through 1.59

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, 1.60.0]
+        rust: [stable, beta, 1.60.0, 1.56.0]
         include:
           - rust: nightly
             components: rustc-dev
@@ -52,6 +52,7 @@ jobs:
             os: windows
     env:
       target: ${{matrix.target && format('--target={0}', matrix.target)}}
+      manifestpath: ${{matrix.rust == '1.56.0' && '--manifest-path tests/crate/Cargo.toml' || ''}}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -60,21 +61,21 @@ jobs:
           toolchain: ${{matrix.rust}}
           targets: ${{matrix.target}}
           components: ${{matrix.components}}
-      - run: cargo check ${{env.target}} --no-default-features
-      - run: cargo check ${{env.target}}
-      - run: cargo check ${{env.target}} --features full
-      - run: cargo check ${{env.target}} --features 'fold visit visit-mut'
-      - run: cargo check ${{env.target}} --features 'full fold visit visit-mut'
-      - run: cargo check ${{env.target}} --no-default-features --features derive
-      - run: cargo check ${{env.target}} --no-default-features --features 'derive parsing'
-      - run: cargo check ${{env.target}} --no-default-features --features 'derive printing'
-      - run: cargo check ${{env.target}} --no-default-features --features 'proc-macro parsing printing'
-      - run: cargo check ${{env.target}} --no-default-features --features full
-      - run: cargo check ${{env.target}} --no-default-features --features 'full parsing'
-      - run: cargo check ${{env.target}} --no-default-features --features 'full printing'
-      - run: cargo check ${{env.target}} --no-default-features --features 'full parsing printing'
-      - run: cargo check ${{env.target}} --no-default-features --features 'fold visit visit-mut parsing printing'
-      - run: cargo check ${{env.target}} --no-default-features --features 'full fold visit visit-mut parsing printing'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features
+      - run: cargo check ${{env.manifestpath}} ${{env.target}}
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --features full
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --features 'fold visit visit-mut'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --features 'full fold visit visit-mut'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features derive
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features 'derive parsing'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features 'derive printing'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features 'proc-macro parsing printing'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features full
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features 'full parsing'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features 'full printing'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features 'full parsing printing'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features 'fold visit visit-mut parsing printing'
+      - run: cargo check ${{env.manifestpath}} ${{env.target}} --no-default-features --features 'full fold visit visit-mut parsing printing'
       - if: matrix.components == 'rustc-dev'
         run: cargo check --benches --all-features --release
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 keywords = ["macros", "syn"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/syn"
-rust-version = "1.60"
+rust-version = "1.56"
 
 [features]
 default = ["derive", "parsing", "printing", "clone-impls", "proc-macro"]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ contains some APIs that may be useful more generally.
 [`syn::DeriveInput`]: https://docs.rs/syn/2.0/syn/struct.DeriveInput.html
 [parser functions]: https://docs.rs/syn/2.0/syn/parse/index.html
 
-*Version requirement: Syn supports rustc 1.60 and up.*
+*Version requirement: Syn supports rustc 1.56 and up.*
 
 [*Release notes*](https://github.com/dtolnay/syn/releases)
 

--- a/tests/crate/Cargo.toml
+++ b/tests/crate/Cargo.toml
@@ -1,0 +1,26 @@
+[workspace]
+[package]
+name = "syn-test-suite"
+version = "0.0.0"
+authors = ["David Tolnay <dtolnay@gmail.com>"]
+edition = "2021"
+publish = false
+
+[lib]
+path = "test.rs"
+
+[dependencies]
+syn = { path = "../..", default-features = false }
+
+[features]
+default = ["derive", "parsing", "printing", "clone-impls", "proc-macro"]
+derive = ["syn/derive"]
+full = ["syn/full"]
+parsing = ["syn/parsing"]
+printing = ["syn/printing"]
+visit = ["syn/visit"]
+visit-mut = ["syn/visit-mut"]
+fold = ["syn/fold"]
+clone-impls = ["syn/clone-impls"]
+extra-traits = ["syn/extra-traits"]
+proc-macro = ["syn/proc-macro"]

--- a/tests/crate/test.rs
+++ b/tests/crate/test.rs
@@ -1,0 +1,1 @@
+pub use syn::*;


### PR DESCRIPTION
This serves as an alternative to https://github.com/dtolnay/syn/commit/0b2b498fa5d48c4ae78c9dbe6f73423c209d87c8.