### PR TITLE
perf: reduce llvm-lines in `Punctuated::into_iter()`

### DIFF
--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -519,8 +519,13 @@ impl<T, P> IntoIterator for Punctuated<T, P> {
 
     fn into_iter(self) -> Self::IntoIter {
         let mut elements = Vec::with_capacity(self.len());
-        elements.extend(self.inner.into_iter().map(|pair| pair.0));
-        elements.extend(self.last.map(|t| *t));
+
+        for (t, _) in self.inner {
+            elements.push(t);
+        }
+        if let Some(t) = self.last {
+            elements.push(*t);
+        }
 
         IntoIter {
             inner: elements.into_iter(),


### PR DESCRIPTION
756 less llvm lines.


Before:
```shell
syn$ cargo llvm-lines --release | head -n 3
  Lines                 Copies              Function name
  -----                 ------              -------------
  113458                2759                (TOTAL)
```

After:
```shell
syn$ cargo llvm-lines --release | head -n 3
  Lines                 Copies              Function name
  -----                 ------              -------------
  112702                2696                (TOTAL)
```