### PR TITLE
perf: reduce llvm-lines in `ParseBuffer::step`

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1072,13 +1072,17 @@ impl<'a> ParseBuffer<'a> {
         // existence of a StepCursor<'c, 'a> as proof that it is safe to cast
         // from Cursor<'c> to Cursor<'a>. If needed outside of Syn, it would be
         // safe to expose that API as a method on StepCursor.
-        let (node, rest) = function(StepCursor {
+        match function(StepCursor {
             scope: self.scope,
             cursor: self.cell.get(),
             marker: PhantomData,
-        })?;
-        self.cell.set(rest);
-        Ok(node)
+        }) {
+            Ok((node, rest)) => {
+                self.cell.set(rest);
+                Ok(node)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Returns the `Span` of the next token in the parse stream, or


### PR DESCRIPTION
Before:
```
syn$ cargo llvm-lines --release | head -n 20
  Lines                 Copies              Function name
  -----                 ------              -------------
  108816                2621                (TOTAL)
...
    1415 (1.3%,  8.3%)    19 (0.7%,  1.9%)  syn::parse::ParseBuffer::step
```

After:
```
syn$ cargo llvm-lines --release | head -n 20
  Lines                 Copies              Function name
  -----                 ------              -------------
  108292                2621                (TOTAL)
...
     891 (0.8%, 20.3%)    19 (0.7%,  8.2%)  syn::parse::ParseBuffer::step
```

```
syn$ cargo -V
cargo 1.93.0-nightly (636800288 2025-10-31)
```