### PR TITLE
Take advantage of the IntoIterator for [T; N]

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -280,7 +280,7 @@ impl ErrorMessage {
         };
 
         // ::core::compile_error!($message)
-        TokenStream::from_iter(vec![
+        TokenStream::from_iter([
             TokenTree::Punct({
                 let mut punct = Punct::new(':', Spacing::Joint);
                 punct.set_span(start);
@@ -310,7 +310,7 @@ impl ErrorMessage {
             }),
             TokenTree::Group({
                 let mut group = Group::new(Delimiter::Brace, {
-                    TokenStream::from_iter(vec![TokenTree::Literal({
+                    TokenStream::from_iter([TokenTree::Literal({
                         let mut string = Literal::string(&self.message);
                         string.set_span(end);
                         string

--- a/tests/test_grouping.rs
+++ b/tests/test_grouping.rs
@@ -8,12 +8,12 @@ use syn::Expr;
 
 #[test]
 fn test_grouping() {
-    let tokens: TokenStream = TokenStream::from_iter(vec![
+    let tokens: TokenStream = TokenStream::from_iter([
         TokenTree::Literal(Literal::i32_suffixed(1)),
         TokenTree::Punct(Punct::new('+', Spacing::Alone)),
         TokenTree::Group(Group::new(
             Delimiter::None,
-            TokenStream::from_iter(vec![
+            TokenStream::from_iter([
                 TokenTree::Literal(Literal::i32_suffixed(2)),
                 TokenTree::Punct(Punct::new('+', Spacing::Alone)),
                 TokenTree::Literal(Literal::i32_suffixed(3)),

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -10,7 +10,7 @@ use syn::{Item, ItemTrait};
 #[test]
 fn test_macro_variable_attr() {
     // mimics the token stream corresponding to `$attr fn f() {}`
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Group(Group::new(Delimiter::None, quote! { #[test] })),
         TokenTree::Ident(Ident::new("fn", Span::call_site())),
         TokenTree::Ident(Ident::new("f", Span::call_site())),
@@ -121,7 +121,7 @@ fn test_negative_impl() {
 #[test]
 fn test_macro_variable_impl() {
     // mimics the token stream corresponding to `impl $trait for $ty {}`
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Ident(Ident::new("impl", Span::call_site())),
         TokenTree::Group(Group::new(Delimiter::None, quote!(Trait))),
         TokenTree::Ident(Ident::new("for", Span::call_site())),

--- a/tests/test_lit.rs
+++ b/tests/test_lit.rs
@@ -310,11 +310,11 @@ fn suffix() {
 
 #[test]
 fn test_deep_group_empty() {
-    let tokens = TokenStream::from_iter(vec![TokenTree::Group(Group::new(
+    let tokens = TokenStream::from_iter([TokenTree::Group(Group::new(
         Delimiter::None,
-        TokenStream::from_iter(vec![TokenTree::Group(Group::new(
+        TokenStream::from_iter([TokenTree::Group(Group::new(
             Delimiter::None,
-            TokenStream::from_iter(vec![TokenTree::Literal(Literal::string("hi"))]),
+            TokenStream::from_iter([TokenTree::Literal(Literal::string("hi"))]),
         ))]),
     ))]);
 

--- a/tests/test_parse_buffer.rs
+++ b/tests/test_parse_buffer.rs
@@ -69,11 +69,11 @@ fn trailing_empty_none_group() {
     }
 
     // `+ ( + <Ø Ø> ) <Ø <Ø Ø> Ø>`
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Punct(Punct::new('+', Spacing::Alone)),
         TokenTree::Group(Group::new(
             Delimiter::Parenthesis,
-            TokenStream::from_iter(vec![
+            TokenStream::from_iter([
                 TokenTree::Punct(Punct::new('+', Spacing::Alone)),
                 TokenTree::Group(Group::new(Delimiter::None, TokenStream::new())),
             ]),
@@ -81,7 +81,7 @@ fn trailing_empty_none_group() {
         TokenTree::Group(Group::new(Delimiter::None, TokenStream::new())),
         TokenTree::Group(Group::new(
             Delimiter::None,
-            TokenStream::from_iter(vec![TokenTree::Group(Group::new(
+            TokenStream::from_iter([TokenTree::Group(Group::new(
                 Delimiter::None,
                 TokenStream::new(),
             ))]),

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -48,7 +48,7 @@ fn test_leading_vert() {
 #[test]
 fn test_group() {
     let group = Group::new(Delimiter::None, quote!(Some(_)));
-    let tokens = TokenStream::from_iter(vec![TokenTree::Group(group)]);
+    let tokens = TokenStream::from_iter([TokenTree::Group(group)]);
     let pat = Pat::parse_single.parse2(tokens).unwrap();
 
     snapshot!(pat, @r###"

--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -10,7 +10,7 @@ use syn::{parse_quote, Expr, Type, TypePath};
 #[test]
 fn parse_interpolated_leading_component() {
     // mimics the token stream corresponding to `$mod::rest`
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Group(Group::new(Delimiter::None, quote! { first })),
         TokenTree::Punct(Punct::new(':', Spacing::Joint)),
         TokenTree::Punct(Punct::new(':', Spacing::Alone)),

--- a/tests/test_stmt.rs
+++ b/tests/test_stmt.rs
@@ -58,9 +58,9 @@ fn test_raw_invalid() {
 #[test]
 fn test_none_group() {
     // <Ø async fn f() {} Ø>
-    let tokens = TokenStream::from_iter(vec![TokenTree::Group(Group::new(
+    let tokens = TokenStream::from_iter([TokenTree::Group(Group::new(
         Delimiter::None,
-        TokenStream::from_iter(vec![
+        TokenStream::from_iter([
             TokenTree::Ident(Ident::new("async", Span::call_site())),
             TokenTree::Ident(Ident::new("fn", Span::call_site())),
             TokenTree::Ident(Ident::new("f", Span::call_site())),

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -21,7 +21,7 @@ fn test_mut_self() {
 #[test]
 fn test_macro_variable_type() {
     // mimics the token stream corresponding to `$ty<T>`
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Group(Group::new(Delimiter::None, quote! { ty })),
         TokenTree::Punct(Punct::new('<', Spacing::Alone)),
         TokenTree::Ident(Ident::new("T", Span::call_site())),
@@ -54,7 +54,7 @@ fn test_macro_variable_type() {
     "###);
 
     // mimics the token stream corresponding to `$ty::<T>`
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Group(Group::new(Delimiter::None, quote! { ty })),
         TokenTree::Punct(Punct::new(':', Spacing::Joint)),
         TokenTree::Punct(Punct::new(':', Spacing::Alone)),
@@ -93,7 +93,7 @@ fn test_macro_variable_type() {
 #[test]
 fn test_group_angle_brackets() {
     // mimics the token stream corresponding to `Option<$ty>`
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Ident(Ident::new("Option", Span::call_site())),
         TokenTree::Punct(Punct::new('<', Spacing::Alone)),
         TokenTree::Group(Group::new(Delimiter::None, quote! { Vec<u8> })),
@@ -144,7 +144,7 @@ fn test_group_angle_brackets() {
 #[test]
 fn test_group_colons() {
     // mimics the token stream corresponding to `$ty::Item`
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Group(Group::new(Delimiter::None, quote! { Vec<u8> })),
         TokenTree::Punct(Punct::new(':', Spacing::Joint)),
         TokenTree::Punct(Punct::new(':', Spacing::Alone)),
@@ -180,7 +180,7 @@ fn test_group_colons() {
     }
     "###);
 
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Group(Group::new(Delimiter::None, quote! { [T] })),
         TokenTree::Punct(Punct::new(':', Spacing::Joint)),
         TokenTree::Punct(Punct::new(':', Spacing::Alone)),

--- a/tests/test_visibility.rs
+++ b/tests/test_visibility.rs
@@ -103,12 +103,12 @@ fn test_junk_after_in() {
 #[test]
 fn test_inherited_vis_named_field() {
     // mimics `struct S { $vis $field: () }` where $vis is empty
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Ident(Ident::new("struct", Span::call_site())),
         TokenTree::Ident(Ident::new("S", Span::call_site())),
         TokenTree::Group(Group::new(
             Delimiter::Brace,
-            TokenStream::from_iter(vec![
+            TokenStream::from_iter([
                 TokenTree::Group(Group::new(Delimiter::None, TokenStream::new())),
                 TokenTree::Group(Group::new(Delimiter::None, quote!(f))),
                 TokenTree::Punct(Punct::new(':', Spacing::Alone)),
@@ -141,12 +141,12 @@ fn test_inherited_vis_named_field() {
 #[test]
 fn test_inherited_vis_unnamed_field() {
     // mimics `struct S($vis $ty);` where $vis is empty
-    let tokens = TokenStream::from_iter(vec![
+    let tokens = TokenStream::from_iter([
         TokenTree::Ident(Ident::new("struct", Span::call_site())),
         TokenTree::Ident(Ident::new("S", Span::call_site())),
         TokenTree::Group(Group::new(
             Delimiter::Parenthesis,
-            TokenStream::from_iter(vec![
+            TokenStream::from_iter([
                 TokenTree::Group(Group::new(Delimiter::None, TokenStream::new())),
                 TokenTree::Group(Group::new(Delimiter::None, quote!(str))),
             ]),


### PR DESCRIPTION
The IntoIterator impl for arrays was stabilized in Rust 1.53, whereas these days syn requires 1.60+.