### PR TITLE
track-caller in quote_spanned!

### DIFF
--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -113,6 +113,7 @@ use proc_macro2::TokenStream;
 
 // Not public API.
 #[doc(hidden)]
+#[track_caller]
 pub fn parse<T: ParseQuote>(token_stream: TokenStream) -> T {
     let parser = T::parse;
     match parser.parse2(token_stream) {


### PR DESCRIPTION
When `parse_quote!` fails, show the location in user crate, not in `syn`.