### PR TITLE
Make LitCStr peekable

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -98,7 +98,7 @@ use crate::error::Result;
 #[cfg(feature = "parsing")]
 use crate::lifetime::Lifetime;
 #[cfg(feature = "parsing")]
-use crate::lit::{Lit, LitBool, LitByte, LitByteStr, LitChar, LitFloat, LitInt, LitStr};
+use crate::lit::{Lit, LitBool, LitByte, LitByteStr, LitCStr, LitChar, LitFloat, LitInt, LitStr};
 #[cfg(feature = "parsing")]
 use crate::parse::{Parse, ParseStream};
 use crate::span::IntoSpans;
@@ -199,6 +199,7 @@ impl_token!("lifetime" Lifetime);
 impl_token!("literal" Lit);
 impl_token!("string literal" LitStr);
 impl_token!("byte string literal" LitByteStr);
+impl_token!("C-string literal" LitCStr);
 impl_token!("byte literal" LitByte);
 impl_token!("character literal" LitChar);
 impl_token!("integer literal" LitInt);


### PR DESCRIPTION
Previously `input.peek(syn::LitStr)` worked but `input.peek(syn::LitCStr)` would fail to compile.

```console
error[E0277]: the trait bound `LitCStr: CustomToken` is not satisfied
   --> src/lib.rs:7:19
    |
7   |     if input.peek(syn::LitCStr) {
    |              ---- ^^^^^^^^^^^^ the trait `CustomToken` is not implemented for `LitCStr`, which is required by `fn(syn::lookahead::TokenMarker) -> LitCStr {LitCStr}: Peek`
    |              |
    |              required by a bound introduced by this call
    |
    = help: the following other types implement trait `CustomToken`:
              syn::expr::parsing::kw::builtin
              syn::expr::parsing::kw::raw
              syn::ext::private::IdentAny
    = note: required for `LitCStr` to implement `Token`
    = note: required for `fn(syn::lookahead::TokenMarker) -> LitCStr {LitCStr}` to implement `Peek`
note: required by a bound in `ParseBuffer::<'a>::peek`
   --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/syn-2.0.66/src/parse.rs:580:20
    |
580 |     pub fn peek<T: Peek>(&self, token: T) -> bool {
    |                    ^^^^ required by this bound in `ParseBuffer::<'a>::peek`
```