### PR TITLE
Fix maximum allowed \x escape in character literal

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -1372,7 +1372,7 @@ mod value {
                     b'x' => {
                         let (byte, rest) = backslash_x(s);
                         s = rest;
-                        assert!(byte <= 0x80, "Invalid \\x byte in string literal");
+                        assert!(byte <= 0x7F, "Invalid \\x byte in character literal");
                         char::from_u32(u32::from(byte)).unwrap()
                     }
                     b'u' => {


### PR DESCRIPTION
`'\x80'` is not allowed (proc-macro2 already enforces this).

```console
error: out of range hex escape
 --> src/main.rs:2:14
  |
2 |     let _ = '\x80';
  |              ^^^^ must be a character in the range [\x00-\x7f]
```