### PR TITLE
Parse `use<'a, T>` precise capturing bounds as verbatim

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -772,6 +772,27 @@ pub(crate) mod parsing {
 
             let begin = input.fork();
 
+            if cfg!(feature = "full") && input.peek(Token![use]) {
+                input.parse::<Token![use]>()?;
+                input.parse::<Token![<]>()?;
+                while !input.peek(Token![>]) {
+                    if input.peek(Lifetime) {
+                        input.parse::<Lifetime>()?;
+                    } else if input.peek(Ident) {
+                        input.parse::<Ident>()?;
+                    } else {
+                        break;
+                    }
+                    if input.peek(Token![,]) {
+                        input.parse::<Token![,]>()?;
+                    } else {
+                        break;
+                    }
+                }
+                input.parse::<Token![>]>()?;
+                return Ok(TypeParamBound::Verbatim(verbatim::between(&begin, input)));
+            }
+
             let content;
             let (paren_token, content) = if input.peek(token::Paren) {
                 (Some(parenthesized!(content in input)), &content)

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -395,3 +395,50 @@ fn test_tuple_comma() {
     }
     "###);
 }
+
+#[test]
+fn test_impl_trait_use() {
+    let tokens = quote! {
+        impl Sized + use<'_, 'a, A, Test>
+    };
+
+    snapshot!(tokens as Type, @r###"
+    Type::ImplTrait {
+        bounds: [
+            TypeParamBound::Trait(TraitBound {
+                path: Path {
+                    segments: [
+                        PathSegment {
+                            ident: "Sized",
+                        },
+                    ],
+                },
+            }),
+            Token![+],
+            TypeParamBound::Verbatim(`use < '_ , 'a , A , Test >`),
+        ],
+    }
+    "###);
+
+    let trailing = quote! {
+        impl Sized + use<'_,>
+    };
+
+    snapshot!(trailing as Type, @r###"
+    Type::ImplTrait {
+        bounds: [
+            TypeParamBound::Trait(TraitBound {
+                path: Path {
+                    segments: [
+                        PathSegment {
+                            ident: "Sized",
+                        },
+                    ],
+                },
+            }),
+            Token![+],
+            TypeParamBound::Verbatim(`use < '_ , >`),
+        ],
+    }
+    "###);
+}


### PR DESCRIPTION
Parses the new `use<>` precise capturing bound (https://rust-lang.github.io/rfcs/3617-precise-capturing.html) as verbatim in all bound positions.

Not exactly sure what the process is for syn support for nightly features. I could alternatively prepare a PR adding full support for this.

cc https://github.com/rust-lang/rust/issues/123432