### PR TITLE
Fix incorrect parse of statement macro followed by range

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -208,7 +208,8 @@ pub(crate) mod parsing {
                 if ahead.peek2(Ident) || ahead.peek2(Token![try]) {
                     is_item_macro = true;
                 } else if ahead.peek2(token::Brace)
-                    && !(ahead.peek3(Token![.]) || ahead.peek3(Token![?]))
+                    && !(ahead.peek3(Token![.]) && !ahead.peek3(Token![..])
+                        || ahead.peek3(Token![?]))
                 {
                     input.advance_to(&ahead);
                     return stmt_mac(input, attrs, path).map(Stmt::Macro);


### PR DESCRIPTION
For the program `fn main() { m! {} .. }`, Syn would previously parse this as `[Stmt::Expr(Expr::Range { start: Expr::Macro, end: None })]`. The correct parse is `[Stmt::Macro, Stmt::Expr(Expr::Range { start: None, end: None })]` as is clear from the following diagnostic from rustc.

```console
error[E0308]: mismatched types
 --> src/main.rs:1:19
  |
1 | fn main() { m! {} .. }
  |          -        ^^ expected `()`, found `RangeFull`
  |          |
  |          expected `()` because of default return type
```