### PR TITLE
Fix parenthesization of jumps in ranges

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3752,11 +3752,12 @@ pub(crate) mod printing {
     fn print_expr_range(e: &ExprRange, tokens: &mut TokenStream, fixup: FixupContext) {
         outer_attrs_to_tokens(&e.attrs, tokens);
         if let Some(start) = &e.start {
+            let start_fixup = fixup.leftmost_subexpression_with_begin_operator(true, false);
             print_subexpression(
                 start,
-                Precedence::of(start) <= Precedence::Range,
+                start_fixup.leading_precedence(start) <= Precedence::Range,
                 tokens,
-                fixup.leftmost_subexpression(),
+                start_fixup,
             );
         }
         e.limits.to_tokens(tokens);

--- a/src/fixup.rs
+++ b/src/fixup.rs
@@ -323,7 +323,7 @@ impl FixupContext {
                 _ => {}
             }
         }
-        self.precedence(expr)
+        self.leading_precedence(expr)
     }
 
     fn precedence(self, expr: &Expr) -> Precedence {

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -704,6 +704,8 @@ fn test_fixup() {
         quote! { { (let _ = ()) } },
         quote! { (#[attr] thing).field },
         quote! { (self.f)() },
+        quote! { (return)..=return },
+        quote! { 1 + (return)..=1 + return },
     ] {
         let original: Expr = syn::parse2(tokens).unwrap();
 


### PR DESCRIPTION
Previously, the syntax tree for `(return)..=return` (with paren flattened away) would get incorrectly turned into `return ..=return` which means a different thing.