### PR TITLE
Add `Fields::iter_member`

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -3,7 +3,6 @@ use crate::expr::Expr;
 use crate::ident::Ident;
 use crate::punctuated::{self, Punctuated};
 use crate::restriction::{FieldMutability, Visibility};
-use crate::spanned::Spanned;
 use crate::token;
 use crate::ty::Type;
 
@@ -145,7 +144,13 @@ mod iter_member {
                 None => {
                     let m = Member::Unnamed(crate::Index {
                         index: self.unnamed_counter,
-                        span: field.ty.span(),
+                        span: {
+                            #[cfg(all(feature = "parsing", feature = "printing"))]
+                            let span = crate::spanned::Spanned::span(&field.ty);
+                            #[cfg(not(all(feature = "parsing", feature = "printing")))]
+                            let span = proc_macro2::Span::call_site();
+                            span
+                        },
                     });
                     self.unnamed_counter += 1;
                     Some(m)

--- a/src/data.rs
+++ b/src/data.rs
@@ -3,6 +3,7 @@ use crate::expr::Expr;
 use crate::ident::Ident;
 use crate::punctuated::{self, Punctuated};
 use crate::restriction::{FieldMutability, Visibility};
+use crate::spanned::Spanned;
 use crate::token;
 use crate::ty::Type;
 
@@ -102,6 +103,54 @@ impl Fields {
             Fields::Unit => true,
             Fields::Named(f) => f.named.is_empty(),
             Fields::Unnamed(f) => f.unnamed.is_empty(),
+        }
+    }
+}
+
+#[cfg(any(feature = "full", feature = "derive"))]
+mod iter_member {
+    use super::*;
+    use crate::Member;
+
+    impl Fields {
+        /// Get an iterator over the fields of a struct or variant as [`Member`]s.
+        /// This iterator can be used to iterate over a named or unnamed struct or
+        /// variant's fields uniformly.
+        ///
+        /// The return type can considered as impl [`Iterator<Item = Member>`].
+        #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
+        pub fn iter_member(&self) -> IterMember {
+            IterMember {
+                iter: self.iter(),
+                unnamed_counter: 0,
+            }
+        }
+    }
+
+    /// An iterator over the fields of a struct or variant as [`Member`]s.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
+    #[derive(Clone)]
+    pub struct IterMember<'a> {
+        iter: punctuated::Iter<'a, Field>,
+        unnamed_counter: u32,
+    }
+
+    impl<'a> Iterator for IterMember<'a> {
+        type Item = Member;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            let field = self.iter.next()?;
+            match &field.ident {
+                Some(ident) => Some(Member::Named(ident.clone())),
+                None => {
+                    let m = Member::Unnamed(crate::Index {
+                        index: self.unnamed_counter,
+                        span: field.ty.span(),
+                    });
+                    self.unnamed_counter += 1;
+                    Some(m)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Acts like `Fields::iter`, but map its `Field` items to `Member`.

For instance, in this struct
```rust
struct Foo {
    a: f32,
    b: bool
}
```
We use `iter_member` to access its fields, and implement `Clone` for it.
```rust
let fields: Fields = ...;
let idents = fields.iter().map(|f| &f.ident);
let members = fields.iter_member();
quote! {
    impl Clone for Foo {
        fn clone(&self) -> Self {
            Self {
                #(#idents: self.#members.clone(),)*
            }
        }
    }
}
```
Then it generates
```rust
impl Clone for Foo {
    fn clone(&self) -> Self {
        Self {
            a: self.a.clone(),
            b: self.b.clone(),
        }
    }
}
```
There is a similar effect on unnamed fields in which iterates `Member::Index` instead.