### PR TITLE
List peekable token types in documentation of Peek trait

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -4,7 +4,6 @@ use crate::buffer::Cursor;
 use crate::error::Result;
 use crate::parse::ParseStream;
 use crate::parse::Peek;
-use crate::sealed::lookahead;
 use crate::token::CustomToken;
 use proc_macro2::Ident;
 
@@ -115,7 +114,8 @@ impl CustomToken for private::IdentAny {
     }
 }
 
-impl lookahead::Sealed for private::PeekFn {}
+#[cfg(not(docsrs))]
+impl crate::sealed::lookahead::Sealed for private::PeekFn {}
 
 mod private {
     use proc_macro2::Ident;

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "parsing")]
 use crate::lookahead;
+#[cfg(all(feature = "parsing", docsrs))]
+use crate::lookahead::Peek;
 
 pub use proc_macro2::Ident;
 
@@ -10,6 +12,11 @@ pub_if_not_doc! {
     pub fn Ident(marker: lookahead::TokenMarker) -> Ident {
         match marker {}
     }
+}
+
+#[cfg(all(feature = "parsing", docsrs))]
+impl Peek for Ident {
+    type Token = Self;
 }
 
 macro_rules! ident_from_token {

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -120,6 +120,11 @@ pub_if_not_doc! {
     }
 }
 
+#[cfg(all(feature = "parsing", docsrs))]
+impl lookahead::Peek for Lifetime {
+    type Token = Self;
+}
+
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::error::Result;

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -807,6 +807,11 @@ macro_rules! lit_extra_traits {
                 match marker {}
             }
         }
+
+        #[cfg(all(feature = "parsing", docsrs))]
+        impl lookahead::Peek for $ty {
+            type Token = Self;
+        }
     };
 }
 
@@ -825,6 +830,11 @@ pub_if_not_doc! {
     pub fn LitBool(marker: lookahead::TokenMarker) -> LitBool {
         match marker {}
     }
+}
+
+#[cfg(all(feature = "parsing", docsrs))]
+impl lookahead::Peek for LitBool {
+    type Token = Self;
 }
 
 /// The style of a string literal, either plain quoted or a raw string like
@@ -846,6 +856,11 @@ pub_if_not_doc! {
     pub fn Lit(marker: lookahead::TokenMarker) -> Lit {
         match marker {}
     }
+}
+
+#[cfg(all(feature = "parsing", docsrs))]
+impl lookahead::Peek for Lit {
+    type Token = Self;
 }
 
 #[cfg(feature = "parsing")]

--- a/src/lookahead.rs
+++ b/src/lookahead.rs
@@ -162,4 +162,5 @@ impl<S> IntoSpans<S> for TokenMarker {
     }
 }
 
+#[cfg(not(docsrs))]
 impl<F: Copy + FnOnce(TokenMarker) -> T, T: Token> Sealed for F {}

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,4 +1,11 @@
 #[cfg(feature = "parsing")]
 pub(crate) mod lookahead {
+    #[cfg(not(docsrs))]
     pub trait Sealed: Copy {}
+
+    #[cfg(docsrs)]
+    pub trait Sealed {}
+
+    #[cfg(docsrs)]
+    impl<T> Sealed for T {}
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -264,6 +264,11 @@ macro_rules! define_keywords {
                 }
             }
 
+            #[cfg(all(feature = "parsing", docsrs))]
+            impl crate::lookahead::Peek for $name {
+                type Token = Self;
+            }
+
             impl std::default::Default for $name {
                 fn default() -> Self {
                     $name {
@@ -391,6 +396,11 @@ macro_rules! define_punctuation_structs {
                 }
             }
 
+            #[cfg(all(feature = "parsing", docsrs))]
+            impl crate::lookahead::Peek for $name {
+                type Token = Self;
+            }
+
             impl std::default::Default for $name {
                 fn default() -> Self {
                     $name {
@@ -498,6 +508,11 @@ macro_rules! define_delimiters {
                 $name {
                     span: span.into_spans(),
                 }
+            }
+
+            #[cfg(all(feature = "parsing", docsrs))]
+            impl crate::lookahead::Peek for $name {
+                type Token = Self;
             }
 
             impl std::default::Default for $name {


### PR DESCRIPTION
#### Before: <img src="https://github.com/dtolnay/syn/assets/1940490/63c00ac7-29b0-4cc1-a86b-ee6d031fa39b">


#### After: <img src="https://github.com/dtolnay/syn/assets/1940490/f38a9fa3-8258-42e0-b17a-f12ee82b7544">

