### PR TITLE
Reorder TraitBound fields to match rustc AST

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1830,8 +1830,8 @@ impl Clone for crate::TraitBound {
     fn clone(&self) -> Self {
         crate::TraitBound {
             paren_token: self.paren_token.clone(),
-            modifier: self.modifier.clone(),
             lifetimes: self.lifetimes.clone(),
+            modifier: self.modifier.clone(),
             path: self.path.clone(),
         }
     }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -2620,8 +2620,8 @@ impl Debug for crate::TraitBound {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("TraitBound");
         formatter.field("paren_token", &self.paren_token);
-        formatter.field("modifier", &self.modifier);
         formatter.field("lifetimes", &self.lifetimes);
+        formatter.field("modifier", &self.modifier);
         formatter.field("path", &self.path);
         formatter.finish()
     }

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1820,8 +1820,8 @@ impl Eq for crate::TraitBound {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::TraitBound {
     fn eq(&self, other: &Self) -> bool {
-        self.paren_token == other.paren_token && self.modifier == other.modifier
-            && self.lifetimes == other.lifetimes && self.path == other.path
+        self.paren_token == other.paren_token && self.lifetimes == other.lifetimes
+            && self.modifier == other.modifier && self.path == other.path
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -3340,8 +3340,8 @@ where
 {
     crate::TraitBound {
         paren_token: node.paren_token,
-        modifier: f.fold_trait_bound_modifier(node.modifier),
         lifetimes: (node.lifetimes).map(|it| f.fold_bound_lifetimes(it)),
+        modifier: f.fold_trait_bound_modifier(node.modifier),
         path: f.fold_path(node.path),
     }
 }

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -2316,8 +2316,8 @@ impl Hash for crate::TraitBound {
         H: Hasher,
     {
         self.paren_token.hash(state);
-        self.modifier.hash(state);
         self.lifetimes.hash(state);
+        self.modifier.hash(state);
         self.path.hash(state);
     }
 }

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -3395,10 +3395,10 @@ where
     V: Visit<'ast> + ?Sized,
 {
     skip!(node.paren_token);
-    v.visit_trait_bound_modifier(&node.modifier);
     if let Some(it) = &node.lifetimes {
         v.visit_bound_lifetimes(it);
     }
+    v.visit_trait_bound_modifier(&node.modifier);
     v.visit_path(&node.path);
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -3230,10 +3230,10 @@ where
     V: VisitMut + ?Sized,
 {
     skip!(node.paren_token);
-    v.visit_trait_bound_modifier_mut(&mut node.modifier);
     if let Some(it) = &mut node.lifetimes {
         v.visit_bound_lifetimes_mut(it);
     }
+    v.visit_trait_bound_modifier_mut(&mut node.modifier);
     v.visit_path_mut(&mut node.path);
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -412,9 +412,9 @@ ast_struct! {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TraitBound {
         pub paren_token: Option<token::Paren>,
-        pub modifier: TraitBoundModifier,
         /// The `for<'a>` in `for<'a> Foo<&'a T>`
         pub lifetimes: Option<BoundLifetimes>,
+        pub modifier: TraitBoundModifier,
         /// The `Foo<&'a T>` in `for<'a> Foo<&'a T>`
         pub path: Path,
     }
@@ -845,8 +845,8 @@ pub(crate) mod parsing {
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     impl Parse for TraitBound {
         fn parse(input: ParseStream) -> Result<Self> {
-            let modifier: TraitBoundModifier = input.parse()?;
             let lifetimes: Option<BoundLifetimes> = input.parse()?;
+            let modifier: TraitBoundModifier = input.parse()?;
 
             let mut path: Path = input.parse()?;
             if path.segments.last().unwrap().arguments.is_empty()
@@ -860,8 +860,8 @@ pub(crate) mod parsing {
 
             Ok(TraitBound {
                 paren_token: None,
-                modifier,
                 lifetimes,
+                modifier,
                 path,
             })
         }
@@ -1270,8 +1270,8 @@ pub(crate) mod printing {
     impl ToTokens for TraitBound {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             let to_tokens = |tokens: &mut TokenStream| {
-                self.modifier.to_tokens(tokens);
                 self.lifetimes.to_tokens(tokens);
+                self.modifier.to_tokens(tokens);
                 self.path.to_tokens(tokens);
             };
             match &self.paren_token {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -441,8 +441,8 @@ pub(crate) mod parsing {
                         Type::Path(TypePath { qself: None, path }) => {
                             TypeParamBound::Trait(TraitBound {
                                 paren_token: Some(paren_token),
-                                modifier: TraitBoundModifier::None,
                                 lifetimes: None,
+                                modifier: TraitBoundModifier::None,
                                 path,
                             })
                         }
@@ -534,8 +534,8 @@ pub(crate) mod parsing {
                 let mut bounds = Punctuated::new();
                 bounds.push_value(TypeParamBound::Trait(TraitBound {
                     paren_token: None,
-                    modifier: TraitBoundModifier::None,
                     lifetimes,
+                    modifier: TraitBoundModifier::None,
                     path: ty.path,
                 }));
                 if allow_plus {

--- a/syn.json
+++ b/syn.json
@@ -4575,13 +4575,13 @@
             "group": "Paren"
           }
         },
-        "modifier": {
-          "syn": "TraitBoundModifier"
-        },
         "lifetimes": {
           "option": {
             "syn": "BoundLifetimes"
           }
+        },
+        "modifier": {
+          "syn": "TraitBoundModifier"
         },
         "path": {
           "syn": "Path"

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -3858,12 +3858,6 @@ impl Debug for Lite<syn::TraitBound> {
         if self.value.paren_token.is_some() {
             formatter.field("paren_token", &Present);
         }
-        match self.value.modifier {
-            syn::TraitBoundModifier::None => {}
-            _ => {
-                formatter.field("modifier", Lite(&self.value.modifier));
-            }
-        }
         if let Some(val) = &self.value.lifetimes {
             #[derive(RefCast)]
             #[repr(transparent)]
@@ -3877,6 +3871,12 @@ impl Debug for Lite<syn::TraitBound> {
                 }
             }
             formatter.field("lifetimes", Print::ref_cast(val));
+        }
+        match self.value.modifier {
+            syn::TraitBoundModifier::None => {}
+            _ => {
+                formatter.field("modifier", Lite(&self.value.modifier));
+            }
         }
         formatter.field("path", Lite(&self.value.path));
         formatter.finish()

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -49,6 +49,11 @@ static EXCLUDE_FILES: &[&str] = &[
     "tests/ui/structs/auxiliary/struct_field_default.rs",
     "tests/ui/structs/default-field-values-support.rs",
 
+    // Incorrect syntax: modifier before lifetime binder `?for<>` - rustc correctly rejects this
+    // but rust-analyzer parser incorrectly accepts it. Syn follows rustc's behavior.
+    // https://github.com/rust-lang/rust-analyzer/pull/20417
+    "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/question_for_type_trait_bound.rs",
+
     // TODO: return type notation: `where T: Trait<method(): Send>` and `where T::method(..): Send`
     // https://github.com/dtolnay/syn/issues/1434
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/return_type_syntax_in_path.rs",


### PR DESCRIPTION
I have fixed the upstream bug which led to this mistake:

https://github.com/rust-lang/rust-analyzer/pull/20417