### PR TITLE
Reject precise captures and ~const in inappropriate syntax positions

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1205,7 +1205,15 @@ pub(crate) mod parsing {
                     if input.peek(Token![where]) || input.peek(Token![=]) || input.peek(Token![;]) {
                         break;
                     }
-                    bounds.push_value(input.parse::<TypeParamBound>()?);
+                    bounds.push_value({
+                        let allow_precise_capture = false;
+                        let allow_tilde_const = true;
+                        TypeParamBound::parse_single(
+                            input,
+                            allow_precise_capture,
+                            allow_tilde_const,
+                        )?
+                    });
                     if input.peek(Token![where]) || input.peek(Token![=]) || input.peek(Token![;]) {
                         break;
                     }
@@ -2184,7 +2192,11 @@ pub(crate) mod parsing {
                 if input.peek(Token![where]) || input.peek(token::Brace) {
                     break;
                 }
-                supertraits.push_value(input.parse()?);
+                supertraits.push_value({
+                    let allow_precise_capture = false;
+                    let allow_tilde_const = true;
+                    TypeParamBound::parse_single(input, allow_precise_capture, allow_tilde_const)?
+                });
                 if input.peek(Token![where]) || input.peek(token::Brace) {
                     break;
                 }
@@ -2252,7 +2264,11 @@ pub(crate) mod parsing {
             if input.peek(Token![where]) || input.peek(Token![;]) {
                 break;
             }
-            bounds.push_value(input.parse()?);
+            bounds.push_value({
+                let allow_precise_capture = false;
+                let allow_tilde_const = false;
+                TypeParamBound::parse_single(input, allow_precise_capture, allow_tilde_const)?
+            });
             if input.peek(Token![where]) || input.peek(Token![;]) {
                 break;
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -377,8 +377,15 @@ pub(crate) mod parsing {
                                     if input.peek(Token![,]) || input.peek(Token![>]) {
                                         break;
                                     }
-                                    let value: TypeParamBound = input.parse()?;
-                                    bounds.push_value(value);
+                                    bounds.push_value({
+                                        let allow_precise_capture = false;
+                                        let allow_tilde_const = true;
+                                        TypeParamBound::parse_single(
+                                            input,
+                                            allow_precise_capture,
+                                            allow_tilde_const,
+                                        )?
+                                    });
                                     if !input.peek(Token![+]) {
                                         break;
                                     }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -402,7 +402,15 @@ pub(crate) mod parsing {
                         }));
                         while let Some(plus) = input.parse()? {
                             bounds.push_punct(plus);
-                            bounds.push_value(input.parse()?);
+                            bounds.push_value({
+                                let allow_precise_capture = false;
+                                let allow_tilde_const = false;
+                                TypeParamBound::parse_single(
+                                    input,
+                                    allow_precise_capture,
+                                    allow_tilde_const,
+                                )?
+                            });
                         }
                         bounds
                     },
@@ -469,7 +477,15 @@ pub(crate) mod parsing {
                             bounds.push_value(first);
                             while let Some(plus) = input.parse()? {
                                 bounds.push_punct(plus);
-                                bounds.push_value(input.parse()?);
+                                bounds.push_value({
+                                    let allow_precise_capture = false;
+                                    let allow_tilde_const = false;
+                                    TypeParamBound::parse_single(
+                                        input,
+                                        allow_precise_capture,
+                                        allow_tilde_const,
+                                    )?
+                                });
                             }
                             bounds
                         },
@@ -532,7 +548,15 @@ pub(crate) mod parsing {
                         {
                             break;
                         }
-                        bounds.push_value(input.parse()?);
+                        bounds.push_value({
+                            let allow_precise_capture = false;
+                            let allow_tilde_const = false;
+                            TypeParamBound::parse_single(
+                                input,
+                                allow_precise_capture,
+                                allow_tilde_const,
+                            )?
+                        });
                     }
                 }
                 return Ok(Type::TraitObject(TypeTraitObject {
@@ -823,7 +847,14 @@ pub(crate) mod parsing {
             input: ParseStream,
             allow_plus: bool,
         ) -> Result<Punctuated<TypeParamBound, Token![+]>> {
-            let bounds = TypeParamBound::parse_multiple(input, allow_plus)?;
+            let allow_precise_capture = false;
+            let allow_tilde_const = false;
+            let bounds = TypeParamBound::parse_multiple(
+                input,
+                allow_plus,
+                allow_precise_capture,
+                allow_tilde_const,
+            )?;
             let mut last_lifetime_span = None;
             let mut at_least_one_trait = false;
             for bound in &bounds {
@@ -863,7 +894,14 @@ pub(crate) mod parsing {
 
         pub(crate) fn parse(input: ParseStream, allow_plus: bool) -> Result<Self> {
             let impl_token: Token![impl] = input.parse()?;
-            let bounds = TypeParamBound::parse_multiple(input, allow_plus)?;
+            let allow_precise_capture = true;
+            let allow_tilde_const = false;
+            let bounds = TypeParamBound::parse_multiple(
+                input,
+                allow_plus,
+                allow_precise_capture,
+                allow_tilde_const,
+            )?;
             let mut last_lifetime_span = None;
             let mut at_least_one_trait = false;
             for bound in &bounds {


### PR DESCRIPTION
Syntax like `let _: &dyn ~const Trait` and `trait Alias<'a> = use<'a> + Trait` are not allowed.