### PR TITLE
Consistently use `tokens` to name TokenStream containing arbitrary tokens

### DIFF
--- a/codegen/src/parse.rs
+++ b/codegen/src/parse.rs
@@ -590,13 +590,13 @@ fn do_load_file(
                 let features = get_features(&item.attrs, features);
 
                 // Try to parse the AstItem declaration out of the item.
-                let tts = item.mac.tokens.clone();
+                let tokens = item.mac.tokens.clone();
                 let mut found = if item.mac.path.is_ident("ast_struct") {
-                    parsing::ast_struct.parse2(tts)
+                    parsing::ast_struct.parse2(tokens)
                 } else if item.mac.path.is_ident("ast_enum") {
-                    parsing::ast_enum.parse2(tts)
+                    parsing::ast_enum.parse2(tokens)
                 } else if item.mac.path.is_ident("ast_enum_of_structs") {
-                    parsing::ast_enum_of_structs.parse2(tts)
+                    parsing::ast_enum_of_structs.parse2(tokens)
                 } else {
                     continue;
                 }?;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -285,13 +285,13 @@ impl<'a> Cursor<'a> {
     /// Copies all remaining tokens visible from this cursor into a
     /// `TokenStream`.
     pub fn token_stream(self) -> TokenStream {
-        let mut tts = TokenStream::new();
+        let mut tokens = TokenStream::new();
         let mut cursor = self;
         while let Some((tt, rest)) = cursor.token_tree() {
-            tts.extend(TokenStream::from(tt));
+            tokens.extend(TokenStream::from(tt));
             cursor = rest;
         }
-        tts
+        tokens
     }
 
     /// If the cursor is pointing at a `TokenTree`, returns it along with a

--- a/src/error.rs
+++ b/src/error.rs
@@ -223,11 +223,11 @@ impl Error {
     /// [`compile_error!`]: std::compile_error!
     /// [`parse_macro_input!`]: crate::parse_macro_input!
     pub fn to_compile_error(&self) -> TokenStream {
-        let mut ts = TokenStream::new();
+        let mut tokens = TokenStream::new();
         for msg in &self.messages {
-            ts.extend(ErrorMessage::to_compile_error(msg));
+            tokens.extend(ErrorMessage::to_compile_error(msg));
         }
-        ts
+        tokens
     }
 
     /// Render the error as an invocation of [`compile_error!`].

--- a/src/tt.rs
+++ b/src/tt.rs
@@ -98,9 +98,9 @@ impl<'a> PartialEq for TokenStreamHelper<'a> {
 
 impl<'a> Hash for TokenStreamHelper<'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let tts = self.0.clone().into_iter().collect::<Vec<_>>();
-        tts.len().hash(state);
-        for tt in tts {
+        let tokens = self.0.clone().into_iter().collect::<Vec<_>>();
+        tokens.len().hash(state);
+        for tt in tokens {
             TokenTreeHelper(&tt).hash(state);
         }
     }


### PR DESCRIPTION
This aligns with the variable name used in the signature of quote::ToTokens::to_tokens.