### PR TITLE
Update insta inline snapshot delimiters

### DIFF
--- a/tests/test_asyncness.rs
+++ b/tests/test_asyncness.rs
@@ -9,7 +9,7 @@ use syn::{Expr, Item};
 fn test_async_fn() {
     let input = "async fn process() {}";
 
-    snapshot!(input as Item, @r###"
+    snapshot!(input as Item, @r#"
     Item::Fn {
         vis: Visibility::Inherited,
         sig: Signature {
@@ -22,14 +22,14 @@ fn test_async_fn() {
             stmts: [],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_async_closure() {
     let input = "async || {}";
 
-    snapshot!(input as Expr, @r###"
+    snapshot!(input as Expr, @r#"
     Expr::Closure {
         asyncness: Some,
         output: ReturnType::Default,
@@ -39,5 +39,5 @@ fn test_async_closure() {
             },
         },
     }
-    "###);
+    "#);
 }

--- a/tests/test_attribute.rs
+++ b/tests/test_attribute.rs
@@ -10,7 +10,7 @@ use syn::{Attribute, Meta};
 fn test_meta_item_word() {
     let meta = test("#[foo]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::Path {
         segments: [
             PathSegment {
@@ -18,14 +18,14 @@ fn test_meta_item_word() {
             },
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_meta_item_name_value() {
     let meta = test("#[foo = 5]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::NameValue {
         path: Path {
             segments: [
@@ -38,14 +38,14 @@ fn test_meta_item_name_value() {
             lit: 5,
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_meta_item_bool_value() {
     let meta = test("#[foo = true]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::NameValue {
         path: Path {
             segments: [
@@ -60,11 +60,11 @@ fn test_meta_item_bool_value() {
             },
         },
     }
-    "###);
+    "#);
 
     let meta = test("#[foo = false]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::NameValue {
         path: Path {
             segments: [
@@ -79,14 +79,14 @@ fn test_meta_item_bool_value() {
             },
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_meta_item_list_lit() {
     let meta = test("#[foo(5)]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -98,14 +98,14 @@ fn test_meta_item_list_lit() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`5`),
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_meta_item_list_word() {
     let meta = test("#[foo(bar)]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -117,14 +117,14 @@ fn test_meta_item_list_word() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`bar`),
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_meta_item_list_name_value() {
     let meta = test("#[foo(bar = 5)]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -136,14 +136,14 @@ fn test_meta_item_list_name_value() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`bar = 5`),
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_meta_item_list_bool_value() {
     let meta = test("#[foo(bar = true)]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -155,14 +155,14 @@ fn test_meta_item_list_bool_value() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`bar = true`),
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_meta_item_multiple() {
     let meta = test("#[foo(word, name = 5, list(name2 = 6), word2)]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -174,14 +174,14 @@ fn test_meta_item_multiple() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`word , name = 5 , list (name2 = 6) , word2`),
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_bool_lit() {
     let meta = test("#[foo(true)]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -193,14 +193,14 @@ fn test_bool_lit() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`true`),
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_negative_lit() {
     let meta = test("#[form(min = -1, max = 200)]");
 
-    snapshot!(meta, @r###"
+    snapshot!(meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -212,7 +212,7 @@ fn test_negative_lit() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`min = - 1 , max = 200`),
     }
-    "###);
+    "#);
 }
 
 fn test(input: &str) -> Meta {

--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -18,7 +18,7 @@ fn test_unit() {
         struct Unit;
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "Unit",
@@ -28,7 +28,7 @@ fn test_unit() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn test_struct() {
         }
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         attrs: [
             Attribute {
@@ -111,9 +111,9 @@ fn test_struct() {
             },
         },
     }
-    "###);
+    "#);
 
-    snapshot!(&input.attrs[0].meta, @r###"
+    snapshot!(&input.attrs[0].meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -125,7 +125,7 @@ fn test_struct() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`Debug , Clone`),
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -137,7 +137,7 @@ fn test_union() {
         }
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "MaybeUninit",
@@ -178,7 +178,7 @@ fn test_union() {
             },
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -198,7 +198,7 @@ fn test_enum() {
         }
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         attrs: [
             Attribute {
@@ -315,11 +315,11 @@ fn test_enum() {
             ],
         },
     }
-    "###);
+    "#);
 
     let meta_items: Vec<_> = input.attrs.into_iter().map(|attr| attr.meta).collect();
 
-    snapshot!(meta_items, @r###"
+    snapshot!(meta_items, @r#"
     [
         Meta::NameValue {
             path: Path {
@@ -341,7 +341,7 @@ fn test_enum() {
             ],
         },
     ]
-    "###);
+    "#);
 }
 
 #[test]
@@ -361,7 +361,7 @@ fn test_attr_with_mod_style_path_with_self() {
         struct S;
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         attrs: [
             Attribute {
@@ -387,9 +387,9 @@ fn test_attr_with_mod_style_path_with_self() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 
-    snapshot!(&input.attrs[0].meta, @r###"
+    snapshot!(&input.attrs[0].meta, @r#"
     Meta::Path {
         segments: [
             PathSegment {
@@ -401,7 +401,7 @@ fn test_attr_with_mod_style_path_with_self() {
             },
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -411,7 +411,7 @@ fn test_pub_restricted() {
         pub(in m) struct Z(pub(in m::n) u8);
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Restricted {
             in_token: Some,
@@ -458,7 +458,7 @@ fn test_pub_restricted() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -467,7 +467,7 @@ fn test_pub_restricted_crate() {
         pub(crate) struct S;
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Restricted {
             path: Path {
@@ -485,7 +485,7 @@ fn test_pub_restricted_crate() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -494,7 +494,7 @@ fn test_pub_restricted_super() {
         pub(super) struct S;
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Restricted {
             path: Path {
@@ -512,7 +512,7 @@ fn test_pub_restricted_super() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -521,7 +521,7 @@ fn test_pub_restricted_in_super() {
         pub(in super) struct S;
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Restricted {
             in_token: Some,
@@ -540,7 +540,7 @@ fn test_pub_restricted_in_super() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -549,7 +549,7 @@ fn test_fields_on_unit_struct() {
         struct S;
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "S",
@@ -559,7 +559,7 @@ fn test_fields_on_unit_struct() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 
     let data = match input.data {
         Data::Struct(data) => data,
@@ -578,7 +578,7 @@ fn test_fields_on_named_struct() {
         }
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "S",
@@ -620,14 +620,14 @@ fn test_fields_on_named_struct() {
             },
         },
     }
-    "###);
+    "#);
 
     let data = match input.data {
         Data::Struct(data) => data,
         _ => panic!("expected a struct"),
     };
 
-    snapshot!(data.fields.into_iter().collect::<Vec<_>>(), @r###"
+    snapshot!(data.fields.into_iter().collect::<Vec<_>>(), @r#"
     [
         Field {
             vis: Visibility::Inherited,
@@ -658,7 +658,7 @@ fn test_fields_on_named_struct() {
             },
         },
     ]
-    "###);
+    "#);
 }
 
 #[test]
@@ -667,7 +667,7 @@ fn test_fields_on_tuple_struct() {
         struct S(i32, pub String);
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "S",
@@ -705,14 +705,14 @@ fn test_fields_on_tuple_struct() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 
     let data = match input.data {
         Data::Struct(data) => data,
         _ => panic!("expected a struct"),
     };
 
-    snapshot!(data.fields.iter().collect::<Vec<_>>(), @r###"
+    snapshot!(data.fields.iter().collect::<Vec<_>>(), @r#"
     [
         Field {
             vis: Visibility::Inherited,
@@ -739,7 +739,7 @@ fn test_fields_on_tuple_struct() {
             },
         },
     ]
-    "###);
+    "#);
 }
 
 #[test]
@@ -749,7 +749,7 @@ fn test_ambiguous_crate() {
         struct S(crate::X);
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "S",
@@ -778,5 +778,5 @@ fn test_ambiguous_crate() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 }

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -17,24 +17,24 @@ use syn::{parse_quote, token, Expr, ExprRange, ExprTuple, Stmt, Token};
 #[test]
 fn test_expr_parse() {
     let tokens = quote!(..100u32);
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Range {
         limits: RangeLimits::HalfOpen,
         end: Some(Expr::Lit {
             lit: 100u32,
         }),
     }
-    "###);
+    "#);
 
     let tokens = quote!(..100u32);
-    snapshot!(tokens as ExprRange, @r###"
+    snapshot!(tokens as ExprRange, @r#"
     ExprRange {
         limits: RangeLimits::HalfOpen,
         end: Some(Expr::Lit {
             lit: 100u32,
         }),
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn test_await() {
     // Must not parse as Expr::Field.
     let tokens = quote!(fut.await);
 
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Await {
         base: Expr::Path {
             path: Path {
@@ -54,13 +54,13 @@ fn test_await() {
             },
         },
     }
-    "###);
+    "#);
 }
 
 #[rustfmt::skip]
 #[test]
 fn test_tuple_multi_index() {
-    let expected = snapshot!("tuple.0.0" as Expr, @r###"
+    let expected = snapshot!("tuple.0.0" as Expr, @r#"
     Expr::Field {
         base: Expr::Field {
             base: Expr::Path {
@@ -80,7 +80,7 @@ fn test_tuple_multi_index() {
             index: 0,
         }),
     }
-    "###);
+    "#);
 
     for &input in &[
         "tuple .0.0",
@@ -110,7 +110,7 @@ fn test_macro_variable_func() {
     let path = Group::new(Delimiter::None, quote!(f));
     let tokens = quote!(#path());
 
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Call {
         func: Expr::Group {
             expr: Expr::Path {
@@ -124,12 +124,12 @@ fn test_macro_variable_func() {
             },
         },
     }
-    "###);
+    "#);
 
     let path = Group::new(Delimiter::None, quote! { #[inside] f });
     let tokens = quote!(#[outside] #path());
 
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Call {
         attrs: [
             Attribute {
@@ -167,7 +167,7 @@ fn test_macro_variable_func() {
             },
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn test_macro_variable_macro() {
     let mac = Group::new(Delimiter::None, quote!(m));
     let tokens = quote!(#mac!());
 
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Macro {
         mac: Macro {
             path: Path {
@@ -190,7 +190,7 @@ fn test_macro_variable_macro() {
             tokens: TokenStream(``),
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -199,7 +199,7 @@ fn test_macro_variable_struct() {
     let s = Group::new(Delimiter::None, quote! { S });
     let tokens = quote!(#s {});
 
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Struct {
         path: Path {
             segments: [
@@ -209,7 +209,7 @@ fn test_macro_variable_struct() {
             ],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn test_macro_variable_unary() {
     // mimics the token stream corresponding to `$expr.method()` where expr is `&self`
     let inner = Group::new(Delimiter::None, quote!(&self));
     let tokens = quote!(#inner.method());
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::MethodCall {
         receiver: Expr::Group {
             expr: Expr::Reference {
@@ -234,7 +234,7 @@ fn test_macro_variable_unary() {
         },
         method: "method",
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -242,7 +242,7 @@ fn test_macro_variable_match_arm() {
     // mimics the token stream corresponding to `match v { _ => $expr }`
     let expr = Group::new(Delimiter::None, quote! { #[a] () });
     let tokens = quote!(match v { _ => #expr });
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Match {
         expr: Expr::Path {
             path: Path {
@@ -275,11 +275,11 @@ fn test_macro_variable_match_arm() {
             },
         ],
     }
-    "###);
+    "#);
 
     let expr = Group::new(Delimiter::None, quote!(loop {} + 1));
     let tokens = quote!(match v { _ => #expr });
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Match {
         expr: Expr::Path {
             path: Path {
@@ -309,7 +309,7 @@ fn test_macro_variable_match_arm() {
             },
         ],
     }
-    "###);
+    "#);
 }
 
 // https://github.com/dtolnay/syn/issues/1019
@@ -317,7 +317,7 @@ fn test_macro_variable_match_arm() {
 fn test_closure_vs_rangefull() {
     #[rustfmt::skip] // rustfmt bug: https://github.com/rust-lang/rustfmt/issues/4808
     let tokens = quote!(|| .. .method());
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::MethodCall {
         receiver: Expr::Closure {
             output: ReturnType::Default,
@@ -327,7 +327,7 @@ fn test_closure_vs_rangefull() {
         },
         method: "method",
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -356,16 +356,16 @@ fn test_range_kinds() {
 
 #[test]
 fn test_range_precedence() {
-    snapshot!(".. .." as Expr, @r###"
+    snapshot!(".. .." as Expr, @r#"
     Expr::Range {
         limits: RangeLimits::HalfOpen,
         end: Some(Expr::Range {
             limits: RangeLimits::HalfOpen,
         }),
     }
-    "###);
+    "#);
 
-    snapshot!(".. .. ()" as Expr, @r###"
+    snapshot!(".. .. ()" as Expr, @r#"
     Expr::Range {
         limits: RangeLimits::HalfOpen,
         end: Some(Expr::Range {
@@ -373,9 +373,9 @@ fn test_range_precedence() {
             end: Some(Expr::Tuple),
         }),
     }
-    "###);
+    "#);
 
-    snapshot!("() .. .." as Expr, @r###"
+    snapshot!("() .. .." as Expr, @r#"
     Expr::Range {
         start: Some(Expr::Tuple),
         limits: RangeLimits::HalfOpen,
@@ -383,7 +383,7 @@ fn test_range_precedence() {
             limits: RangeLimits::HalfOpen,
         }),
     }
-    "###);
+    "#);
 
     // A range with a lower bound cannot be the upper bound of another range,
     // and a range with an upper bound cannot be the lower bound of another
@@ -426,7 +426,7 @@ fn test_extended_interpolated_path() {
     let path = Group::new(Delimiter::None, quote!(a::b));
 
     let tokens = quote!(if #path {});
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::If {
         cond: Expr::Group {
             expr: Expr::Path {
@@ -447,10 +447,10 @@ fn test_extended_interpolated_path() {
             stmts: [],
         },
     }
-    "###);
+    "#);
 
     let tokens = quote!(#path {});
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Struct {
         path: Path {
             segments: [
@@ -464,10 +464,10 @@ fn test_extended_interpolated_path() {
             ],
         },
     }
-    "###);
+    "#);
 
     let tokens = quote!(#path :: c);
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Path {
         path: Path {
             segments: [
@@ -485,11 +485,11 @@ fn test_extended_interpolated_path() {
             ],
         },
     }
-    "###);
+    "#);
 
     let nested = Group::new(Delimiter::None, quote!(a::b || true));
     let tokens = quote!(if #nested && false {});
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::If {
         cond: Expr::Binary {
             left: Expr::Group {
@@ -526,7 +526,7 @@ fn test_extended_interpolated_path() {
             stmts: [],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -540,27 +540,27 @@ fn test_tuple_comma() {
 
     expr.elems.push_value(parse_quote!(continue));
     // Must not parse to Expr::Paren
-    snapshot!(expr.to_token_stream() as Expr, @r###"
+    snapshot!(expr.to_token_stream() as Expr, @r#"
     Expr::Tuple {
         elems: [
             Expr::Continue,
             Token![,],
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Expr, @r###"
+    snapshot!(expr.to_token_stream() as Expr, @r#"
     Expr::Tuple {
         elems: [
             Expr::Continue,
             Token![,],
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_value(parse_quote!(continue));
-    snapshot!(expr.to_token_stream() as Expr, @r###"
+    snapshot!(expr.to_token_stream() as Expr, @r#"
     Expr::Tuple {
         elems: [
             Expr::Continue,
@@ -568,10 +568,10 @@ fn test_tuple_comma() {
             Expr::Continue,
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Expr, @r###"
+    snapshot!(expr.to_token_stream() as Expr, @r#"
     Expr::Tuple {
         elems: [
             Expr::Continue,
@@ -580,13 +580,13 @@ fn test_tuple_comma() {
             Token![,],
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_binop_associativity() {
     // Left to right.
-    snapshot!("() + () + ()" as Expr, @r###"
+    snapshot!("() + () + ()" as Expr, @r#"
     Expr::Binary {
         left: Expr::Binary {
             left: Expr::Tuple,
@@ -596,10 +596,10 @@ fn test_binop_associativity() {
         op: BinOp::Add,
         right: Expr::Tuple,
     }
-    "###);
+    "#);
 
     // Right to left.
-    snapshot!("() += () += ()" as Expr, @r###"
+    snapshot!("() += () += ()" as Expr, @r#"
     Expr::Binary {
         left: Expr::Tuple,
         op: BinOp::AddAssign,
@@ -609,7 +609,7 @@ fn test_binop_associativity() {
             right: Expr::Tuple,
         },
     }
-    "###);
+    "#);
 
     // Parenthesization is required.
     syn::parse_str::<Expr>("() == () == ()").unwrap_err();
@@ -619,7 +619,7 @@ fn test_binop_associativity() {
 fn test_assign_range_precedence() {
     // Range has higher precedence as the right-hand of an assignment, but
     // ambiguous precedence as the left-hand of an assignment.
-    snapshot!("() = () .. ()" as Expr, @r###"
+    snapshot!("() = () .. ()" as Expr, @r#"
     Expr::Assign {
         left: Expr::Tuple,
         right: Expr::Range {
@@ -628,9 +628,9 @@ fn test_assign_range_precedence() {
             end: Some(Expr::Tuple),
         },
     }
-    "###);
+    "#);
 
-    snapshot!("() += () .. ()" as Expr, @r###"
+    snapshot!("() += () .. ()" as Expr, @r#"
     Expr::Binary {
         left: Expr::Tuple,
         op: BinOp::AddAssign,
@@ -640,7 +640,7 @@ fn test_assign_range_precedence() {
             end: Some(Expr::Tuple),
         },
     }
-    "###);
+    "#);
 
     syn::parse_str::<Expr>("() .. () = ()").unwrap_err();
     syn::parse_str::<Expr>("() .. () += ()").unwrap_err();

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -17,7 +17,7 @@ fn test_split_for_impl() {
         struct S<'a, 'b: 'a, #[may_dangle] T: 'a = ()> where T: Debug;
     };
 
-    snapshot!(input as DeriveInput, @r###"
+    snapshot!(input as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "S",
@@ -99,7 +99,7 @@ fn test_split_for_impl() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 
     let generics = input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
@@ -129,21 +129,21 @@ fn test_split_for_impl() {
 #[test]
 fn test_ty_param_bound() {
     let tokens = quote!('a);
-    snapshot!(tokens as TypeParamBound, @r###"
+    snapshot!(tokens as TypeParamBound, @r#"
     TypeParamBound::Lifetime {
         ident: "a",
     }
-    "###);
+    "#);
 
     let tokens = quote!('_);
-    snapshot!(tokens as TypeParamBound, @r###"
+    snapshot!(tokens as TypeParamBound, @r#"
     TypeParamBound::Lifetime {
         ident: "_",
     }
-    "###);
+    "#);
 
     let tokens = quote!(Debug);
-    snapshot!(tokens as TypeParamBound, @r###"
+    snapshot!(tokens as TypeParamBound, @r#"
     TypeParamBound::Trait(TraitBound {
         path: Path {
             segments: [
@@ -153,10 +153,10 @@ fn test_ty_param_bound() {
             ],
         },
     })
-    "###);
+    "#);
 
     let tokens = quote!(?Sized);
-    snapshot!(tokens as TypeParamBound, @r###"
+    snapshot!(tokens as TypeParamBound, @r#"
     TypeParamBound::Trait(TraitBound {
         modifier: TraitBoundModifier::Maybe,
         path: Path {
@@ -167,7 +167,7 @@ fn test_ty_param_bound() {
             ],
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn test_fn_precedence_in_where_clause() {
         }
     };
 
-    snapshot!(input as ItemFn, @r###"
+    snapshot!(input as ItemFn, @r#"
     ItemFn {
         vis: Visibility::Inherited,
         sig: Signature {
@@ -252,7 +252,7 @@ fn test_fn_precedence_in_where_clause() {
             stmts: [],
         },
     }
-    "###);
+    "#);
 
     let where_clause = input.sig.generics.where_clause.as_ref().unwrap();
     assert_eq!(where_clause.predicates.len(), 1);

--- a/tests/test_grouping.rs
+++ b/tests/test_grouping.rs
@@ -25,7 +25,7 @@ fn test_grouping() {
 
     assert_eq!(tokens.to_string(), "1i32 + 2i32 + 3i32 * 4i32");
 
-    snapshot!(tokens as Expr, @r###"
+    snapshot!(tokens as Expr, @r#"
     Expr::Binary {
         left: Expr::Lit {
             lit: 1i32,
@@ -49,5 +49,5 @@ fn test_grouping() {
             },
         },
     }
-    "###);
+    "#);
 }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -18,7 +18,7 @@ fn test_macro_variable_attr() {
         TokenTree::Group(Group::new(Delimiter::Brace, TokenStream::new())),
     ]);
 
-    snapshot!(tokens as Item, @r###"
+    snapshot!(tokens as Item, @r#"
     Item::Fn {
         attrs: [
             Attribute {
@@ -42,7 +42,7 @@ fn test_macro_variable_attr() {
             stmts: [],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -54,12 +54,12 @@ fn test_negative_impl() {
     let tokens = quote! {
         impl ! {}
     };
-    snapshot!(tokens as Item, @r###"
+    snapshot!(tokens as Item, @r#"
     Item::Impl {
         generics: Generics,
         self_ty: Type::Never,
     }
-    "###);
+    "#);
 
     #[cfg(any())]
     #[rustfmt::skip]
@@ -67,19 +67,19 @@ fn test_negative_impl() {
     let tokens = quote! {
         impl !Trait {}
     };
-    snapshot!(tokens as Item, @r###"
+    snapshot!(tokens as Item, @r#"
     Item::Impl {
         generics: Generics,
         self_ty: Type::Verbatim(`! Trait`),
     }
-    "###);
+    "#);
 
     #[cfg(any())]
     impl !Trait for T {}
     let tokens = quote! {
         impl !Trait for T {}
     };
-    snapshot!(tokens as Item, @r###"
+    snapshot!(tokens as Item, @r#"
     Item::Impl {
         generics: Generics,
         trait_: Some((
@@ -102,7 +102,7 @@ fn test_negative_impl() {
             },
         },
     }
-    "###);
+    "#);
 
     #[cfg(any())]
     #[rustfmt::skip]
@@ -110,12 +110,12 @@ fn test_negative_impl() {
     let tokens = quote! {
         impl !! {}
     };
-    snapshot!(tokens as Item, @r###"
+    snapshot!(tokens as Item, @r#"
     Item::Impl {
         generics: Generics,
         self_ty: Type::Verbatim(`! !`),
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -129,7 +129,7 @@ fn test_macro_variable_impl() {
         TokenTree::Group(Group::new(Delimiter::Brace, TokenStream::new())),
     ]);
 
-    snapshot!(tokens as Item, @r###"
+    snapshot!(tokens as Item, @r#"
     Item::Impl {
         generics: Generics,
         trait_: Some((
@@ -154,7 +154,7 @@ fn test_macro_variable_impl() {
             },
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -163,7 +163,7 @@ fn test_supertraits() {
 
     #[rustfmt::skip]
     let tokens = quote!(trait Trait where {});
-    snapshot!(tokens as ItemTrait, @r###"
+    snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
         ident: "Trait",
@@ -171,11 +171,11 @@ fn test_supertraits() {
             where_clause: Some(WhereClause),
         },
     }
-    "###);
+    "#);
 
     #[rustfmt::skip]
     let tokens = quote!(trait Trait: where {});
-    snapshot!(tokens as ItemTrait, @r###"
+    snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
         ident: "Trait",
@@ -184,11 +184,11 @@ fn test_supertraits() {
         },
         colon_token: Some,
     }
-    "###);
+    "#);
 
     #[rustfmt::skip]
     let tokens = quote!(trait Trait: Sized where {});
-    snapshot!(tokens as ItemTrait, @r###"
+    snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
         ident: "Trait",
@@ -208,11 +208,11 @@ fn test_supertraits() {
             }),
         ],
     }
-    "###);
+    "#);
 
     #[rustfmt::skip]
     let tokens = quote!(trait Trait: Sized + where {});
-    snapshot!(tokens as ItemTrait, @r###"
+    snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
         ident: "Trait",
@@ -233,7 +233,7 @@ fn test_supertraits() {
             Token![+],
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn test_type_empty_bounds() {
         }
     };
 
-    snapshot!(tokens as ItemTrait, @r###"
+    snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
         ident: "Foo",
@@ -258,7 +258,7 @@ fn test_type_empty_bounds() {
             },
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn test_impl_type_parameter_defaults() {
     let tokens = quote! {
         impl<T = ()> () {}
     };
-    snapshot!(tokens as Item, @r###"
+    snapshot!(tokens as Item, @r#"
     Item::Impl {
         generics: Generics {
             lt_token: Some,
@@ -292,7 +292,7 @@ fn test_impl_type_parameter_defaults() {
         },
         self_ty: Type::Tuple,
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -301,7 +301,7 @@ fn test_impl_trait_trailing_plus() {
         fn f() -> impl Sized + {}
     };
 
-    snapshot!(tokens as Item, @r###"
+    snapshot!(tokens as Item, @r#"
     Item::Fn {
         vis: Visibility::Inherited,
         sig: Signature {
@@ -328,5 +328,5 @@ fn test_impl_trait_trailing_plus() {
             stmts: [],
         },
     }
-    "###);
+    "#);
 }

--- a/tests/test_meta.rs
+++ b/tests/test_meta.rs
@@ -14,7 +14,7 @@ use syn::{Meta, MetaList, MetaNameValue};
 fn test_parse_meta_item_word() {
     let input = "hello";
 
-    snapshot!(input as Meta, @r###"
+    snapshot!(input as Meta, @r#"
     Meta::Path {
         segments: [
             PathSegment {
@@ -22,7 +22,7 @@ fn test_parse_meta_item_word() {
             },
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn test_parse_meta_name_value() {
     let input = "foo = 5";
     let (inner, meta) = (input, input);
 
-    snapshot!(inner as MetaNameValue, @r###"
+    snapshot!(inner as MetaNameValue, @r#"
     MetaNameValue {
         path: Path {
             segments: [
@@ -43,9 +43,9 @@ fn test_parse_meta_name_value() {
             lit: 5,
         },
     }
-    "###);
+    "#);
 
-    snapshot!(meta as Meta, @r###"
+    snapshot!(meta as Meta, @r#"
     Meta::NameValue {
         path: Path {
             segments: [
@@ -58,7 +58,7 @@ fn test_parse_meta_name_value() {
             lit: 5,
         },
     }
-    "###);
+    "#);
 
     assert_eq!(meta, Meta::NameValue(inner));
 }
@@ -68,7 +68,7 @@ fn test_parse_meta_item_list_lit() {
     let input = "foo(5)";
     let (inner, meta) = (input, input);
 
-    snapshot!(inner as MetaList, @r###"
+    snapshot!(inner as MetaList, @r#"
     MetaList {
         path: Path {
             segments: [
@@ -80,9 +80,9 @@ fn test_parse_meta_item_list_lit() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`5`),
     }
-    "###);
+    "#);
 
-    snapshot!(meta as Meta, @r###"
+    snapshot!(meta as Meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -94,7 +94,7 @@ fn test_parse_meta_item_list_lit() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`5`),
     }
-    "###);
+    "#);
 
     assert_eq!(meta, Meta::List(inner));
 }
@@ -104,7 +104,7 @@ fn test_parse_meta_item_multiple() {
     let input = "foo(word, name = 5, list(name2 = 6), word2)";
     let (inner, meta) = (input, input);
 
-    snapshot!(inner as MetaList, @r###"
+    snapshot!(inner as MetaList, @r#"
     MetaList {
         path: Path {
             segments: [
@@ -116,9 +116,9 @@ fn test_parse_meta_item_multiple() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`word , name = 5 , list (name2 = 6) , word2`),
     }
-    "###);
+    "#);
 
-    snapshot!(meta as Meta, @r###"
+    snapshot!(meta as Meta, @r#"
     Meta::List {
         path: Path {
             segments: [
@@ -130,7 +130,7 @@ fn test_parse_meta_item_multiple() {
         delimiter: MacroDelimiter::Paren,
         tokens: TokenStream(`word , name = 5 , list (name2 = 6) , word2`),
     }
-    "###);
+    "#);
 
     assert_eq!(meta, Meta::List(inner));
 }
@@ -138,7 +138,7 @@ fn test_parse_meta_item_multiple() {
 #[test]
 fn test_parse_path() {
     let input = "::serde::Serialize";
-    snapshot!(input as Meta, @r###"
+    snapshot!(input as Meta, @r#"
     Meta::Path {
         leading_colon: Some,
         segments: [
@@ -151,5 +151,5 @@ fn test_parse_path() {
             },
         ],
     }
-    "###);
+    "#);
 }

--- a/tests/test_parse_quote.rs
+++ b/tests/test_parse_quote.rs
@@ -9,7 +9,7 @@ use syn::{parse_quote, Attribute, Field, Lit, Pat, Stmt, Token};
 #[test]
 fn test_attribute() {
     let attr: Attribute = parse_quote!(#[test]);
-    snapshot!(attr, @r###"
+    snapshot!(attr, @r#"
     Attribute {
         style: AttrStyle::Outer,
         meta: Meta::Path {
@@ -20,10 +20,10 @@ fn test_attribute() {
             ],
         },
     }
-    "###);
+    "#);
 
     let attr: Attribute = parse_quote!(#![no_std]);
-    snapshot!(attr, @r###"
+    snapshot!(attr, @r#"
     Attribute {
         style: AttrStyle::Inner,
         meta: Meta::Path {
@@ -34,13 +34,13 @@ fn test_attribute() {
             ],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_field() {
     let field: Field = parse_quote!(pub enabled: bool);
-    snapshot!(field, @r###"
+    snapshot!(field, @r#"
     Field {
         vis: Visibility::Public,
         ident: Some("enabled"),
@@ -55,10 +55,10 @@ fn test_field() {
             },
         },
     }
-    "###);
+    "#);
 
     let field: Field = parse_quote!(primitive::bool);
-    snapshot!(field, @r###"
+    snapshot!(field, @r#"
     Field {
         vis: Visibility::Inherited,
         ty: Type::Path {
@@ -75,13 +75,13 @@ fn test_field() {
             },
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_pat() {
     let pat: Pat = parse_quote!(Some(false) | None);
-    snapshot!(&pat, @r###"
+    snapshot!(&pat, @r#"
     Pat::Or {
         cases: [
             Pat::TupleStruct {
@@ -106,7 +106,7 @@ fn test_pat() {
             },
         ],
     }
-    "###);
+    "#);
 
     let boxed_pat: Box<Pat> = parse_quote!(Some(false) | None);
     assert_eq!(*boxed_pat, pat);
@@ -115,7 +115,7 @@ fn test_pat() {
 #[test]
 fn test_punctuated() {
     let punctuated: Punctuated<Lit, Token![|]> = parse_quote!(true | true);
-    snapshot!(punctuated, @r###"
+    snapshot!(punctuated, @r#"
     [
         Lit::Bool {
             value: true,
@@ -125,10 +125,10 @@ fn test_punctuated() {
             value: true,
         },
     ]
-    "###);
+    "#);
 
     let punctuated: Punctuated<Lit, Token![|]> = parse_quote!(true | true |);
-    snapshot!(punctuated, @r###"
+    snapshot!(punctuated, @r#"
     [
         Lit::Bool {
             value: true,
@@ -139,7 +139,7 @@ fn test_punctuated() {
         },
         Token![|],
     ]
-    "###);
+    "#);
 }
 
 #[test]
@@ -148,7 +148,7 @@ fn test_vec_stmt() {
         let _;
         true
     };
-    snapshot!(stmts, @r###"
+    snapshot!(stmts, @r#"
     [
         Stmt::Local {
             pat: Pat::Wild,
@@ -162,5 +162,5 @@ fn test_vec_stmt() {
             None,
         ),
     ]
-    "###);
+    "#);
 }

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -51,7 +51,7 @@ fn test_group() {
     let tokens = TokenStream::from_iter([TokenTree::Group(group)]);
     let pat = Pat::parse_single.parse2(tokens).unwrap();
 
-    snapshot!(pat, @r###"
+    snapshot!(pat, @r#"
     Pat::TupleStruct {
         path: Path {
             segments: [
@@ -64,7 +64,7 @@ fn test_group() {
             Pat::Wild,
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -108,27 +108,27 @@ fn test_tuple_comma() {
 
     expr.elems.push_value(parse_quote!(_));
     // Must not parse to Pat::Paren
-    snapshot!(expr.to_token_stream() as Pat, @r###"
+    snapshot!(expr.to_token_stream() as Pat, @r#"
     Pat::Tuple {
         elems: [
             Pat::Wild,
             Token![,],
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Pat, @r###"
+    snapshot!(expr.to_token_stream() as Pat, @r#"
     Pat::Tuple {
         elems: [
             Pat::Wild,
             Token![,],
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_value(parse_quote!(_));
-    snapshot!(expr.to_token_stream() as Pat, @r###"
+    snapshot!(expr.to_token_stream() as Pat, @r#"
     Pat::Tuple {
         elems: [
             Pat::Wild,
@@ -136,10 +136,10 @@ fn test_tuple_comma() {
             Pat::Wild,
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Pat, @r###"
+    snapshot!(expr.to_token_stream() as Pat, @r#"
     Pat::Tuple {
         elems: [
             Pat::Wild,
@@ -148,5 +148,5 @@ fn test_tuple_comma() {
             Token![,],
         ],
     }
-    "###);
+    "#);
 }

--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -17,7 +17,7 @@ fn parse_interpolated_leading_component() {
         TokenTree::Ident(Ident::new("rest", Span::call_site())),
     ]);
 
-    snapshot!(tokens.clone() as Expr, @r###"
+    snapshot!(tokens.clone() as Expr, @r#"
     Expr::Path {
         path: Path {
             segments: [
@@ -31,9 +31,9 @@ fn parse_interpolated_leading_component() {
             ],
         },
     }
-    "###);
+    "#);
 
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::Path {
         path: Path {
             segments: [
@@ -47,58 +47,38 @@ fn parse_interpolated_leading_component() {
             ],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn print_incomplete_qpath() {
     // qpath with `as` token
     let mut ty: TypePath = parse_quote!(<Self as A>::Q);
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`< Self as A > :: Q`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`< Self as A > :: Q`)");
     assert!(ty.path.segments.pop().is_some());
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`< Self as A > ::`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`< Self as A > ::`)");
     assert!(ty.path.segments.pop().is_some());
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`< Self >`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`< Self >`)");
     assert!(ty.path.segments.pop().is_none());
 
     // qpath without `as` token
     let mut ty: TypePath = parse_quote!(<Self>::A::B);
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`< Self > :: A :: B`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`< Self > :: A :: B`)");
     assert!(ty.path.segments.pop().is_some());
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`< Self > :: A ::`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`< Self > :: A ::`)");
     assert!(ty.path.segments.pop().is_some());
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`< Self > ::`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`< Self > ::`)");
     assert!(ty.path.segments.pop().is_none());
 
     // normal path
     let mut ty: TypePath = parse_quote!(Self::A::B);
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`Self :: A :: B`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`Self :: A :: B`)");
     assert!(ty.path.segments.pop().is_some());
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`Self :: A ::`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`Self :: A ::`)");
     assert!(ty.path.segments.pop().is_some());
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(`Self ::`)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(`Self ::`)");
     assert!(ty.path.segments.pop().is_some());
-    snapshot!(ty.to_token_stream(), @r###"
-    TokenStream(``)
-    "###);
+    snapshot!(ty.to_token_stream(), @"TokenStream(``)");
     assert!(ty.path.segments.pop().is_none());
 }
 
@@ -106,7 +86,7 @@ fn print_incomplete_qpath() {
 fn parse_parenthesized_path_arguments_with_disambiguator() {
     #[rustfmt::skip]
     let tokens = quote!(dyn FnOnce::() -> !);
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::TraitObject {
         dyn_token: Some,
         bounds: [
@@ -126,5 +106,5 @@ fn parse_parenthesized_path_arguments_with_disambiguator() {
             }),
         ],
     }
-    "###);
+    "#);
 }

--- a/tests/test_receiver.rs
+++ b/tests/test_receiver.rs
@@ -10,7 +10,7 @@ fn test_by_value() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn by_value(self: Self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         colon_token: Some,
         ty: Type::Path {
@@ -23,7 +23,7 @@ fn test_by_value() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn test_by_mut_value() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn by_mut(mut self: Self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         mutability: Some,
         colon_token: Some,
@@ -45,7 +45,7 @@ fn test_by_mut_value() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn test_by_ref() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn by_ref(self: &Self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         colon_token: Some,
         ty: Type::Reference {
@@ -68,7 +68,7 @@ fn test_by_ref() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -76,7 +76,7 @@ fn test_by_box() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn by_box(self: Box<Self>);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         colon_token: Some,
         ty: Type::Path {
@@ -102,7 +102,7 @@ fn test_by_box() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn test_by_pin() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn by_pin(self: Pin<Self>);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         colon_token: Some,
         ty: Type::Path {
@@ -136,7 +136,7 @@ fn test_by_pin() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn test_explicit_type() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn explicit_type(self: Pin<MyType>);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         colon_token: Some,
         ty: Type::Path {
@@ -170,7 +170,7 @@ fn test_explicit_type() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn test_value_shorthand() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn value_shorthand(self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         ty: Type::Path {
             path: Path {
@@ -190,7 +190,7 @@ fn test_value_shorthand() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -198,7 +198,7 @@ fn test_mut_value_shorthand() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn mut_value_shorthand(mut self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         mutability: Some,
         ty: Type::Path {
@@ -211,7 +211,7 @@ fn test_mut_value_shorthand() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -219,7 +219,7 @@ fn test_ref_shorthand() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn ref_shorthand(&self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         reference: Some(None),
         ty: Type::Reference {
@@ -234,7 +234,7 @@ fn test_ref_shorthand() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -242,7 +242,7 @@ fn test_ref_shorthand_with_lifetime() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn ref_shorthand(&'a self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         reference: Some(Some(Lifetime {
             ident: "a",
@@ -262,7 +262,7 @@ fn test_ref_shorthand_with_lifetime() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -270,7 +270,7 @@ fn test_ref_mut_shorthand() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn ref_mut_shorthand(&mut self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         reference: Some(None),
         mutability: Some,
@@ -287,7 +287,7 @@ fn test_ref_mut_shorthand() {
             },
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -295,7 +295,7 @@ fn test_ref_mut_shorthand_with_lifetime() {
     let TraitItemFn { sig, .. } = parse_quote! {
         fn ref_mut_shorthand(&'a mut self);
     };
-    snapshot!(&sig.inputs[0], @r###"
+    snapshot!(&sig.inputs[0], @r#"
     FnArg::Receiver(Receiver {
         reference: Some(Some(Lifetime {
             ident: "a",
@@ -317,5 +317,5 @@ fn test_ref_mut_shorthand_with_lifetime() {
             },
         },
     })
-    "###);
+    "#);
 }

--- a/tests/test_shebang.rs
+++ b/tests/test_shebang.rs
@@ -7,7 +7,7 @@ mod macros;
 fn test_basic() {
     let content = "#!/usr/bin/env rustx\nfn main() {}";
     let file = syn::parse_file(content).unwrap();
-    snapshot!(file, @r###"
+    snapshot!(file, @r##"
     File {
         shebang: Some("#!/usr/bin/env rustx"),
         items: [
@@ -24,14 +24,14 @@ fn test_basic() {
             },
         ],
     }
-    "###);
+    "##);
 }
 
 #[test]
 fn test_comment() {
     let content = "#!//am/i/a/comment\n[allow(dead_code)] fn main() {}";
     let file = syn::parse_file(content).unwrap();
-    snapshot!(file, @r###"
+    snapshot!(file, @r#"
     File {
         attrs: [
             Attribute {
@@ -63,5 +63,5 @@ fn test_comment() {
             },
         ],
     }
-    "###);
+    "#);
 }

--- a/tests/test_stmt.rs
+++ b/tests/test_stmt.rs
@@ -17,21 +17,21 @@ use syn::{Block, Stmt};
 fn test_raw_operator() {
     let stmt = syn::parse_str::<Stmt>("let _ = &raw const x;").unwrap();
 
-    snapshot!(stmt, @r###"
+    snapshot!(stmt, @r#"
     Stmt::Local {
         pat: Pat::Wild,
         init: Some(LocalInit {
             expr: Expr::Verbatim(`& raw const x`),
         }),
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_raw_variable() {
     let stmt = syn::parse_str::<Stmt>("let _ = &raw;").unwrap();
 
-    snapshot!(stmt, @r###"
+    snapshot!(stmt, @r#"
     Stmt::Local {
         pat: Pat::Wild,
         init: Some(LocalInit {
@@ -48,7 +48,7 @@ fn test_raw_variable() {
             },
         }),
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn test_none_group() {
             TokenTree::Group(Group::new(Delimiter::Brace, TokenStream::new())),
         ]),
     ))]);
-    snapshot!(tokens as Stmt, @r###"
+    snapshot!(tokens as Stmt, @r#"
     Stmt::Item(Item::Fn {
         vis: Visibility::Inherited,
         sig: Signature {
@@ -82,11 +82,11 @@ fn test_none_group() {
             stmts: [],
         },
     })
-    "###);
+    "#);
 
     let tokens = Group::new(Delimiter::None, quote!(let None = None)).to_token_stream();
     let stmts = Block::parse_within.parse2(tokens).unwrap();
-    snapshot!(stmts, @r###"
+    snapshot!(stmts, @r#"
     [
         Stmt::Expr(
             Expr::Group {
@@ -108,7 +108,7 @@ fn test_none_group() {
             None,
         ),
     ]
-    "###);
+    "#);
 }
 
 #[test]
@@ -117,7 +117,7 @@ fn test_let_dot_dot() {
         let .. = 10;
     };
 
-    snapshot!(tokens as Stmt, @r###"
+    snapshot!(tokens as Stmt, @r#"
     Stmt::Local {
         pat: Pat::Rest,
         init: Some(LocalInit {
@@ -126,7 +126,7 @@ fn test_let_dot_dot() {
             },
         }),
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -135,7 +135,7 @@ fn test_let_else() {
         let Some(x) = None else { return 0; };
     };
 
-    snapshot!(tokens as Stmt, @r###"
+    snapshot!(tokens as Stmt, @r#"
     Stmt::Local {
         pat: Pat::TupleStruct {
             path: Path {
@@ -177,7 +177,7 @@ fn test_let_else() {
             }),
         }),
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn test_macros() {
         }
     };
 
-    snapshot!(tokens as Stmt, @r###"
+    snapshot!(tokens as Stmt, @r#"
     Stmt::Item(Item::Fn {
         vis: Visibility::Inherited,
         sig: Signature {
@@ -261,7 +261,7 @@ fn test_macros() {
             ],
         },
     })
-    "###);
+    "#);
 }
 
 #[test]
@@ -275,7 +275,7 @@ fn test_early_parse_loop() {
 
     let stmts = Block::parse_within.parse2(tokens).unwrap();
 
-    snapshot!(stmts, @r###"
+    snapshot!(stmts, @r#"
     [
         Stmt::Expr(
             Expr::Loop {
@@ -290,7 +290,7 @@ fn test_early_parse_loop() {
             None,
         ),
     ]
-    "###);
+    "#);
 
     let tokens = quote! {
         'a: loop {}
@@ -299,7 +299,7 @@ fn test_early_parse_loop() {
 
     let stmts = Block::parse_within.parse2(tokens).unwrap();
 
-    snapshot!(stmts, @r###"
+    snapshot!(stmts, @r#"
     [
         Stmt::Expr(
             Expr::Loop {
@@ -319,5 +319,5 @@ fn test_early_parse_loop() {
             None,
         ),
     ]
-    "###);
+    "#);
 }

--- a/tests/test_token_trees.rs
+++ b/tests/test_token_trees.rs
@@ -17,11 +17,11 @@ fn test_struct() {
         }
     ";
 
-    snapshot!(input as TokenStream, @r###"
+    snapshot!(input as TokenStream, @r##"
     TokenStream(
         `# [derive (Debug , Clone)] pub struct Item { pub ident : Ident , pub attrs : Vec < Attribute >, }`,
     )
-    "###);
+    "##);
 }
 
 #[test]

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -28,7 +28,7 @@ fn test_macro_variable_type() {
         TokenTree::Punct(Punct::new('>', Spacing::Alone)),
     ]);
 
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::Path {
         path: Path {
             segments: [
@@ -51,7 +51,7 @@ fn test_macro_variable_type() {
             ],
         },
     }
-    "###);
+    "#);
 
     // mimics the token stream corresponding to `$ty::<T>`
     let tokens = TokenStream::from_iter([
@@ -63,7 +63,7 @@ fn test_macro_variable_type() {
         TokenTree::Punct(Punct::new('>', Spacing::Alone)),
     ]);
 
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::Path {
         path: Path {
             segments: [
@@ -87,7 +87,7 @@ fn test_macro_variable_type() {
             ],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -100,7 +100,7 @@ fn test_group_angle_brackets() {
         TokenTree::Punct(Punct::new('>', Spacing::Alone)),
     ]);
 
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::Path {
         path: Path {
             segments: [
@@ -138,7 +138,7 @@ fn test_group_angle_brackets() {
             ],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn test_group_colons() {
         TokenTree::Ident(Ident::new("Item", Span::call_site())),
     ]);
 
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::Path {
         path: Path {
             segments: [
@@ -178,7 +178,7 @@ fn test_group_colons() {
             ],
         },
     }
-    "###);
+    "#);
 
     let tokens = TokenStream::from_iter([
         TokenTree::Group(Group::new(Delimiter::None, quote! { [T] })),
@@ -187,7 +187,7 @@ fn test_group_colons() {
         TokenTree::Ident(Ident::new("Element", Span::call_site())),
     ]);
 
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::Path {
         qself: Some(QSelf {
             ty: Type::Slice {
@@ -212,13 +212,13 @@ fn test_group_colons() {
             ],
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
 fn test_trait_object() {
     let tokens = quote!(dyn for<'a> Trait<'a> + 'static);
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::TraitObject {
         dyn_token: Some,
         bounds: [
@@ -253,10 +253,10 @@ fn test_trait_object() {
             },
         ],
     }
-    "###);
+    "#);
 
     let tokens = quote!(dyn 'a + Trait);
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::TraitObject {
         dyn_token: Some,
         bounds: [
@@ -275,7 +275,7 @@ fn test_trait_object() {
             }),
         ],
     }
-    "###);
+    "#);
 
     // None of the following are valid Rust types.
     syn::parse_str::<Type>("for<'a> dyn Trait<'a>").unwrap_err();
@@ -286,7 +286,7 @@ fn test_trait_object() {
 fn test_trailing_plus() {
     #[rustfmt::skip]
     let tokens = quote!(impl Trait +);
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::ImplTrait {
         bounds: [
             TypeParamBound::Trait(TraitBound {
@@ -301,11 +301,11 @@ fn test_trailing_plus() {
             Token![+],
         ],
     }
-    "###);
+    "#);
 
     #[rustfmt::skip]
     let tokens = quote!(dyn Trait +);
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::TraitObject {
         dyn_token: Some,
         bounds: [
@@ -321,11 +321,11 @@ fn test_trailing_plus() {
             Token![+],
         ],
     }
-    "###);
+    "#);
 
     #[rustfmt::skip]
     let tokens = quote!(Trait +);
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::TraitObject {
         bounds: [
             TypeParamBound::Trait(TraitBound {
@@ -340,7 +340,7 @@ fn test_trailing_plus() {
             Token![+],
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -353,27 +353,27 @@ fn test_tuple_comma() {
 
     expr.elems.push_value(parse_quote!(_));
     // Must not parse to Type::Paren
-    snapshot!(expr.to_token_stream() as Type, @r###"
+    snapshot!(expr.to_token_stream() as Type, @r#"
     Type::Tuple {
         elems: [
             Type::Infer,
             Token![,],
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Type, @r###"
+    snapshot!(expr.to_token_stream() as Type, @r#"
     Type::Tuple {
         elems: [
             Type::Infer,
             Token![,],
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_value(parse_quote!(_));
-    snapshot!(expr.to_token_stream() as Type, @r###"
+    snapshot!(expr.to_token_stream() as Type, @r#"
     Type::Tuple {
         elems: [
             Type::Infer,
@@ -381,10 +381,10 @@ fn test_tuple_comma() {
             Type::Infer,
         ],
     }
-    "###);
+    "#);
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Type, @r###"
+    snapshot!(expr.to_token_stream() as Type, @r#"
     Type::Tuple {
         elems: [
             Type::Infer,
@@ -393,7 +393,7 @@ fn test_tuple_comma() {
             Token![,],
         ],
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -402,7 +402,7 @@ fn test_impl_trait_use() {
         impl Sized + use<'_, 'a, A, Test>
     };
 
-    snapshot!(tokens as Type, @r###"
+    snapshot!(tokens as Type, @r#"
     Type::ImplTrait {
         bounds: [
             TypeParamBound::Trait(TraitBound {
@@ -418,13 +418,13 @@ fn test_impl_trait_use() {
             TypeParamBound::Verbatim(`use < '_ , 'a , A , Test >`),
         ],
     }
-    "###);
+    "#);
 
     let trailing = quote! {
         impl Sized + use<'_,>
     };
 
-    snapshot!(trailing as Type, @r###"
+    snapshot!(trailing as Type, @r#"
     Type::ImplTrait {
         bounds: [
             TypeParamBound::Trait(TraitBound {
@@ -440,5 +440,5 @@ fn test_impl_trait_use() {
             TypeParamBound::Verbatim(`use < '_ , >`),
         ],
     }
-    "###);
+    "#);
 }

--- a/tests/test_visibility.rs
+++ b/tests/test_visibility.rs
@@ -117,7 +117,7 @@ fn test_inherited_vis_named_field() {
         )),
     ]);
 
-    snapshot!(tokens as DeriveInput, @r###"
+    snapshot!(tokens as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "S",
@@ -135,7 +135,7 @@ fn test_inherited_vis_named_field() {
             },
         },
     }
-    "###);
+    "#);
 }
 
 #[test]
@@ -154,7 +154,7 @@ fn test_inherited_vis_unnamed_field() {
         TokenTree::Punct(Punct::new(';', Spacing::Alone)),
     ]);
 
-    snapshot!(tokens as DeriveInput, @r###"
+    snapshot!(tokens as DeriveInput, @r#"
     DeriveInput {
         vis: Visibility::Inherited,
         ident: "S",
@@ -181,5 +181,5 @@ fn test_inherited_vis_unnamed_field() {
             semi_token: Some,
         },
     }
-    "###);
+    "#);
 }


### PR DESCRIPTION
As of https://github.com/mitsuhiko/insta/pull/540 and https://github.com/mitsuhiko/insta/pull/603, `cargo insta accept` writes fewer `###` in its raw string literals than it used to.