### PR TITLE
Support '$' in custom_punctuation macro

### DIFF
--- a/src/custom_punctuation.rs
+++ b/src/custom_punctuation.rs
@@ -245,6 +245,7 @@ macro_rules! custom_punctuation_len {
     ($mode:ident, ^=)    => { 2 };
     ($mode:ident, :)     => { 1 };
     ($mode:ident, ,)     => { 1 };
+    ($mode:ident, $)     => { 1 };
     ($mode:ident, .)     => { 1 };
     ($mode:ident, ..)    => { 2 };
     ($mode:ident, ...)   => { 3 };


### PR DESCRIPTION
Fixes #1609.

This didn't used to work prior to Rust 1.17 &mdash; see the contortions required for `Token![$]` in https://github.com/dtolnay/syn/commit/2ccec118ceb77479e3f7cbd5d79b75ba1b6e098c. But now there is no reason it shouldn't be supported.