### PR TITLE
Rename subsequent_subexpression -> rightmost_subexpression

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3282,7 +3282,7 @@ pub(crate) mod printing {
             &e.right,
             fixup.precedence(&e.right) < Precedence::Assign,
             tokens,
-            fixup.subsequent_subexpression(),
+            fixup.rightmost_subexpression(),
         );
     }
 
@@ -3362,7 +3362,7 @@ pub(crate) mod printing {
             &e.right,
             right_needs_group,
             tokens,
-            fixup.subsequent_subexpression(),
+            fixup.rightmost_subexpression(),
         );
     }
 
@@ -3399,7 +3399,7 @@ pub(crate) mod printing {
                 //                     ^---------------------------------^
                 e.label.is_none() && classify::expr_leading_label(value),
                 tokens,
-                fixup.subsequent_subexpression(),
+                fixup.rightmost_subexpression(),
             );
         }
     }
@@ -3766,7 +3766,7 @@ pub(crate) mod printing {
                 end,
                 fixup.precedence(end) <= Precedence::Range,
                 tokens,
-                fixup.subsequent_subexpression(),
+                fixup.rightmost_subexpression(),
             );
         }
     }
@@ -3789,7 +3789,7 @@ pub(crate) mod printing {
             &e.expr,
             fixup.precedence(&e.expr) < Precedence::Prefix,
             tokens,
-            fixup.subsequent_subexpression(),
+            fixup.rightmost_subexpression(),
         );
     }
 
@@ -3808,7 +3808,7 @@ pub(crate) mod printing {
             &e.expr,
             fixup.precedence(&e.expr) < Precedence::Prefix,
             tokens,
-            fixup.subsequent_subexpression(),
+            fixup.rightmost_subexpression(),
         );
     }
 
@@ -3838,7 +3838,7 @@ pub(crate) mod printing {
         outer_attrs_to_tokens(&e.attrs, tokens);
         e.return_token.to_tokens(tokens);
         if let Some(expr) = &e.expr {
-            print_expr(expr, tokens, fixup.subsequent_subexpression());
+            print_expr(expr, tokens, fixup.rightmost_subexpression());
         }
     }
 
@@ -3918,7 +3918,7 @@ pub(crate) mod printing {
             &e.expr,
             fixup.precedence(&e.expr) < Precedence::Prefix,
             tokens,
-            fixup.subsequent_subexpression(),
+            fixup.rightmost_subexpression(),
         );
     }
 
@@ -3963,7 +3963,7 @@ pub(crate) mod printing {
         outer_attrs_to_tokens(&e.attrs, tokens);
         e.yield_token.to_tokens(tokens);
         if let Some(expr) = &e.expr {
-            print_expr(expr, tokens, fixup.subsequent_subexpression());
+            print_expr(expr, tokens, fixup.rightmost_subexpression());
         }
     }
 

--- a/src/fixup.rs
+++ b/src/fixup.rs
@@ -242,15 +242,18 @@ impl FixupContext {
         }
     }
 
-    /// Transform this fixup into the one that should apply when printing any
-    /// subexpression that is neither a leftmost subexpression nor surrounded in
-    /// delimiters.
+    /// Transform this fixup into the one that should apply when printing the
+    /// rightmost subexpression of the current expression.
     ///
-    /// This is for any subexpression that has a different first token than the
-    /// current expression, and is not surrounded by a paren/bracket/brace. For
-    /// example the `$b` in `$a + $b` and `-$b`, but not the one in `[$b]` or
-    /// `$a.f($b)`.
-    pub fn subsequent_subexpression(self) -> Self {
+    /// The rightmost subexpression is any subexpression that has a different
+    /// first token than the current expression, but has the same last token.
+    ///
+    /// For example in `$a + $b` and `-$b`, the subexpression `$b` is a
+    /// rightmost subexpression.
+    ///
+    /// Not every expression has a rightmost subexpression. For example neither
+    /// `[$b]` nor `$a.f($b)` have one.
+    pub fn rightmost_subexpression(self) -> Self {
         FixupContext {
             #[cfg(feature = "full")]
             stmt: false,


### PR DESCRIPTION
The logic in this function, notably the treatment of `next_operator_can_begin_expr` and `next_operator_can_continue_expr` and `next_operator_can_begin_generics`, only makes sense if the subexpression's last token is the same as the outer expression's last token.