### PR TITLE
feat: ParseBuffer::call takes FnOnce(..) instead of fn(..)

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -502,7 +502,7 @@ impl<'a> ParseBuffer<'a> {
     ///     }
     /// }
     /// ```
-    pub fn call<T>(&'a self, function: fn(ParseStream<'a>) -> Result<T>) -> Result<T> {
+    pub fn call<T>(&'a self, function: impl FnOnce(ParseStream<'a>) -> Result<T>) -> Result<T> {
         function(self)
     }
 


### PR DESCRIPTION
Curious how you'd feel about this.
Reasonably sure it's backwards compatible, and would be great for users of [`attrs`](https://docs.rs/attrs).