### PR TITLE
Expose non-impl-Trait iterator return types

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -105,42 +105,44 @@ impl Fields {
         }
     }
 
-    /// Get an iterator over the fields of a struct or variant as [`Member`]s.
-    /// This iterator can be used to iterate over a named or unnamed struct or
-    /// variant's fields uniformly.
-    ///
-    /// # Example
-    ///
-    /// The following is a simplistic [`Clone`] derive for structs. (A more
-    /// complete implementation would additionally want to infer trait bounds on
-    /// the generic type parameters.)
-    ///
-    /// ```
-    /// # use quote::quote;
-    /// #
-    /// fn derive_clone(input: &syn::ItemStruct) -> proc_macro2::TokenStream {
-    ///     let ident = &input.ident;
-    ///     let members = input.fields.members();
-    ///     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    ///     quote! {
-    ///         impl #impl_generics Clone for #ident #ty_generics #where_clause {
-    ///             fn clone(&self) -> Self {
-    ///                 Self {
-    ///                     #(#members: self.#members.clone()),*
-    ///                 }
-    ///             }
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// For structs with named fields, it produces an expression like `Self { a:
-    /// self.a.clone() }`. For structs with unnamed fields, `Self { 0:
-    /// self.0.clone() }`. And for unit structs, `Self {}`.
-    pub fn members(&self) -> impl Iterator<Item = Member> + Clone + '_ {
-        Members {
-            fields: self.iter(),
-            index: 0,
+    return_impl_trait! {
+        /// Get an iterator over the fields of a struct or variant as [`Member`]s.
+        /// This iterator can be used to iterate over a named or unnamed struct or
+        /// variant's fields uniformly.
+        ///
+        /// # Example
+        ///
+        /// The following is a simplistic [`Clone`] derive for structs. (A more
+        /// complete implementation would additionally want to infer trait bounds on
+        /// the generic type parameters.)
+        ///
+        /// ```
+        /// # use quote::quote;
+        /// #
+        /// fn derive_clone(input: &syn::ItemStruct) -> proc_macro2::TokenStream {
+        ///     let ident = &input.ident;
+        ///     let members = input.fields.members();
+        ///     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+        ///     quote! {
+        ///         impl #impl_generics Clone for #ident #ty_generics #where_clause {
+        ///             fn clone(&self) -> Self {
+        ///                 Self {
+        ///                     #(#members: self.#members.clone()),*
+        ///                 }
+        ///             }
+        ///         }
+        ///     }
+        /// }
+        /// ```
+        ///
+        /// For structs with named fields, it produces an expression like `Self { a:
+        /// self.a.clone() }`. For structs with unnamed fields, `Self { 0:
+        /// self.0.clone() }`. And for unit structs, `Self {}`.
+        pub fn members(&self) -> impl Iterator<Item = Member> + Clone + '_ [Members] {
+            Members {
+                fields: self.iter(),
+                index: 0,
+            }
         }
     }
 }

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -103,34 +103,46 @@ impl Default for Generics {
 }
 
 impl Generics {
-    /// Iterator over the lifetime parameters in `self.params`.
-    pub fn lifetimes(&self) -> impl Iterator<Item = &LifetimeParam> {
-        Lifetimes(self.params.iter())
+    return_impl_trait! {
+        /// Iterator over the lifetime parameters in `self.params`.
+        pub fn lifetimes(&self) -> impl Iterator<Item = &LifetimeParam> [Lifetimes] {
+            Lifetimes(self.params.iter())
+        }
     }
 
-    /// Iterator over the lifetime parameters in `self.params`.
-    pub fn lifetimes_mut(&mut self) -> impl Iterator<Item = &mut LifetimeParam> {
-        LifetimesMut(self.params.iter_mut())
+    return_impl_trait! {
+        /// Iterator over the lifetime parameters in `self.params`.
+        pub fn lifetimes_mut(&mut self) -> impl Iterator<Item = &mut LifetimeParam> [LifetimesMut] {
+            LifetimesMut(self.params.iter_mut())
+        }
     }
 
-    /// Iterator over the type parameters in `self.params`.
-    pub fn type_params(&self) -> impl Iterator<Item = &TypeParam> {
-        TypeParams(self.params.iter())
+    return_impl_trait! {
+        /// Iterator over the type parameters in `self.params`.
+        pub fn type_params(&self) -> impl Iterator<Item = &TypeParam> [TypeParams] {
+            TypeParams(self.params.iter())
+        }
     }
 
-    /// Iterator over the type parameters in `self.params`.
-    pub fn type_params_mut(&mut self) -> impl Iterator<Item = &mut TypeParam> {
-        TypeParamsMut(self.params.iter_mut())
+    return_impl_trait! {
+        /// Iterator over the type parameters in `self.params`.
+        pub fn type_params_mut(&mut self) -> impl Iterator<Item = &mut TypeParam> [TypeParamsMut] {
+            TypeParamsMut(self.params.iter_mut())
+        }
     }
 
-    /// Iterator over the constant parameters in `self.params`.
-    pub fn const_params(&self) -> impl Iterator<Item = &ConstParam> {
-        ConstParams(self.params.iter())
+    return_impl_trait! {
+        /// Iterator over the constant parameters in `self.params`.
+        pub fn const_params(&self) -> impl Iterator<Item = &ConstParam> [ConstParams] {
+            ConstParams(self.params.iter())
+        }
     }
 
-    /// Iterator over the constant parameters in `self.params`.
-    pub fn const_params_mut(&mut self) -> impl Iterator<Item = &mut ConstParam> {
-        ConstParamsMut(self.params.iter_mut())
+    return_impl_trait! {
+        /// Iterator over the constant parameters in `self.params`.
+        pub fn const_params_mut(&mut self) -> impl Iterator<Item = &mut ConstParam> [ConstParamsMut] {
+            ConstParamsMut(self.params.iter_mut())
+        }
     }
 
     /// Initializes an empty `where`-clause if there is not one present already.

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -105,139 +105,31 @@ impl Default for Generics {
 impl Generics {
     /// Iterator over the lifetime parameters in `self.params`.
     pub fn lifetimes(&self) -> impl Iterator<Item = &LifetimeParam> {
-        struct Lifetimes<'a>(Iter<'a, GenericParam>);
-
-        impl<'a> Iterator for Lifetimes<'a> {
-            type Item = &'a LifetimeParam;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                let next = match self.0.next() {
-                    Some(item) => item,
-                    None => return None,
-                };
-                if let GenericParam::Lifetime(lifetime) = next {
-                    Some(lifetime)
-                } else {
-                    self.next()
-                }
-            }
-        }
-
         Lifetimes(self.params.iter())
     }
 
     /// Iterator over the lifetime parameters in `self.params`.
     pub fn lifetimes_mut(&mut self) -> impl Iterator<Item = &mut LifetimeParam> {
-        struct LifetimesMut<'a>(IterMut<'a, GenericParam>);
-
-        impl<'a> Iterator for LifetimesMut<'a> {
-            type Item = &'a mut LifetimeParam;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                let next = match self.0.next() {
-                    Some(item) => item,
-                    None => return None,
-                };
-                if let GenericParam::Lifetime(lifetime) = next {
-                    Some(lifetime)
-                } else {
-                    self.next()
-                }
-            }
-        }
-
         LifetimesMut(self.params.iter_mut())
     }
 
     /// Iterator over the type parameters in `self.params`.
     pub fn type_params(&self) -> impl Iterator<Item = &TypeParam> {
-        struct TypeParams<'a>(Iter<'a, GenericParam>);
-
-        impl<'a> Iterator for TypeParams<'a> {
-            type Item = &'a TypeParam;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                let next = match self.0.next() {
-                    Some(item) => item,
-                    None => return None,
-                };
-                if let GenericParam::Type(type_param) = next {
-                    Some(type_param)
-                } else {
-                    self.next()
-                }
-            }
-        }
-
         TypeParams(self.params.iter())
     }
 
     /// Iterator over the type parameters in `self.params`.
     pub fn type_params_mut(&mut self) -> impl Iterator<Item = &mut TypeParam> {
-        struct TypeParamsMut<'a>(IterMut<'a, GenericParam>);
-
-        impl<'a> Iterator for TypeParamsMut<'a> {
-            type Item = &'a mut TypeParam;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                let next = match self.0.next() {
-                    Some(item) => item,
-                    None => return None,
-                };
-                if let GenericParam::Type(type_param) = next {
-                    Some(type_param)
-                } else {
-                    self.next()
-                }
-            }
-        }
-
         TypeParamsMut(self.params.iter_mut())
     }
 
     /// Iterator over the constant parameters in `self.params`.
     pub fn const_params(&self) -> impl Iterator<Item = &ConstParam> {
-        struct ConstParams<'a>(Iter<'a, GenericParam>);
-
-        impl<'a> Iterator for ConstParams<'a> {
-            type Item = &'a ConstParam;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                let next = match self.0.next() {
-                    Some(item) => item,
-                    None => return None,
-                };
-                if let GenericParam::Const(const_param) = next {
-                    Some(const_param)
-                } else {
-                    self.next()
-                }
-            }
-        }
-
         ConstParams(self.params.iter())
     }
 
     /// Iterator over the constant parameters in `self.params`.
     pub fn const_params_mut(&mut self) -> impl Iterator<Item = &mut ConstParam> {
-        struct ConstParamsMut<'a>(IterMut<'a, GenericParam>);
-
-        impl<'a> Iterator for ConstParamsMut<'a> {
-            type Item = &'a mut ConstParam;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                let next = match self.0.next() {
-                    Some(item) => item,
-                    None => return None,
-                };
-                if let GenericParam::Const(const_param) = next {
-                    Some(const_param)
-                } else {
-                    self.next()
-                }
-            }
-        }
-
         ConstParamsMut(self.params.iter_mut())
     }
 
@@ -275,6 +167,114 @@ impl Generics {
             TypeGenerics(self),
             self.where_clause.as_ref(),
         )
+    }
+}
+
+pub struct Lifetimes<'a>(Iter<'a, GenericParam>);
+
+impl<'a> Iterator for Lifetimes<'a> {
+    type Item = &'a LifetimeParam;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = match self.0.next() {
+            Some(item) => item,
+            None => return None,
+        };
+        if let GenericParam::Lifetime(lifetime) = next {
+            Some(lifetime)
+        } else {
+            self.next()
+        }
+    }
+}
+
+pub struct LifetimesMut<'a>(IterMut<'a, GenericParam>);
+
+impl<'a> Iterator for LifetimesMut<'a> {
+    type Item = &'a mut LifetimeParam;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = match self.0.next() {
+            Some(item) => item,
+            None => return None,
+        };
+        if let GenericParam::Lifetime(lifetime) = next {
+            Some(lifetime)
+        } else {
+            self.next()
+        }
+    }
+}
+
+pub struct TypeParams<'a>(Iter<'a, GenericParam>);
+
+impl<'a> Iterator for TypeParams<'a> {
+    type Item = &'a TypeParam;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = match self.0.next() {
+            Some(item) => item,
+            None => return None,
+        };
+        if let GenericParam::Type(type_param) = next {
+            Some(type_param)
+        } else {
+            self.next()
+        }
+    }
+}
+
+pub struct TypeParamsMut<'a>(IterMut<'a, GenericParam>);
+
+impl<'a> Iterator for TypeParamsMut<'a> {
+    type Item = &'a mut TypeParam;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = match self.0.next() {
+            Some(item) => item,
+            None => return None,
+        };
+        if let GenericParam::Type(type_param) = next {
+            Some(type_param)
+        } else {
+            self.next()
+        }
+    }
+}
+
+pub struct ConstParams<'a>(Iter<'a, GenericParam>);
+
+impl<'a> Iterator for ConstParams<'a> {
+    type Item = &'a ConstParam;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = match self.0.next() {
+            Some(item) => item,
+            None => return None,
+        };
+        if let GenericParam::Const(const_param) = next {
+            Some(const_param)
+        } else {
+            self.next()
+        }
+    }
+}
+
+pub struct ConstParamsMut<'a>(IterMut<'a, GenericParam>);
+
+impl<'a> Iterator for ConstParamsMut<'a> {
+    type Item = &'a mut ConstParam;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = match self.0.next() {
+            Some(item) => item,
+            None => return None,
+        };
+        if let GenericParam::Const(const_param) = next {
+            Some(const_param)
+        } else {
+            self.next()
+        }
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -164,3 +164,19 @@ macro_rules! check_keyword_matches {
     (pub pub) => {};
     (struct struct) => {};
 }
+
+#[cfg(any(feature = "full", feature = "derive"))]
+macro_rules! return_impl_trait {
+    (
+        $(#[$attr:meta])*
+        $vis:vis fn $name:ident $args:tt -> $impl_trait:ty [$concrete:ty] $body:block
+    ) => {
+        #[cfg(not(docsrs))]
+        $(#[$attr])*
+        $vis fn $name $args -> $concrete $body
+
+        #[cfg(docsrs)]
+        $(#[$attr])*
+        $vis fn $name $args -> $impl_trait $body
+    };
+}

--- a/tests/test_iterators.rs
+++ b/tests/test_iterators.rs
@@ -1,7 +1,7 @@
-#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::map_unwrap_or, clippy::uninlined_format_args)]
 
 use syn::punctuated::{Pair, Punctuated};
-use syn::Token;
+use syn::{parse_quote, GenericParam, Generics, Lifetime, LifetimeParam, Token};
 
 #[macro_use]
 mod macros;
@@ -67,4 +67,23 @@ fn may_dangle() {
             break;
         }
     }
+}
+
+// Regression test for https://github.com/dtolnay/syn/issues/1718
+#[test]
+fn no_opaque_drop() {
+    let mut generics = Generics::default();
+
+    let _ = generics
+        .lifetimes()
+        .next()
+        .map(|param| param.lifetime.clone())
+        .unwrap_or_else(|| {
+            let lifetime: Lifetime = parse_quote!('a);
+            generics.params.insert(
+                0,
+                GenericParam::Lifetime(LifetimeParam::new(lifetime.clone())),
+            );
+            lifetime
+        });
 }


### PR DESCRIPTION
Fixes #1718.

There is no syntax in `impl Trait<'a>` to express that the underlying type either does not have a `Drop` impl or has a dropck eyepatch: `unsafe impl<#[may_dangle] 'a> Drop`.