### PR TITLE
Parenthesize leading Expr::Let in statement

### DIFF
--- a/src/fixup.rs
+++ b/src/fixup.rs
@@ -221,6 +221,7 @@ impl FixupContext {
     /// examples.
     pub fn would_cause_statement_boundary(self, expr: &Expr) -> bool {
         (self.leftmost_subexpression_in_stmt && !classify::requires_semi_to_be_stmt(expr))
+            || ((self.stmt || self.leftmost_subexpression_in_stmt) && matches!(expr, Expr::Let(_)))
             || (self.leftmost_subexpression_in_match_arm
                 && !classify::requires_comma_to_be_match_arm(expr))
     }

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -680,6 +680,7 @@ fn test_fixup() {
         quote! { (..) = () },
         quote! { (..) += () },
         quote! { (1 < 2) == (3 < 4) },
+        quote! { { (let _ = ()) } },
     ] {
         let original: Expr = syn::parse2(tokens).unwrap();
 


### PR DESCRIPTION
Printing Expr::Let at the start of a statement would cause it to be interpreted as Stmt::Local. This PR causes parentheses to be inserted in that scenario to preserve the Expr::Let.