### PR TITLE
Parse raw addr syntax in discriminants

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -322,7 +322,7 @@ pub(crate) mod parsing {
         loop {
             if initial {
                 if consume![&] {
-                    input.parse::<Option<Token![mut]>>()?;
+                    initial = consume![mut] || !consume![raw] || consume![const] || consume![mut];
                 } else if consume![if] || consume![match] || consume![while] {
                     depth += 1;
                 } else if input.parse::<Option<Lit>>()?.is_some()


### PR DESCRIPTION
https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#native-syntax-for-creating-a-raw-pointer

```rust
static X: i32 = 0;

pub enum Enum {
    Variant = match &raw const X { _ => 1 },
}
```