### PR TITLE
perf: remove .collect() into Vec in respan_token_stream

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -212,13 +212,12 @@ impl LitStr {
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     pub fn parse_with<F: Parser>(&self, parser: F) -> Result<F::Output> {
         use proc_macro2::Group;
-        use quote::TokenStreamExt;
 
         // Token stream with every span replaced by the given one.
         fn respan_token_stream(stream: TokenStream, span: Span) -> TokenStream {
             let mut tokens = TokenStream::new();
             for token in stream.into_iter() {
-                tokens.append(respan_token_tree(token, span));
+                tokens.extend(Some(respan_token_tree(token, span)));
             }
             tokens
         }


### PR DESCRIPTION
427 less llvm lines

Before:
```
syn$ cargo llvm-lines --all-features --release | head -n 3
  Lines                 Copies              Function name
  -----                 ------              -------------
  221565                4748                (TOTAL)
```

After:
```
syn$ cargo llvm-lines --all-features --release | head -n 3
  Lines                 Copies              Function name
  -----                 ------              -------------
  221138                4723                (TOTAL)
```