### PR TITLE
Disambiguate Expr::Cast precedence in scan_left

### DIFF
--- a/src/fixup.rs
+++ b/src/fixup.rs
@@ -475,6 +475,7 @@ fn scan_left(expr: &Expr, fixup: FixupContext) -> bool {
             Precedence::Assign => fixup.previous_operator <= Precedence::Assign,
             binop_prec => fixup.previous_operator < binop_prec,
         },
+        Expr::Cast(_) => fixup.previous_operator < Precedence::Cast,
         Expr::Range(e) => e.start.is_none() || fixup.previous_operator < Precedence::Assign,
         _ => true,
     }


### PR DESCRIPTION
This makes a difference for expressions such as `*(&(x as T)..)` (unary deref containing range containing reference containing cast). Without this, it would get printed incorrectly as `*(&x as T..)` (unary deref containing range containing cast containing reference).