### PR TITLE
Raise required compiler to rust 1.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, 1.63.0, 1.60.0]
+        rust: [stable, beta, 1.63.0, 1.61.0]
         include:
           - rust: nightly
             components: rustc-dev
@@ -77,7 +77,7 @@ jobs:
       - run: cargo check ${{env.target}} --no-default-features --features 'full fold visit visit-mut parsing printing'
       - if: matrix.components == 'rustc-dev'
         run: cargo check --benches --all-features --release
-      - if: matrix.rust != '1.60.0'
+      - if: matrix.rust != '1.61.0'
         run: cargo check ${{env.target}} --manifest-path json/Cargo.toml --no-default-features
 
   examples:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 keywords = ["macros", "syn"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/syn"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [features]
 default = ["derive", "parsing", "printing", "clone-impls", "proc-macro"]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ contains some APIs that may be useful more generally.
 [`syn::DeriveInput`]: https://docs.rs/syn/2.0/syn/struct.DeriveInput.html
 [parser functions]: https://docs.rs/syn/2.0/syn/parse/index.html
 
-*Version requirement: Syn supports rustc 1.60 and up.*
+*Version requirement: Syn supports rustc 1.61 and up.*
 
 [*Release notes*](https://github.com/dtolnay/syn/releases)
 


### PR DESCRIPTION
I need this in an upcoming PR for access to `Vec::retain_mut`.