### PR TITLE
Allow lifetimes in function pointer return values

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -502,7 +502,7 @@ impl<'a> ParseBuffer<'a> {
     ///     }
     /// }
     /// ```
-    pub fn call<T>(&self, function: fn(ParseStream) -> Result<T>) -> Result<T> {
+    pub fn call<T>(&'a self, function: fn(ParseStream<'a>) -> Result<T>) -> Result<T> {
         function(self)
     }
 
@@ -732,8 +732,8 @@ impl<'a> ParseBuffer<'a> {
     /// }
     /// ```
     pub fn parse_terminated<T, P>(
-        &self,
-        parser: fn(ParseStream) -> Result<T>,
+        &'a self,
+        parser: fn(ParseStream<'a>) -> Result<T>,
         separator: P,
     ) -> Result<Punctuated<T, P::Token>>
     where

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -305,9 +305,9 @@ impl<T, P> Punctuated<T, P> {
     /// [`parse_terminated`]: Punctuated::parse_terminated
     #[cfg(feature = "parsing")]
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
-    pub fn parse_terminated_with(
-        input: ParseStream,
-        parser: fn(ParseStream) -> Result<T>,
+    pub fn parse_terminated_with<'a>(
+        input: ParseStream<'a>,
+        parser: fn(ParseStream<'a>) -> Result<T>,
     ) -> Result<Self>
     where
         P: Parse,
@@ -357,9 +357,9 @@ impl<T, P> Punctuated<T, P> {
     /// [`parse_separated_nonempty`]: Punctuated::parse_separated_nonempty
     #[cfg(feature = "parsing")]
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
-    pub fn parse_separated_nonempty_with(
-        input: ParseStream,
-        parser: fn(ParseStream) -> Result<T>,
+    pub fn parse_separated_nonempty_with<'a>(
+        input: ParseStream<'a>,
+        parser: fn(ParseStream<'a>) -> Result<T>,
     ) -> Result<Self>
     where
         P: Token + Parse,


### PR DESCRIPTION
Example:

```rust
use syn::parse::{ParseBuffer, ParseStream, Result};
use syn::token::{Brace, Bracket, Paren};
use syn::{braced, bracketed, parenthesized, MacroDelimiter};

fn parse(input: ParseStream) -> Result<()> {
    let (_delim, _content) = input.call(macro_delimiter)?;
    Ok(())
}

fn macro_delimiter<'a>(input: ParseStream<'a>) -> Result<(MacroDelimiter, ParseBuffer<'a>)> {
    let content;
    let lookahead = input.lookahead1();
    let delim = if input.peek(Paren) {
        MacroDelimiter::Paren(parenthesized!(content in input))
    } else if input.peek(Brace) {
        MacroDelimiter::Brace(braced!(content in input))
    } else if input.peek(Bracket) {
        MacroDelimiter::Bracket(bracketed!(content in input))
    } else {
        return Err(lookahead.error());
    };
    Ok((delim, content))
}
```

**Before:**

```console
error[E0308]: mismatched types
   --> src/main.rs:6:41
    |
6   |     let (_delim, _content) = input.call(macro_delimiter)?;
    |                                    ---- ^^^^^^^^^^^^^^^ one type is more general than the other
    |                                    |
    |                                    arguments to this method are incorrect
    |
    = note: expected fn pointer `for<'a> fn(&'a ParseBuffer<'a>) -> Result<_, _>`
                  found fn item `for<'a> fn(&'a ParseBuffer<'a>) -> Result<(MacroDelimiter, ParseBuffer<'a>), _> {macro_delimiter}`
note: method defined here
   --> syn/src/parse.rs:505:12
    |
505 |     pub fn call<T>(&self, function: fn(ParseStream) -> Result<T>) -> Result<T> {
    |            ^^^^
```

**After:** works.