### PR TITLE
Parenthesize ranges on left-hand side of assignment operator

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3157,7 +3157,7 @@ pub(crate) mod printing {
         outer_attrs_to_tokens(&e.attrs, tokens);
         print_subexpression(
             &e.left,
-            Precedence::of(&e.left) <= Precedence::Assign,
+            Precedence::of(&e.left) <= Precedence::Range,
             tokens,
             fixup.leftmost_subexpression(),
         );
@@ -3247,7 +3247,7 @@ pub(crate) mod printing {
 
         let binop_prec = Precedence::of_binop(&e.op);
         let (mut left_needs_group, right_needs_group) = if let Precedence::Assign = binop_prec {
-            (left_prec <= binop_prec, right_prec < binop_prec)
+            (left_prec <= Precedence::Range, right_prec < binop_prec)
         } else {
             (left_prec < binop_prec, right_prec <= binop_prec)
         };

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -677,6 +677,8 @@ fn test_fixup() {
         quote! { if let _ = ((break) - 1 || true) {} },
         quote! { if let _ = (break + 1 || true) {} },
         quote! { (break)() },
+        quote! { (..) = () },
+        quote! { (..) += () },
     ] {
         let original: Expr = syn::parse2(tokens).unwrap();
 


### PR DESCRIPTION
Unparenthesized ranges are legal on the right of an assignment, but not on the left of an assignment.

```console
error: expected one of `;` or `}`, found `=`
 --> src/main.rs:3:12
  |
3 |         .. = true;
  |            ^ expected one of `;` or `}`

error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `=`
 --> src/main.rs:6:14
  |
6 |         a..b = true;
  |              ^ expected one of 8 possible tokens
```