### PR TITLE
Parenthesize chained comparison on both sides

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3246,10 +3246,10 @@ pub(crate) mod printing {
         );
 
         let binop_prec = Precedence::of_binop(&e.op);
-        let (mut left_needs_group, right_needs_group) = if let Precedence::Assign = binop_prec {
-            (left_prec <= Precedence::Range, right_prec < binop_prec)
-        } else {
-            (left_prec < binop_prec, right_prec <= binop_prec)
+        let (mut left_needs_group, right_needs_group) = match binop_prec {
+            Precedence::Assign => (left_prec <= Precedence::Range, right_prec < binop_prec),
+            Precedence::Compare => (left_prec <= binop_prec, right_prec <= binop_prec),
+            _ => (left_prec < binop_prec, right_prec <= binop_prec),
         };
 
         // These cases require parenthesization independently of precedence.

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -679,6 +679,7 @@ fn test_fixup() {
         quote! { (break)() },
         quote! { (..) = () },
         quote! { (..) += () },
+        quote! { (1 < 2) == (3 < 4) },
     ] {
         let original: Expr = syn::parse2(tokens).unwrap();
 


### PR DESCRIPTION
`a < b < c` is not valid syntax. Depending on whether the inner comparison is on the left or right of the outer one, syn needs to insert parentheses to print either `(a < b) < c` or `a < (b < c)`.