### PR TITLE
Enable expression fixups in "derive" mode

### DIFF
--- a/src/classify.rs
+++ b/src/classify.rs
@@ -1,11 +1,19 @@
+#[cfg(feature = "full")]
 use crate::expr::Expr;
+#[cfg(any(feature = "printing", feature = "full"))]
 use crate::generics::TypeParamBound;
+#[cfg(any(feature = "printing", feature = "full"))]
 use crate::path::{Path, PathArguments};
+#[cfg(any(feature = "printing", feature = "full"))]
 use crate::punctuated::Punctuated;
+#[cfg(any(feature = "printing", feature = "full"))]
 use crate::ty::{ReturnType, Type};
+#[cfg(feature = "full")]
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
+#[cfg(any(feature = "printing", feature = "full"))]
 use std::ops::ControlFlow;
 
+#[cfg(feature = "full")]
 pub(crate) fn requires_semi_to_be_stmt(expr: &Expr) -> bool {
     match expr {
         Expr::Macro(expr) => !expr.mac.delimiter.is_brace(),
@@ -13,6 +21,7 @@ pub(crate) fn requires_semi_to_be_stmt(expr: &Expr) -> bool {
     }
 }
 
+#[cfg(feature = "full")]
 pub(crate) fn requires_comma_to_be_match_arm(expr: &Expr) -> bool {
     match expr {
         Expr::If(_)
@@ -57,7 +66,7 @@ pub(crate) fn requires_comma_to_be_match_arm(expr: &Expr) -> bool {
     }
 }
 
-#[cfg(feature = "printing")]
+#[cfg(all(feature = "printing", feature = "full"))]
 pub(crate) fn confusable_with_adjacent_block(mut expr: &Expr) -> bool {
     let mut stack = Vec::new();
 
@@ -199,7 +208,7 @@ pub(crate) fn trailing_unparameterized_path(mut ty: &Type) -> bool {
 }
 
 /// Whether the expression's first token is the label of a loop/block.
-#[cfg(feature = "printing")]
+#[cfg(all(feature = "printing", feature = "full"))]
 pub(crate) fn expr_leading_label(mut expr: &Expr) -> bool {
     loop {
         match expr {
@@ -252,6 +261,7 @@ pub(crate) fn expr_leading_label(mut expr: &Expr) -> bool {
 }
 
 /// Whether the expression's last token is `}`.
+#[cfg(feature = "full")]
 pub(crate) fn expr_trailing_brace(mut expr: &Expr) -> bool {
     loop {
         match expr {

--- a/src/fixup.rs
+++ b/src/fixup.rs
@@ -13,6 +13,7 @@ pub(crate) struct FixupContext {
     //
     //     match x {};  // not when its own statement
     //
+    #[cfg(feature = "full")]
     stmt: bool,
 
     // This is the difference between:
@@ -44,6 +45,7 @@ pub(crate) struct FixupContext {
     //     Example: `$match;`
     //
     //     No parentheses required.
+    #[cfg(feature = "full")]
     leftmost_subexpression_in_stmt: bool,
 
     // Print expression such that it can be parsed as a match arm.
@@ -59,6 +61,7 @@ pub(crate) struct FixupContext {
     //         _ => m! {} - 1,  // binary subtraction operator
     //     }
     //
+    #[cfg(feature = "full")]
     match_arm: bool,
 
     // This is almost equivalent to `leftmost_subexpression_in_stmt`, other than
@@ -74,6 +77,7 @@ pub(crate) struct FixupContext {
     //         _ => m! {} - 1,  // no parens
     //     }
     //
+    #[cfg(feature = "full")]
     leftmost_subexpression_in_match_arm: bool,
 
     // This is the difference between:
@@ -84,6 +88,7 @@ pub(crate) struct FixupContext {
     //         () if let _ = Struct {} => {}  // no parens
     //     }
     //
+    #[cfg(feature = "full")]
     parenthesize_exterior_struct_lit: bool,
 
     // This is the difference between:
@@ -92,6 +97,7 @@ pub(crate) struct FixupContext {
     //
     //     let _ = 1 + (return 1) + 1;  // needs parens
     //
+    #[cfg(feature = "full")]
     parenthesize_exterior_jump: bool,
 
     // This is the difference between:
@@ -100,6 +106,7 @@ pub(crate) struct FixupContext {
     //
     //     let _ = return + 1;  // no paren because '+' cannot begin expr
     //
+    #[cfg(feature = "full")]
     next_operator_can_begin_expr: bool,
 
     // This is the difference between:
@@ -116,18 +123,26 @@ impl FixupContext {
     /// The default amount of fixing is minimal fixing. Fixups should be turned
     /// on in a targeted fashion where needed.
     pub const NONE: Self = FixupContext {
+        #[cfg(feature = "full")]
         stmt: false,
+        #[cfg(feature = "full")]
         leftmost_subexpression_in_stmt: false,
+        #[cfg(feature = "full")]
         match_arm: false,
+        #[cfg(feature = "full")]
         leftmost_subexpression_in_match_arm: false,
+        #[cfg(feature = "full")]
         parenthesize_exterior_struct_lit: false,
+        #[cfg(feature = "full")]
         parenthesize_exterior_jump: false,
+        #[cfg(feature = "full")]
         next_operator_can_begin_expr: false,
         next_operator_can_begin_generics: false,
     };
 
     /// Create the initial fixup for printing an expression in statement
     /// position.
+    #[cfg(feature = "full")]
     pub fn new_stmt() -> Self {
         FixupContext {
             stmt: true,
@@ -137,6 +152,7 @@ impl FixupContext {
 
     /// Create the initial fixup for printing an expression as the right-hand
     /// side of a match arm.
+    #[cfg(feature = "full")]
     pub fn new_match_arm() -> Self {
         FixupContext {
             match_arm: true,
@@ -148,6 +164,7 @@ impl FixupContext {
     /// of an `if` or `while`. There are a few other positions which are
     /// grammatically equivalent and also use this, such as the iterator
     /// expression in `for` and the scrutinee in `match`.
+    #[cfg(feature = "full")]
     pub fn new_condition() -> Self {
         FixupContext {
             parenthesize_exterior_struct_lit: true,
@@ -168,11 +185,16 @@ impl FixupContext {
     /// `-$a` nor `[$a]` have one.
     pub fn leftmost_subexpression(self) -> Self {
         FixupContext {
+            #[cfg(feature = "full")]
             stmt: false,
+            #[cfg(feature = "full")]
             leftmost_subexpression_in_stmt: self.stmt || self.leftmost_subexpression_in_stmt,
+            #[cfg(feature = "full")]
             match_arm: false,
+            #[cfg(feature = "full")]
             leftmost_subexpression_in_match_arm: self.match_arm
                 || self.leftmost_subexpression_in_match_arm,
+            #[cfg(feature = "full")]
             parenthesize_exterior_jump: true,
             ..self
         }
@@ -184,10 +206,15 @@ impl FixupContext {
     /// subexpressions.
     pub fn leftmost_subexpression_with_dot(self) -> Self {
         FixupContext {
+            #[cfg(feature = "full")]
             stmt: self.stmt || self.leftmost_subexpression_in_stmt,
+            #[cfg(feature = "full")]
             leftmost_subexpression_in_stmt: false,
+            #[cfg(feature = "full")]
             match_arm: self.match_arm || self.leftmost_subexpression_in_match_arm,
+            #[cfg(feature = "full")]
             leftmost_subexpression_in_match_arm: false,
+            #[cfg(feature = "full")]
             parenthesize_exterior_jump: true,
             ..self
         }
@@ -198,10 +225,11 @@ impl FixupContext {
     /// first token of an expression.
     pub fn leftmost_subexpression_with_begin_operator(
         self,
-        next_operator_can_begin_expr: bool,
+        #[cfg(feature = "full")] next_operator_can_begin_expr: bool,
         next_operator_can_begin_generics: bool,
     ) -> Self {
         FixupContext {
+            #[cfg(feature = "full")]
             next_operator_can_begin_expr,
             next_operator_can_begin_generics,
             ..self.leftmost_subexpression()
@@ -218,9 +246,13 @@ impl FixupContext {
     /// `$a.f($b)`.
     pub fn subsequent_subexpression(self) -> Self {
         FixupContext {
+            #[cfg(feature = "full")]
             stmt: false,
+            #[cfg(feature = "full")]
             leftmost_subexpression_in_stmt: false,
+            #[cfg(feature = "full")]
             match_arm: false,
+            #[cfg(feature = "full")]
             leftmost_subexpression_in_match_arm: false,
             ..self
         }
@@ -231,6 +263,7 @@ impl FixupContext {
     ///
     /// The documentation on `FixupContext::leftmost_subexpression_in_stmt` has
     /// examples.
+    #[cfg(feature = "full")]
     pub fn would_cause_statement_boundary(self, expr: &Expr) -> bool {
         (self.leftmost_subexpression_in_stmt && !classify::requires_semi_to_be_stmt(expr))
             || ((self.stmt || self.leftmost_subexpression_in_stmt) && matches!(expr, Expr::Let(_)))
@@ -249,6 +282,7 @@ impl FixupContext {
     ///
     ///   - `true && false`, because otherwise this would be misinterpreted as a
     ///     "let chain".
+    #[cfg(feature = "full")]
     pub fn needs_group_as_let_scrutinee(self, expr: &Expr) -> bool {
         self.parenthesize_exterior_struct_lit && classify::confusable_with_adjacent_block(expr)
             || self.trailing_precedence(expr) < Precedence::Let
@@ -257,6 +291,7 @@ impl FixupContext {
     /// Determines the effective precedence of a left subexpression. Some
     /// expressions have lower precedence when adjacent to particular operators.
     pub fn leading_precedence(self, expr: &Expr) -> Precedence {
+        #[cfg(feature = "full")]
         if self.next_operator_can_begin_expr {
             // Decrease precedence of value-less jumps when followed by an
             // operator that would otherwise get interpreted as beginning a
@@ -272,6 +307,7 @@ impl FixupContext {
     /// expressions have higher precedence on the right side of a binary
     /// operator than on the left.
     pub fn trailing_precedence(self, expr: &Expr) -> Precedence {
+        #[cfg(feature = "full")]
         if !self.parenthesize_exterior_jump {
             match expr {
                 // Increase precedence of expressions that extend to the end of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,10 @@ mod bigint;
 #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
 pub mod buffer;
 
-#[cfg(all(any(feature = "parsing", feature = "printing"), feature = "full"))]
+#[cfg(any(
+    all(feature = "parsing", feature = "full"),
+    all(feature = "printing", any(feature = "full", feature = "derive")),
+))]
 mod classify;
 
 mod custom_keyword;
@@ -384,7 +387,7 @@ mod file;
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub use crate::file::File;
 
-#[cfg(all(feature = "full", feature = "printing"))]
+#[cfg(all(any(feature = "full", feature = "derive"), feature = "printing"))]
 mod fixup;
 
 #[cfg(any(feature = "full", feature = "derive"))]


### PR DESCRIPTION
This is needed after https://github.com/dtolnay/syn/pull/1703 to support parenthesization of casts such as `1 + (x as i32) < 0`, which can occur even when "full" feature is not enabled.