### PR TITLE
Allow braced structs when parsing ExprLet

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2117,7 +2117,7 @@ pub(crate) mod parsing {
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     impl Parse for ExprLet {
         fn parse(input: ParseStream) -> Result<Self> {
-            let allow_struct = AllowStruct(false);
+            let allow_struct = AllowStruct(true);
             expr_let(input, allow_struct)
         }
     }


### PR DESCRIPTION
`let` is not valid as an expression on its own:

```rust
macro_rules! expr {
    ($e:expr) => {};
}
expr!(let _ = Struct {});
```

```console
error: no rules expected the token `let`
 --> src/lib.rs:4:7
  |
1 | macro_rules! expr {
  | ----------------- when calling this macro
...
4 | expr!(let _ = Struct {});
  |       ^^^ no rules expected this token in macro call
```

It is only allowed in combination with something like `if let …` or `while let …` or `if foo() && let …`, and none of those allow `{` in the `let` expression.

But `match … { … if let … => … }` (match guards) does allow it.

Closes #1670.