### PR TITLE
Parenthesize closures and jumps which are not rightmost subexpressions

### DIFF
--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -122,18 +122,6 @@ impl Precedence {
             Expr::Closure(_) => unreachable!(),
         }
     }
-
-    #[cfg(feature = "printing")]
-    pub(crate) fn of_rhs(e: &Expr) -> Self {
-        match e {
-            Expr::Break(_) | Expr::Closure(_) | Expr::Return(_) | Expr::Yield(_) => {
-                Precedence::Prefix
-            }
-            #[cfg(feature = "full")]
-            Expr::Range(e) if e.start.is_none() => Precedence::Prefix,
-            _ => Precedence::of(e),
-        }
-    }
 }
 
 impl Copy for Precedence {}

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -673,6 +673,7 @@ fn test_fixup() {
         quote! { if let _ = (a && b) && c {} },
         quote! { if let _ = (S {}) {} },
         quote! { break ('a: loop { break 'a 1 } + 1) },
+        quote! { a + (|| b) + c },
     ] {
         let original: Expr = syn::parse2(tokens).unwrap();
 


### PR DESCRIPTION
Previously, in `$a + 1` where $a is something like `1 + || 1` or `1 + return 1` or `1 + break 1` or `1 + ..=1`, the middle expression was not being adequately parenthesized to  preserve its precedence relative to the trailing `+ 1`.