### PR TITLE
Lower the precedence of expressions containing outer attrs

### DIFF
--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -702,6 +702,7 @@ fn test_fixup() {
         quote! { (..) += () },
         quote! { (1 < 2) == (3 < 4) },
         quote! { { (let _ = ()) } },
+        quote! { (#[attr] thing).field },
     ] {
         let original: Expr = syn::parse2(tokens).unwrap();
 


### PR DESCRIPTION
`thing.field` does not need parentheses around `thing`, but `(#[attr] thing).field` does. So the presence of outer attributes is relevant to the effective precedence of a subexpression.