### PR TITLE
Support regenerating Clone impls with syntax tree changes

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 
 publish = false # this is an internal crate which should never be published
 
+[features]
+default = ["json"]
+json = ["syn-codegen/serde"]
+
 [dependencies]
 anyhow = "1"
 color-backtrace = "0.6"
@@ -18,7 +22,7 @@ semver = { version = "1", features = ["serde"] }
 serde = "1.0.88"
 serde_json = "1.0.38"
 syn = { version = "2", features = ["derive", "full", "parsing", "printing"], default-features = false }
-syn-codegen = { path = "../json" }
+syn-codegen = { path = "../json", default-features = false }
 toml = "0.8"
 
 [workspace]

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -28,6 +28,7 @@ mod fold;
 mod full;
 mod gen;
 mod hash;
+#[cfg(feature = "json")]
 mod json;
 mod lookup;
 mod operand;
@@ -45,6 +46,7 @@ fn main() -> anyhow::Result<()> {
     debug::generate(&defs)?;
     eq::generate(&defs)?;
     hash::generate(&defs)?;
+    #[cfg(feature = "json")]
     json::generate(&defs)?;
     fold::generate(&defs)?;
     visit::generate(&defs)?;


### PR DESCRIPTION
It takes 2 steps: `cargo run --no-default-features` to regenerate the Clone impls in src/gen/clone.rs, then `cargo run` (which depends on exactly those Clone impls through serde_derive) to regenerate syn.json.