### PR TITLE
Include semicolon in doc comment example for `syn::Local`.

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -38,7 +38,7 @@ ast_enum! {
 }
 
 ast_struct! {
-    /// A local `let` binding: `let x: u64 = s.parse()?`.
+    /// A local `let` binding: `let x: u64 = s.parse()?;`.
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     pub struct Local {
         pub attrs: Vec<Attribute>,


### PR DESCRIPTION
Include a semicolon in `syn::Local`’s doc comment example to better reflect the struct fields.