### PR TITLE
Improve precision of jump parentheses when next token cannot begin expr

### DIFF
--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -675,7 +675,8 @@ fn test_fixup() {
         quote! { break ('a: loop { break 'a 1 } + 1) },
         quote! { a + (|| b) + c },
         quote! { if let _ = ((break) - 1 || true) {} },
-        quote! { if let _ = ((break) + 1 || true) {} },
+        quote! { if let _ = (break + 1 || true) {} },
+        quote! { (break)() },
     ] {
         let original: Expr = syn::parse2(tokens).unwrap();
 

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -674,6 +674,8 @@ fn test_fixup() {
         quote! { if let _ = (S {}) {} },
         quote! { break ('a: loop { break 'a 1 } + 1) },
         quote! { a + (|| b) + c },
+        quote! { if let _ = ((break) - 1 || true) {} },
+        quote! { if let _ = ((break) + 1 || true) {} },
     ] {
         let original: Expr = syn::parse2(tokens).unwrap();
 


### PR DESCRIPTION
Previously syn would forcibly put parentheses when printing something like `(break) + 1` or `(return) + 1`. Although parentheses are required in `(break) - 1` and `(return) - 1`, they should not be required when the next token following the valueless jump is not a legal first token of an expression.