### PR TITLE
Parse type parameter binder

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -671,8 +671,23 @@ pub(crate) mod parsing {
                 lifetimes: {
                     let mut lifetimes = Punctuated::new();
                     while !input.peek(Token![>]) {
-                        let lifetime_param: LifetimeParam = input.parse()?;
-                        lifetimes.push_value(GenericParam::Lifetime(lifetime_param));
+                        let attrs = input.call(Attribute::parse_outer)?;
+
+                        let lookahead = input.lookahead1();
+                        if lookahead.peek(Lifetime) {
+                            lifetimes.push_value(GenericParam::Lifetime(LifetimeParam {
+                                attrs,
+                                ..input.parse()?
+                            }));
+                        } else if cfg!(feature = "full") && lookahead.peek(Ident) {
+                            lifetimes.push_value(GenericParam::Type(TypeParam {
+                                attrs,
+                                ..input.parse()?
+                            }));
+                        } else {
+                            return Err(lookahead.error());
+                        }
+
                         if input.peek(Token![>]) {
                             break;
                         }

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -31,15 +31,6 @@ static EXCLUDE_FILES: &[&str] = &[
     // https://github.com/dtolnay/syn/issues/1901
     "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/for_binder_bound.rs",
 
-    // TODO: non-lifetime binders: `where for<'a, T> &'a Struct<T>: Trait`
-    // https://github.com/dtolnay/syn/issues/1435
-    "src/tools/rustfmt/tests/source/issue_5721.rs",
-    "src/tools/rustfmt/tests/target/issue_5721.rs",
-    "tests/rustdoc-json/non_lifetime_binders.rs",
-    "tests/rustdoc/inline_cross/auxiliary/non_lifetime_binders.rs",
-    "tests/rustdoc/non_lifetime_binders.rs",
-    "tests/ui/trivial-bounds/everybody-copies.rs",
-
     // TODO: unsafe binders: `unsafe<'a> &'a T`
     // https://github.com/dtolnay/syn/issues/1791
     "src/tools/rustfmt/tests/source/unsafe-binders.rs",

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -34,9 +34,7 @@ static EXCLUDE_FILES: &[&str] = &[
     // TODO: non-lifetime binders: `where for<'a, T> &'a Struct<T>: Trait`
     // https://github.com/dtolnay/syn/issues/1435
     "src/tools/rustfmt/tests/source/issue_5721.rs",
-    "src/tools/rustfmt/tests/source/non-lifetime-binders.rs",
     "src/tools/rustfmt/tests/target/issue_5721.rs",
-    "src/tools/rustfmt/tests/target/non-lifetime-binders.rs",
     "tests/rustdoc-json/non_lifetime_binders.rs",
     "tests/rustdoc/inline_cross/auxiliary/non_lifetime_binders.rs",
     "tests/rustdoc/non_lifetime_binders.rs",
@@ -321,6 +319,10 @@ static EXCLUDE_FILES: &[&str] = &[
 
     // Lifetimes and types out of order in angle bracketed path arguments
     "tests/ui/parser/constraints-before-generic-args-syntactic-pass.rs",
+
+    // Const parameter in lifetime binder: `for<const C: usize> [T; C]: Sized`
+    "src/tools/rustfmt/tests/target/non-lifetime-binders.rs",
+    "src/tools/rustfmt/tests/source/non-lifetime-binders.rs",
 
     // Deprecated anonymous parameter syntax in traits
     "src/tools/rustfmt/tests/source/trait.rs",


### PR DESCRIPTION
Closes https://github.com/dtolnay/syn/issues/1435.

Const parameters continue to be unsupported, like in rustc.

```rust
#![feature(non_lifetime_binders)]

pub trait Trait<const K: usize> {}

pub fn f<T>()
where
    T: for<const K: usize> Trait<K>,
{}
```

```console
error: late-bound const parameters cannot be used currently
 --> src/lib.rs:7:18
  |
7 |     T: for<const K: usize> Trait<K>,
  |                  ^
```