### PR TITLE
Parse default field values as `Type::Verbatim`

### DIFF
--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -194,6 +194,8 @@ impl ParseQuote for Field {
 
         let ty: Type = input.parse()?;
 
+        // TODO: Once `Field` supports default_field_values, parse them here
+
         Ok(Field {
             attrs,
             vis,

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -275,6 +275,67 @@ fn test_impl_visibility() {
 }
 
 #[test]
+fn test_struct_default_field_values() {
+    let tokens = quote! {
+        struct Foo {
+            field: i32 = const { 42 },
+        }
+    };
+    snapshot!(tokens as Item, @r#"
+    Item::Struct {
+        vis: Visibility::Inherited,
+        ident: "Foo",
+        generics: Generics,
+        fields: Fields::Named {
+            named: [
+                Field {
+                    vis: Visibility::Inherited,
+                    ident: Some("field"),
+                    colon_token: Some,
+                    ty: Type::Verbatim(`i32 = const { 42 }`),
+                },
+                Token![,],
+            ],
+        },
+    }
+    "#);
+}
+
+#[test]
+fn test_enum_default_field_values() {
+    let tokens = quote! {
+        enum Foo {
+            Bar {
+                field: i32 = 42,
+            }
+        }
+    };
+    snapshot!(tokens as Item, @r#"
+    Item::Enum {
+        vis: Visibility::Inherited,
+        ident: "Foo",
+        generics: Generics,
+        variants: [
+            Variant {
+                ident: "Bar",
+                fields: Fields::Named {
+                    named: [
+                        Field {
+                            vis: Visibility::Inherited,
+                            ident: Some("field"),
+                            colon_token: Some,
+                            ty: Type::Verbatim(`i32 = 42`),
+                        },
+                        Token![,],
+                    ],
+                },
+            },
+        ],
+    }
+    "#);
+}
+
+#[test]
 fn test_impl_type_parameter_defaults() {
     #[cfg(any())]
     impl<T = ()> () {}


### PR DESCRIPTION
See #1774 (noting that a true fix will require 3.x and #1851)

* RFC: https://github.com/rust-lang/rfcs/pull/3681
* Tracking issue: https://github.com/rust-lang/rust/issues/132162
* Feature gate: `#![feature(default_field_values)]`

```rust
#[derive(Default)]
struct Pet {
    name: Option<String>,
    age: i128 = 42,
    //        ^^^^
}
```

Adapted from #1851. cc @estebank

This PR is an alternative to #1851 but avoiding the breaking-change. Instead, if a named field has a default value, the field's entire type and the default value is parsed as a `Type::Verbatim`. Our users can then detect and support this case, by re-parsing the verbatim type into the type and default value expression.

Semantically of course, the default value is not part of the type, but syntactically, the default value is in type position. Our handling of negative inherent impls has a similar shape.

The interaction with `unnamed_fields` was a bit unclear to me, so I took my cue from #1851 (of allowing both features to be combined). Note that since https://github.com/rust-lang/rust/pull/131045, `unnamed_fields` is not supported by upstream Rust.

I chose not to implement the solution you proposed in https://github.com/dtolnay/syn/pull/1851#discussion_r1983947505, both because the idiomatic implementation strategy was unclear to me, and because if I understand correctly, the proposed solution makes supporting `default_field_values` in dependent macros unfeasible.

Thanks for all your great work!