### PR TITLE
Extract Precedence to its own module

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1100,81 +1100,6 @@ ast_enum! {
 }
 
 #[cfg(feature = "parsing")]
-mod precedence {
-    use super::BinOp;
-    use std::cmp::Ordering;
-
-    pub(super) enum Precedence {
-        Any,
-        Assign,
-        Range,
-        Or,
-        And,
-        Compare,
-        BitOr,
-        BitXor,
-        BitAnd,
-        Shift,
-        Arithmetic,
-        Term,
-        Cast,
-    }
-
-    impl Precedence {
-        pub(super) fn of(op: &BinOp) -> Self {
-            match op {
-                BinOp::Add(_) | BinOp::Sub(_) => Precedence::Arithmetic,
-                BinOp::Mul(_) | BinOp::Div(_) | BinOp::Rem(_) => Precedence::Term,
-                BinOp::And(_) => Precedence::And,
-                BinOp::Or(_) => Precedence::Or,
-                BinOp::BitXor(_) => Precedence::BitXor,
-                BinOp::BitAnd(_) => Precedence::BitAnd,
-                BinOp::BitOr(_) => Precedence::BitOr,
-                BinOp::Shl(_) | BinOp::Shr(_) => Precedence::Shift,
-                BinOp::Eq(_)
-                | BinOp::Lt(_)
-                | BinOp::Le(_)
-                | BinOp::Ne(_)
-                | BinOp::Ge(_)
-                | BinOp::Gt(_) => Precedence::Compare,
-                BinOp::AddAssign(_)
-                | BinOp::SubAssign(_)
-                | BinOp::MulAssign(_)
-                | BinOp::DivAssign(_)
-                | BinOp::RemAssign(_)
-                | BinOp::BitXorAssign(_)
-                | BinOp::BitAndAssign(_)
-                | BinOp::BitOrAssign(_)
-                | BinOp::ShlAssign(_)
-                | BinOp::ShrAssign(_) => Precedence::Assign,
-            }
-        }
-    }
-
-    impl Copy for Precedence {}
-
-    impl Clone for Precedence {
-        fn clone(&self) -> Self {
-            *self
-        }
-    }
-
-    impl PartialEq for Precedence {
-        fn eq(&self, other: &Self) -> bool {
-            *self as u8 == *other as u8
-        }
-    }
-
-    impl PartialOrd for Precedence {
-        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-            let this = *self as u8;
-            let other = *other as u8;
-            Some(this.cmp(&other))
-        }
-    }
-}
-
-#[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     #[cfg(feature = "full")]
     use crate::attr;
@@ -1182,7 +1107,6 @@ pub(crate) mod parsing {
     #[cfg(feature = "full")]
     use crate::classify;
     use crate::error::{Error, Result};
-    use crate::expr::precedence::Precedence;
     #[cfg(feature = "full")]
     use crate::expr::{
         Arm, ExprArray, ExprAssign, ExprAsync, ExprAwait, ExprBlock, ExprBreak, ExprClosure,
@@ -1212,6 +1136,7 @@ pub(crate) mod parsing {
     #[cfg(feature = "full")]
     use crate::pat::{Pat, PatType};
     use crate::path::{self, AngleBracketedGenericArguments, Path, QSelf};
+    use crate::precedence::Precedence;
     use crate::punctuated::Punctuated;
     #[cfg(feature = "full")]
     use crate::stmt::Block;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,6 +477,9 @@ pub use crate::path::{
     ParenthesizedGenericArguments, Path, PathArguments, PathSegment, QSelf,
 };
 
+#[cfg(all(any(feature = "full", feature = "derive"), feature = "parsing"))]
+mod precedence;
+
 #[cfg(all(any(feature = "full", feature = "derive"), feature = "printing"))]
 mod print;
 

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -1,0 +1,71 @@
+use crate::op::BinOp;
+use std::cmp::Ordering;
+
+pub(crate) enum Precedence {
+    Any,
+    Assign,
+    Range,
+    Or,
+    And,
+    Compare,
+    BitOr,
+    BitXor,
+    BitAnd,
+    Shift,
+    Arithmetic,
+    Term,
+    Cast,
+}
+
+impl Precedence {
+    pub(crate) fn of(op: &BinOp) -> Self {
+        match op {
+            BinOp::Add(_) | BinOp::Sub(_) => Precedence::Arithmetic,
+            BinOp::Mul(_) | BinOp::Div(_) | BinOp::Rem(_) => Precedence::Term,
+            BinOp::And(_) => Precedence::And,
+            BinOp::Or(_) => Precedence::Or,
+            BinOp::BitXor(_) => Precedence::BitXor,
+            BinOp::BitAnd(_) => Precedence::BitAnd,
+            BinOp::BitOr(_) => Precedence::BitOr,
+            BinOp::Shl(_) | BinOp::Shr(_) => Precedence::Shift,
+            BinOp::Eq(_)
+            | BinOp::Lt(_)
+            | BinOp::Le(_)
+            | BinOp::Ne(_)
+            | BinOp::Ge(_)
+            | BinOp::Gt(_) => Precedence::Compare,
+            BinOp::AddAssign(_)
+            | BinOp::SubAssign(_)
+            | BinOp::MulAssign(_)
+            | BinOp::DivAssign(_)
+            | BinOp::RemAssign(_)
+            | BinOp::BitXorAssign(_)
+            | BinOp::BitAndAssign(_)
+            | BinOp::BitOrAssign(_)
+            | BinOp::ShlAssign(_)
+            | BinOp::ShrAssign(_) => Precedence::Assign,
+        }
+    }
+}
+
+impl Copy for Precedence {}
+
+impl Clone for Precedence {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl PartialEq for Precedence {
+    fn eq(&self, other: &Self) -> bool {
+        *self as u8 == *other as u8
+    }
+}
+
+impl PartialOrd for Precedence {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let this = *self as u8;
+        let other = *other as u8;
+        Some(this.cmp(&other))
+    }
+}


### PR DESCRIPTION
As part of porting https://github.com/rust-lang/rust/pull/124191 to syn, a new `fixup` module is going to need access to some new precedence-related computations. Having a module dedicated to `precedence` will serve as a good location to have these.