### PR TITLE
Short-circuit precedence scan for high-precedence expressions

### DIFF
--- a/src/fixup.rs
+++ b/src/fixup.rs
@@ -351,9 +351,15 @@ impl FixupContext {
         let default_prec = self.precedence(expr);
 
         #[cfg(feature = "full")]
-        if default_prec < Precedence::Prefix
-            && (!self.next_operator_can_begin_expr || self.next_operator == Precedence::Range)
-        {
+        if match self.previous_operator {
+            Precedence::Assign | Precedence::Let | Precedence::Prefix => {
+                default_prec < self.previous_operator
+            }
+            _ => default_prec <= self.previous_operator,
+        } && match self.next_operator {
+            Precedence::Range => true,
+            _ => !self.next_operator_can_begin_expr,
+        } {
             if let Scan::Bailout | Scan::Fail = scan_right(expr, self, self.previous_operator, 1, 0)
             {
                 if scan_left(expr, self) {


### PR DESCRIPTION
This part of rightmost_subexpression_precedence is deciding whether to raise the precedence of a low-precedence expression because the parenthesis's role is instead going to be served by a bailout. But when the caller was not planning to put parentheses anyway, computing a completely accurate precedence is unnecessary work.