### PR TITLE
Reject polarity modifier and lifetime binder used in the same trait bound

### DIFF
--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -381,6 +381,7 @@ static EXCLUDE_FILES: &[&str] = &[
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/field_expr.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/generic_arg_bounds.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/global_asm.rs",
+    "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/question_for_type_trait_bound.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/ref_expr.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/use_tree_abs_star.rs",
     "src/tools/rust-analyzer/crates/parser/test_data/parser/ok/0015_use_tree.rs",

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -130,7 +130,7 @@ fn test_split_for_impl() {
 }
 
 #[test]
-fn test_ty_param_bound() {
+fn test_type_param_bound() {
     let tokens = quote!('a);
     snapshot!(tokens as TypeParamBound, @r#"
     TypeParamBound::Lifetime {
@@ -171,6 +171,42 @@ fn test_ty_param_bound() {
         },
     })
     "#);
+
+    let tokens = quote!(for<'a> Trait);
+    snapshot!(tokens as TypeParamBound, @r#"
+    TypeParamBound::Trait(TraitBound {
+        lifetimes: Some(BoundLifetimes {
+            lifetimes: [
+                GenericParam::Lifetime(LifetimeParam {
+                    lifetime: Lifetime {
+                        ident: "a",
+                    },
+                }),
+            ],
+        }),
+        path: Path {
+            segments: [
+                PathSegment {
+                    ident: "Trait",
+                },
+            ],
+        },
+    })
+    "#);
+
+    let tokens = quote!(for<> ?Trait);
+    let err = syn::parse2::<TypeParamBound>(tokens).unwrap_err();
+    assert_eq!(
+        "`for<...>` binder not allowed with `?` trait polarity modifier",
+        err.to_string(),
+    );
+
+    let tokens = quote!(?for<> Trait);
+    let err = syn::parse2::<TypeParamBound>(tokens).unwrap_err();
+    assert_eq!(
+        "`for<...>` binder not allowed with `?` trait polarity modifier",
+        err.to_string(),
+    );
 }
 
 #[test]


### PR DESCRIPTION
Corresponding rustc change: https://github.com/rust-lang/rust/pull/127054