### PR TITLE
Simplify the span used for pre-2018 trait syntax workaround

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1617,7 +1617,7 @@ pub(crate) mod parsing {
         // test/ui/rfc-2565-param-attrs/param-attrs-pretty.rs
         // because the rest of the test case is valuable.
         if input.peek(Ident) && input.peek2(Token![<]) {
-            let span = input.fork().parse::<Ident>()?.span();
+            let span = input.span();
             return Ok(FnArgOrVariadic::FnArg(FnArg::Typed(PatType {
                 attrs,
                 pat: Box::new(Pat::Wild(PatWild {


### PR DESCRIPTION
This is equivalent unless the trait function argument's type is wrapped in a macro metavariable, which is fine.
`trait Trait { fn f($ty); }`