### PR TITLE
Prune dev-dependencies when testing with miri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,15 +42,17 @@ unicode-ident = "1"
 [dev-dependencies]
 anyhow = "1"
 automod = "1"
-flate2 = "1"
 insta = "1"
-rayon = "1"
 ref-cast = "1"
-reqwest = { version = "0.12", features = ["blocking"] }
 rustversion = "1"
 syn-test-suite = { version = "0", path = "tests/features" }
-tar = "0.4.16"
 termcolor = "1"
+
+[target.'cfg(not(miri))'.dev-dependencies]
+flate2 = "1"
+rayon = "1"
+reqwest = { version = "0.12", features = ["blocking"] }
+tar = "0.4.16"
 walkdir = "2.3.2"
 
 [lib]


### PR DESCRIPTION
This enables cross-compilation of tests with Miri, which previously failed due to the transitive dependency on `openssl-sys` through `reqwest`.

```console
$ cargo miri test --all-features --target i686-unknown-linux-gnu --test test_parse_buffer
error: failed to run custom build command for `openssl-sys v0.9.102`

Caused by:
  process didn't exit successfully: `target/miri/debug/build/openssl-sys-908aa9a24708f521/build-script-main` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=I686_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
  I686_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
  OPENSSL_LIB_DIR unset
  cargo:rerun-if-env-changed=I686_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
  I686_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
  OPENSSL_INCLUDE_DIR unset
  cargo:rerun-if-env-changed=I686_UNKNOWN_LINUX_GNU_OPENSSL_DIR
  I686_UNKNOWN_LINUX_GNU_OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_DIR
  OPENSSL_DIR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_i686-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_i686_unknown_linux_gnu
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_i686-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_i686_unknown_linux_gnu
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_i686-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_i686_unknown_linux_gnu
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR
  run pkg_config fail: pkg-config has not been configured to support cross-compilation.

  Install a sysroot for the target platform and configure it via
  PKG_CONFIG_SYSROOT_DIR and PKG_CONFIG_PATH, or install a
  cross-compiling wrapper for pkg-config and set it via
  PKG_CONFIG environment variable.

  --- stderr
  thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/openssl-sys-0.9.102/build/find_normal.rs:190:5:

  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = i686-unknown-linux-gnu
  openssl-sys = 0.9.102
```