### PR TITLE
Force cursor to advance in parse_expr calls

### DIFF
--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -646,9 +646,17 @@ fn test_assign_range_precedence() {
 fn test_chained_comparison() {
     // https://github.com/dtolnay/syn/issues/1738
     let _ = syn::parse_str::<Expr>("a = a < a <");
+    let _ = syn::parse_str::<Expr>("a = a .. a ..");
+    let _ = syn::parse_str::<Expr>("a = a .. a +=");
 
     let err = syn::parse_str::<Expr>("a < a < a").unwrap_err();
     assert_eq!("comparison operators cannot be chained", err.to_string());
+
+    let err = syn::parse_str::<Expr>("a .. a .. a").unwrap_err();
+    assert_eq!("unexpected token", err.to_string());
+
+    let err = syn::parse_str::<Expr>("a .. a += a").unwrap_err();
+    assert_eq!("unexpected token", err.to_string());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1738 (v2).