### PR TITLE
Preserve extern static unsafety in ForeignItem::Verbatim

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1896,7 +1896,7 @@ pub(crate) mod parsing {
                     input.parse::<Expr>()?;
                 }
                 let semi_token: Token![;] = input.parse()?;
-                if safe || has_value {
+                if unsafety.is_some() || safe || has_value {
                     Ok(ForeignItem::Verbatim(verbatim::between(&begin, input)))
                 } else {
                     Ok(ForeignItem::Static(ForeignItemStatic {


### PR DESCRIPTION
```rust
unsafe extern {
    pub unsafe static STATIC: T;
}
```

Fixes a bug in #1768.