### PR TITLE
Check for legal binding name in the ident of Pat::Ident

### DIFF
--- a/src/pat.rs
+++ b/src/pat.rs
@@ -470,7 +470,13 @@ pub(crate) mod parsing {
             attrs: Vec::new(),
             by_ref: input.parse()?,
             mutability: input.parse()?,
-            ident: input.call(Ident::parse_any)?,
+            ident: {
+                if input.peek(Token![self]) {
+                    input.call(Ident::parse_any)?
+                } else {
+                    input.parse()?
+                }
+            },
             subpat: {
                 if input.peek(Token![@]) {
                     let at_token: Token![@] = input.parse()?;


### PR DESCRIPTION
The `Ident::parse_any` in this code is here to support https://github.com/dtolnay/syn/issues/517 in syn 0.15. At the time, the function argument in `fn f(self: T)` was parsed as https://docs.rs/syn/0.15.44/syn/enum.FnArg.html#variant.Captured in the form of a Pat, colon token, and Type. The only other variants of `FnArg` held a Pat only, a Type only, `self`, `mut self`, `&self`, or `&mut self`, none of which are suitable for the form `self: T`. So `self` needed to be handled as some kind of Pat, and Pat::Ident was selected. (It might alternatively have been Pat::Path.)

These days in syn 2, the function argument in `fn f(self: T)` is parsed as https://docs.rs/syn/2/syn/struct.Receiver.html but `self` continues to be considered a legal Pat::Ident. Keywords other than `self` should not be, however. For example:

```rust
if let Some(ref mut extern) = x {}
```