### PR TITLE
Include expected close delimiter in unexpected token message

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -364,6 +364,16 @@ impl<'a> Cursor<'a> {
 
         Some(unsafe { Cursor::create(self.ptr.add(len), self.scope) })
     }
+
+    pub(crate) fn scope_delimiter(self) -> Delimiter {
+        match unsafe { &*self.scope } {
+            Entry::End(_, offset) => match unsafe { &*self.scope.offset(*offset) } {
+                Entry::Group(group, _) => group.delimiter(),
+                _ => Delimiter::None,
+            },
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl<'a> Copy for Cursor<'a> {}

--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -175,8 +175,8 @@ impl<'a> Speculative for ParseBuffer<'a> {
         if !Rc::ptr_eq(&self_unexp, &fork_unexp) {
             match (fork_sp, self_sp) {
                 // Unexpected set on the fork, but not on `self`, copy it over.
-                (Some(span), None) => {
-                    self_unexp.set(Unexpected::Some(span));
+                (Some((span, delimiter)), None) => {
+                    self_unexp.set(Unexpected::Some(span, delimiter));
                 }
                 // Unexpected unset. Use chain to propagate errors from fork.
                 (None, None) => {


### PR DESCRIPTION
**Before:**

```console
error: unexpected token
 --> dev/main.rs:4:22
  |
4 |     extern fn f(..., more: T) {}
  |                      ^^^^
```

**After:**

```console
error: unexpected token, expected `)`
 --> dev/main.rs:4:22
  |
4 |     extern fn f(..., more: T) {}
  |                      ^^^^
```