### PR TITLE
perf: replace format! with format_args!

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -247,7 +247,7 @@ impl Attribute {
             Meta::Path(path) => Err(crate::error::new2(
                 path.segments.first().unwrap().ident.span(),
                 path.segments.last().unwrap().ident.span(),
-                format!(
+                format_args!(
                     "expected attribute arguments in parentheses: {}[{}(...)]",
                     parsing::DisplayAttrStyle(&self.style),
                     parsing::DisplayPath(path),
@@ -535,7 +535,7 @@ impl Meta {
             Meta::Path(path) => Err(crate::error::new2(
                 path.segments.first().unwrap().ident.span(),
                 path.segments.last().unwrap().ident.span(),
-                format!(
+                format_args!(
                     "expected attribute arguments in parentheses: `{}(...)`",
                     parsing::DisplayPath(path),
                 ),
@@ -553,7 +553,7 @@ impl Meta {
             Meta::Path(path) => Err(crate::error::new2(
                 path.segments.first().unwrap().ident.span(),
                 path.segments.last().unwrap().ident.span(),
-                format!(
+                format_args!(
                     "expected a value for this attribute: `{} = ...`",
                     parsing::DisplayPath(path),
                 ),

--- a/src/error.rs
+++ b/src/error.rs
@@ -327,7 +327,7 @@ impl ErrorMessage {
 #[cfg(feature = "parsing")]
 pub(crate) fn new_at<T: Display>(scope: Span, cursor: Cursor, message: T) -> Error {
     if cursor.eof() {
-        Error::new(scope, format!("unexpected end of input, {}", message))
+        Error::new(scope, format_args!("unexpected end of input, {}", message))
     } else {
         let span = crate::buffer::open_span_of_group(cursor);
         Error::new(span, message)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3112,7 +3112,7 @@ pub(crate) mod parsing {
         } else {
             return Ok(());
         };
-        let msg = format!("casts cannot be followed by {}", kind);
+        let msg = format_args!("casts cannot be followed by {}", kind);
         Err(input.error(msg))
     }
 }

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -246,7 +246,7 @@ impl LitStr {
         if !suffix.is_empty() {
             return Err(Error::new(
                 self.span(),
-                format!("unexpected suffix `{}` on string literal", suffix),
+                format_args!("unexpected suffix `{}` on string literal", suffix),
             ));
         }
 

--- a/src/lookahead.rs
+++ b/src/lookahead.rs
@@ -132,15 +132,16 @@ impl<'a> Lookahead1<'a> {
                 }
             }
             1 => {
-                let message = format!("expected {}", comparisons[0]);
+                let message = format_args!("expected {}", comparisons[0]);
                 error::new_at(self.scope, self.cursor, message)
             }
             2 => {
-                let message = format!("expected {} or {}", comparisons[0], comparisons[1]);
+                let message = format_args!("expected {} or {}", comparisons[0], comparisons[1]);
                 error::new_at(self.scope, self.cursor, message)
             }
             _ => {
-                let message = format!("expected one of: {}", CommaSeparated(&comparisons));
+                let comparisons = CommaSeparated(&comparisons);
+                let message = format_args!("expected one of: {}", comparisons);
                 error::new_at(self.scope, self.cursor, message)
             }
         }

--- a/src/token.rs
+++ b/src/token.rs
@@ -987,7 +987,7 @@ pub(crate) mod parsing {
                     return Ok((ident.span(), rest));
                 }
             }
-            Err(cursor.error(format!("expected `{}`", token)))
+            Err(cursor.error(format_args!("expected `{}`", token)))
         })
     }
 
@@ -1028,7 +1028,7 @@ pub(crate) mod parsing {
                 }
             }
 
-            Err(Error::new(spans[0], format!("expected `{}`", token)))
+            Err(Error::new(spans[0], format_args!("expected `{}`", token)))
         })
     }
 


### PR DESCRIPTION
284 less llvm lines.

<details>
  <summary>Compile time changed by a statistical error</summary>
  

5.86s vs 5.88s with stdev=280 ms 
I shouldn't benchmark in VirtualBox probably 😆

</details>

Before:
```
$ cargo llvm-lines --release | head -n 3
  Lines                 Copies              Function name
  -----                 ------              -------------
  113458                2759                (TOTAL)
```

After:
```
$ cargo llvm-lines --release | head -n 3
  Lines                 Copies              Function name
  -----                 ------              -------------
  113174                2755                (TOTAL)
```
