### PR TITLE
Allow `parse_quote!` to produce Vec<Attribute>

### DIFF
--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -154,6 +154,17 @@ impl ParseQuote for Attribute {
 }
 
 #[cfg(any(feature = "full", feature = "derive"))]
+impl ParseQuote for Vec<Attribute> {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut attrs = Vec::new();
+        while !input.is_empty() {
+            attrs.push(ParseQuote::parse(input)?);
+        }
+        Ok(attrs)
+    }
+}
+
+#[cfg(any(feature = "full", feature = "derive"))]
 impl ParseQuote for Field {
     fn parse(input: ParseStream) -> Result<Self> {
         let attrs = input.call(Attribute::parse_outer)?;


### PR DESCRIPTION
`parse_quote!` for a single Attribute was already supported since #319.

```rust
self.attrs.push(parse_quote! {
    #[...]
});
```

This PR adds support for:

```rust
self.attrs = parse_quote! {
    #[...]
    #[...]
};
```

```rust
self.attrs.append(&mut parse_quote! {
    #[...]
    #[...]
});
```