### PR TITLE
Fix lifetime on `as_turbofish`

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -344,7 +344,7 @@ generics_wrapper_impls!(Turbofish);
 #[cfg(feature = "printing")]
 impl<'a> TypeGenerics<'a> {
     /// Turn a type's generics like `<X, Y>` into a turbofish like `::<X, Y>`.
-    pub fn as_turbofish(&self) -> Turbofish {
+    pub fn as_turbofish(&self) -> Turbofish<'a> {
         Turbofish(self.0)
     }
 }


### PR DESCRIPTION
I'd like to write something like this:

```rust
struct W(syn::Generics);

impl W {
    pub fn as_turbofish(&self) -> syn::Turbofish<'_> {
        self.0.split_for_impl().1.as_turbofish()
    }
}
```

Unfortunately, that doesn't compile today and as far as I can tell it's completely unimplementable -
the lifetime of the `syn::Turbofish` ends up tied to the temporary returned by `split_for_impl`.

That seems silly and unintentional, fix it.
