### PR TITLE
Allow const parameters in for<>

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -671,23 +671,7 @@ pub(crate) mod parsing {
                 lifetimes: {
                     let mut lifetimes = Punctuated::new();
                     while !input.peek(Token![>]) {
-                        let attrs = input.call(Attribute::parse_outer)?;
-
-                        let lookahead = input.lookahead1();
-                        if lookahead.peek(Lifetime) {
-                            lifetimes.push_value(GenericParam::Lifetime(LifetimeParam {
-                                attrs,
-                                ..input.parse()?
-                            }));
-                        } else if cfg!(feature = "full") && lookahead.peek(Ident) {
-                            lifetimes.push_value(GenericParam::Type(TypeParam {
-                                attrs,
-                                ..input.parse()?
-                            }));
-                        } else {
-                            return Err(lookahead.error());
-                        }
-
+                        lifetimes.push_value(input.parse()?);
                         if input.peek(Token![>]) {
                             break;
                         }

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -20,6 +20,11 @@ const REVISION: &str = "3672a55b7cfd0a12e7097197b6242872473ffaa7";
 
 #[rustfmt::skip]
 static EXCLUDE_FILES: &[&str] = &[
+    // TODO: non-lifetime binders on closures: `let _ = for<T> || {}`
+    // https://github.com/dtolnay/syn/issues/1906
+    "src/tools/rustfmt/tests/target/non-lifetime-binders.rs",
+    "src/tools/rustfmt/tests/source/non-lifetime-binders.rs",
+
     // TODO: const traits: `pub const trait Trait {}`
     // https://github.com/dtolnay/syn/issues/1887
     "src/tools/clippy/tests/ui/assign_ops.rs",
@@ -307,10 +312,6 @@ static EXCLUDE_FILES: &[&str] = &[
 
     // Lifetimes and types out of order in angle bracketed path arguments
     "tests/ui/parser/constraints-before-generic-args-syntactic-pass.rs",
-
-    // Const parameter in lifetime binder: `for<const C: usize> [T; C]: Sized`
-    "src/tools/rustfmt/tests/target/non-lifetime-binders.rs",
-    "src/tools/rustfmt/tests/source/non-lifetime-binders.rs",
 
     // Deprecated anonymous parameter syntax in traits
     "src/tools/rustfmt/tests/source/trait.rs",


### PR DESCRIPTION
This seems harmless to allow syntactically. Rustc does as well, since Rust 1.51:

```rust
pub trait Trait<const K: usize> {}

#[cfg(any())]
fn f(_: impl for<const K: usize> Trait<K>) {}
```