### PR TITLE
Skip doctests in Miri job on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@miri
       - run: cargo miri setup
-      - run: cargo miri test --all-features
+      - run: cargo miri test --all-features ${{github.event_name == 'pull_request' && '--tests' || ''}}
         env:
           MIRIFLAGS: -Zmiri-strict-provenance
 


### PR DESCRIPTION
The Miri job is our slowest CI job. We get good enough coverage for the rustdoc tests in the nightly cron job; they do not also need to be tested in pull requests.