### PR TITLE
Use span from the correct Group token when parsing delimited content

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -425,10 +425,3 @@ pub(crate) fn open_span_of_group(cursor: Cursor) -> Span {
         _ => cursor.span(),
     }
 }
-
-pub(crate) fn close_span_of_group(cursor: Cursor) -> Span {
-    match cursor.entry() {
-        Entry::Group(group, _) => group.span_close(),
-        _ => cursor.span(),
-    }
-}

--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -212,7 +212,7 @@ impl<'a> AnyDelimiter for ParseBuffer<'a> {
     fn parse_any_delimiter(&self) -> Result<(Delimiter, DelimSpan, ParseBuffer)> {
         self.step(|cursor| {
             if let Some((content, delimiter, span, rest)) = cursor.any_group() {
-                let scope = crate::buffer::close_span_of_group(*cursor);
+                let scope = span.close();
                 let nested = crate::parse::advance_step_cursor(cursor, content);
                 let unexpected = crate::parse::get_unexpected(self);
                 let content = crate::parse::new_parse_buffer(scope, nested, unexpected);

--- a/src/group.rs
+++ b/src/group.rs
@@ -82,7 +82,7 @@ fn parse_delimited<'a>(
 ) -> Result<(DelimSpan, ParseBuffer<'a>)> {
     input.step(|cursor| {
         if let Some((content, span, rest)) = cursor.group(delimiter) {
-            let scope = crate::buffer::close_span_of_group(*cursor);
+            let scope = span.close();
             let nested = crate::parse::advance_step_cursor(cursor, content);
             let unexpected = crate::parse::get_unexpected(input);
             let content = crate::parse::new_parse_buffer(scope, nested, unexpected);


### PR DESCRIPTION
Fixes #1678.

The original implementation using `close_span_of_group` is significantly older than #1393, but as of the conversion to `DelimSpan`, this case is easy to handle correctly.