### PR TITLE
Raise default edition of rust-lang/rust test files to 2021

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -294,7 +294,7 @@ pub fn edition(path: &Path) -> &'static str {
     if path.ends_with("dyn-2015-no-warnings-without-lints.rs") {
         "2015"
     } else {
-        "2018"
+        "2021"
     }
 }
 


### PR DESCRIPTION
Without this, rustc's parser fails to parse files containing C-string literal syntax (https://github.com/dtolnay/syn/issues/1502). For example this file: <https://github.com/rust-lang/rust/blob/1.77.0/src/tools/clippy/tests/ui/needless_raw_string_hashes.rs>. In edition 2018, it fails with this error:

```console
error: unknown character escape: `a`
  --> src/main.rs:13:10
   |
13 |     cr#"\aaa"#;
   |          ^ unknown character escape
   |
   = help: for more information, visit <https://doc.rust-lang.org/reference/tokens.html#literals>
help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
   |
13 |     cr#r"\aaa"#;
   |        ~~~~~~~

error: unknown start of token: \
  --> src/main.rs:19:9
   |
19 |         \a
   |         ^

error[E0765]: unterminated double quote string
  --> src/main.rs:25:19
   |
25 |       r#"hello world"#;
   |  ___________________^
26 | | }
   | |_^

```