### PR TITLE
Remove codegen's dependency on serde_derive

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro2 = { version = "1.0.20", features = ["span-locations"] }
 quote = "1"
 semver = { version = "1", features = ["serde"] }
 serde = "1.0.88"
-serde_derive = "1.0.88"
 serde_json = "1.0.38"
 syn = { version = "2", features = ["derive", "full", "parsing", "printing"], default-features = false }
 syn-codegen = { path = "../json" }

--- a/codegen/src/version.rs
+++ b/codegen/src/version.rs
@@ -1,7 +1,8 @@
 use crate::workspace_path;
 use anyhow::Result;
 use semver::Version;
-use serde_derive::Deserialize;
+use serde::de::{Deserialize, Deserializer, IgnoredAny, MapAccess, Visitor};
+use std::fmt;
 use std::fs;
 
 pub fn get() -> Result<Version> {
@@ -11,12 +12,88 @@ pub fn get() -> Result<Version> {
     Ok(parsed.package.version)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 struct Manifest {
     package: Package,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 struct Package {
     version: Version,
+}
+
+impl<'de> Deserialize<'de> for Manifest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ManifestVisitor;
+
+        impl<'de> Visitor<'de> for ManifestVisitor {
+            type Value = Manifest;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Manifest")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut package = None;
+                while let Some(k) = map.next_key::<String>()? {
+                    if k == "package" {
+                        if package.is_some() {
+                            return Err(serde::de::Error::duplicate_field("package"));
+                        }
+                        package = Some(map.next_value()?);
+                    } else {
+                        map.next_value::<IgnoredAny>()?;
+                    }
+                }
+                let package = package.ok_or_else(|| serde::de::Error::missing_field("package"))?;
+                Ok(Manifest { package })
+            }
+        }
+
+        deserializer.deserialize_struct("Manifest", &["package"], ManifestVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Package {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PackageVisitor;
+
+        impl<'de> Visitor<'de> for PackageVisitor {
+            type Value = Package;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Package")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut version = None;
+                while let Some(k) = map.next_key::<String>()? {
+                    if k == "version" {
+                        if version.is_some() {
+                            return Err(serde::de::Error::duplicate_field("version"));
+                        }
+                        version = Some(map.next_value()?);
+                    } else {
+                        map.next_value::<IgnoredAny>()?;
+                    }
+                }
+                let version = version.ok_or_else(|| serde::de::Error::missing_field("version"))?;
+                Ok(Package { version })
+            }
+        }
+
+        deserializer.deserialize_struct("Package", &["version"], PackageVisitor)
+    }
 }

--- a/codegen/src/version.rs
+++ b/codegen/src/version.rs
@@ -1,99 +1,19 @@
 use crate::workspace_path;
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use semver::Version;
-use serde::de::{Deserialize, Deserializer, IgnoredAny, MapAccess, Visitor};
-use std::fmt;
 use std::fs;
+use toml::Table;
 
 pub fn get() -> Result<Version> {
     let syn_cargo_toml = workspace_path::get("Cargo.toml");
-    let manifest = fs::read_to_string(syn_cargo_toml)?;
-    let parsed: Manifest = toml::from_str(&manifest)?;
-    Ok(parsed.package.version)
-}
-
-#[derive(Debug)]
-struct Manifest {
-    package: Package,
-}
-
-#[derive(Debug)]
-struct Package {
-    version: Version,
-}
-
-impl<'de> Deserialize<'de> for Manifest {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct ManifestVisitor;
-
-        impl<'de> Visitor<'de> for ManifestVisitor {
-            type Value = Manifest;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct Manifest")
-            }
-
-            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
-            where
-                M: MapAccess<'de>,
-            {
-                let mut package = None;
-                while let Some(k) = map.next_key::<String>()? {
-                    if k == "package" {
-                        if package.is_some() {
-                            return Err(serde::de::Error::duplicate_field("package"));
-                        }
-                        package = Some(map.next_value()?);
-                    } else {
-                        map.next_value::<IgnoredAny>()?;
-                    }
-                }
-                let package = package.ok_or_else(|| serde::de::Error::missing_field("package"))?;
-                Ok(Manifest { package })
-            }
-        }
-
-        deserializer.deserialize_struct("Manifest", &["package"], ManifestVisitor)
-    }
-}
-
-impl<'de> Deserialize<'de> for Package {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct PackageVisitor;
-
-        impl<'de> Visitor<'de> for PackageVisitor {
-            type Value = Package;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct Package")
-            }
-
-            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
-            where
-                M: MapAccess<'de>,
-            {
-                let mut version = None;
-                while let Some(k) = map.next_key::<String>()? {
-                    if k == "version" {
-                        if version.is_some() {
-                            return Err(serde::de::Error::duplicate_field("version"));
-                        }
-                        version = Some(map.next_value()?);
-                    } else {
-                        map.next_value::<IgnoredAny>()?;
-                    }
-                }
-                let version = version.ok_or_else(|| serde::de::Error::missing_field("version"))?;
-                Ok(Package { version })
-            }
-        }
-
-        deserializer.deserialize_struct("Package", &["version"], PackageVisitor)
-    }
+    let content = fs::read_to_string(syn_cargo_toml)?;
+    let manifest: Table = toml::from_str(&content)?;
+    manifest
+        .get("package")
+        .context("[package] not found in Cargo.toml")?
+        .get("version")
+        .and_then(toml::Value::as_str)
+        .context("package version not found in Cargo.toml")?
+        .parse()
+        .context("failed to parse package version")
 }


### PR DESCRIPTION
Serde_derive enables syn's "clone-impls" feature, which is based on code that is generated by this codegen code. If syn's codegen depends on serde_derive, that means generated Clone impls need to be manually updated when making syntax tree changes. If codegen can avoid depending on "clone-impls", then the Clone impls can be generated.