### PR TITLE
Make ParseBuffer unwindsafe

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -197,6 +197,7 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Deref;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -282,6 +283,9 @@ impl<'a> Debug for ParseBuffer<'a> {
         Debug::fmt(&self.cursor().token_stream(), f)
     }
 }
+
+impl<'a> UnwindSafe for ParseBuffer<'a> {}
+impl<'a> RefUnwindSafe for ParseBuffer<'a> {}
 
 /// Cursor state associated with speculative parsing.
 ///

--- a/tests/test_parse_buffer.rs
+++ b/tests/test_parse_buffer.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::non_ascii_literal)]
 
-use proc_macro2::{Delimiter, Group, Punct, Spacing, TokenStream, TokenTree};
+use proc_macro2::{Delimiter, Group, Ident, Punct, Spacing, TokenStream, TokenTree};
+use std::panic;
 use syn::parse::discouraged::Speculative as _;
 use syn::parse::{Parse, ParseStream, Parser, Result};
 use syn::{parenthesized, Token};
@@ -89,4 +90,14 @@ fn trailing_empty_none_group() {
     ]);
 
     parse.parse2(tokens).unwrap();
+}
+
+#[test]
+fn test_unwind_safe() {
+    fn parse(input: ParseStream) -> Result<Ident> {
+        let thread_result = panic::catch_unwind(|| input.parse());
+        thread_result.unwrap()
+    }
+
+    parse.parse_str("throw").unwrap();
 }


### PR DESCRIPTION
ParseBuffer contains interior mutability, but there isn't any way to get it into some invalid state by panicking in user code.