### PR TITLE
perf: reduce llvm-lines by removing .collect() into TokenStream

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -285,13 +285,13 @@ impl<'a> Cursor<'a> {
     /// Copies all remaining tokens visible from this cursor into a
     /// `TokenStream`.
     pub fn token_stream(self) -> TokenStream {
-        let mut tts = Vec::new();
+        let mut tts = TokenStream::new();
         let mut cursor = self;
         while let Some((tt, rest)) = cursor.token_tree() {
-            tts.push(tt);
+            tts.extend(TokenStream::from(tt));
             cursor = rest;
         }
-        tts.into_iter().collect()
+        tts
     }
 
     /// If the cursor is pointing at a `TokenTree`, returns it along with a

--- a/src/error.rs
+++ b/src/error.rs
@@ -223,10 +223,11 @@ impl Error {
     /// [`compile_error!`]: std::compile_error!
     /// [`parse_macro_input!`]: crate::parse_macro_input!
     pub fn to_compile_error(&self) -> TokenStream {
-        self.messages
-            .iter()
-            .map(ErrorMessage::to_compile_error)
-            .collect()
+        let mut ts = TokenStream::new();
+        for msg in self.messages.as_slice() {
+            ts.extend(ErrorMessage::to_compile_error(msg));
+        }
+        ts
     }
 
     /// Render the error as an invocation of [`compile_error!`].


### PR DESCRIPTION
2026 less llvm-lines.
1.4% faster compile time (7.77s vs 7.88s, stdev = 26 ms).

Before:
```shell
syn$ cargo llvm-lines --release | head -n 5
  Lines                 Copies              Function name
  -----                 ------              -------------
  112085                2792                (TOTAL)
    3431 (3.1%,  3.1%)     1 (0.0%,  0.0%)  syn::ty::parsing::ambig_ty
    2608 (2.3%,  5.4%)    17 (0.6%,  0.6%)  <T as alloc::slice::<impl [T]>::to_vec_in::ConvertVec>::to_vec
```

After:
```shell
syn$ cargo llvm-lines --release | head -n 5
  Lines                 Copies              Function name
  -----                 ------              -------------
  110059                2715                (TOTAL)
    3431 (3.1%,  3.1%)     1 (0.0%,  0.0%)  syn::ty::parsing::ambig_ty
    2608 (2.4%,  5.5%)    17 (0.6%,  0.7%)  <T as alloc::slice::<impl [T]>::to_vec_in::ConvertVec>::to_vec
```

<details>
  <summary>[Spoiler] bash script `compare.sh`</summary>
  

```bash
while true; do

git checkout dishmaker/perf_llvm_lines_collect
cargo +nightly rustc --release -- -Z time-passes -C codegen-units=1 2>> compare_mybranch.txt

git checkout master
cargo +nightly rustc --release -- -Z time-passes -C codegen-units=1 2>> compare_master.txt

done

grep "total" compare_mybranch.txt
echo ____master____
grep "total" compare_master.txt
```

</details>
