### PR TITLE
Create a module for expr classification functions

### DIFF
--- a/src/classify.rs
+++ b/src/classify.rs
@@ -1,0 +1,45 @@
+use crate::expr::Expr;
+
+pub(crate) fn requires_terminator(expr: &Expr) -> bool {
+    // see https://github.com/rust-lang/rust/blob/9a19e7604/compiler/rustc_ast/src/util/classify.rs#L7-L26
+    match expr {
+        Expr::If(_)
+        | Expr::Match(_)
+        | Expr::Block(_) | Expr::Unsafe(_) // both under ExprKind::Block in rustc
+        | Expr::While(_)
+        | Expr::Loop(_)
+        | Expr::ForLoop(_)
+        | Expr::TryBlock(_)
+        | Expr::Const(_) => false,
+        Expr::Array(_)
+        | Expr::Assign(_)
+        | Expr::Async(_)
+        | Expr::Await(_)
+        | Expr::Binary(_)
+        | Expr::Break(_)
+        | Expr::Call(_)
+        | Expr::Cast(_)
+        | Expr::Closure(_)
+        | Expr::Continue(_)
+        | Expr::Field(_)
+        | Expr::Group(_)
+        | Expr::Index(_)
+        | Expr::Infer(_)
+        | Expr::Let(_)
+        | Expr::Lit(_)
+        | Expr::Macro(_)
+        | Expr::MethodCall(_)
+        | Expr::Paren(_)
+        | Expr::Path(_)
+        | Expr::Range(_)
+        | Expr::Reference(_)
+        | Expr::Repeat(_)
+        | Expr::Return(_)
+        | Expr::Struct(_)
+        | Expr::Try(_)
+        | Expr::Tuple(_)
+        | Expr::Unary(_)
+        | Expr::Yield(_)
+        | Expr::Verbatim(_) => true
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,10 @@ mod bigint;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parsing")))]
 pub mod buffer;
 
+#[cfg(any(feature = "parsing", feature = "printing"))]
+#[cfg(feature = "full")]
+mod classify;
+
 mod custom_keyword;
 
 mod custom_punctuation;

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -80,8 +80,9 @@ ast_struct! {
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::Attribute;
+    use crate::classify;
     use crate::error::Result;
-    use crate::expr::{self, Expr, ExprBlock, ExprMacro};
+    use crate::expr::{Expr, ExprBlock, ExprMacro};
     use crate::ident::Ident;
     use crate::item;
     use crate::mac::{self, Macro};
@@ -158,7 +159,7 @@ pub(crate) mod parsing {
                 }
                 let stmt = parse_stmt(input, AllowNoSemi(true))?;
                 let requires_semicolon = match &stmt {
-                    Stmt::Expr(stmt, None) => expr::requires_terminator(stmt),
+                    Stmt::Expr(stmt, None) => classify::requires_terminator(stmt),
                     Stmt::Macro(stmt) => {
                         stmt.semi_token.is_none() && !stmt.mac.delimiter.is_brace()
                     }
@@ -400,7 +401,7 @@ pub(crate) mod parsing {
 
         if semi_token.is_some() {
             Ok(Stmt::Expr(e, semi_token))
-        } else if allow_nosemi.0 || !expr::requires_terminator(&e) {
+        } else if allow_nosemi.0 || !classify::requires_terminator(&e) {
             Ok(Stmt::Expr(e, None))
         } else {
             Err(input.error("expected semicolon"))


### PR DESCRIPTION
This will eventually hold all 3 of the functions from <https://github.com/rust-lang/rust/pull/119427>'s compiler/rustc_ast/src/util/classify.rs:

- `expr_requires_semi_to_be_stmt`
- `expr_requires_comma_to_be_match_arm`
- `expr_trailing_brace`