### PR TITLE
Make tail call expr mandatory

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2400,9 +2400,7 @@ pub(crate) mod parsing {
     fn expr_become(input: ParseStream) -> Result<Expr> {
         let begin = input.fork();
         input.parse::<Token![become]>()?;
-        if can_begin_expr(input) {
-            input.parse::<Expr>()?;
-        }
+        input.parse::<Expr>()?;
         Ok(Expr::Verbatim(verbatim::between(&begin, input)))
     }
 


### PR DESCRIPTION
This was probably written just mirroring the grammar of `return`. But for `become`, the expression after the keyword is mandatory.

```rust
#![allow(incomplete_features)]
#![feature(explicit_tail_calls)]

fn repro() {
    become;
}
```

```console
error: expected expression, found `;`
 --> src/lib.rs:5:11
  |
5 |     become;
  |           ^ expected expression
```