### PR TITLE
Parse super let syntax (#1889)

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1389,6 +1389,7 @@ impl Clone for crate::Local {
     fn clone(&self) -> Self {
         crate::Local {
             attrs: self.attrs.clone(),
+            super_token: self.super_token.clone(),
             let_token: self.let_token.clone(),
             pat: self.pat.clone(),
             init: self.init.clone(),

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -2796,6 +2796,7 @@ where
 {
     crate::Local {
         attrs: f.fold_attributes(node.attrs),
+        super_token: node.super_token,
         let_token: node.let_token,
         pat: f.fold_pat(node.pat),
         init: (node.init).map(|it| f.fold_local_init(it)),

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -42,6 +42,7 @@ ast_struct! {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     pub struct Local {
         pub attrs: Vec<Attribute>,
+        pub super_token: Option<Token![super]>,
         pub let_token: Token![let],
         pub pat: Pat,
         pub init: Option<LocalInit>,
@@ -217,7 +218,9 @@ pub(crate) mod parsing {
             }
         }
 
-        if input.peek(Token![let]) && !input.peek(token::Group) {
+        if (input.peek(Token![let]) || input.peek(Token![super]) && input.peek2(Token![let]))
+            && !input.peek(token::Group)
+        {
             stmt_local(input, attrs).map(Stmt::Local)
         } else if input.peek(Token![pub])
             || input.peek(Token![crate]) && !input.peek2(Token![::])
@@ -281,6 +284,12 @@ pub(crate) mod parsing {
     }
 
     fn stmt_local(input: ParseStream, attrs: Vec<Attribute>) -> Result<Local> {
+        let super_token: Option<Token![super]> = if input.peek(Token![super]) {
+            Some(input.parse()?)
+        } else {
+            None
+        };
+
         let let_token: Token![let] = input.parse()?;
 
         let mut pat = Pat::parse_single(input)?;
@@ -324,6 +333,7 @@ pub(crate) mod parsing {
 
         Ok(Local {
             attrs,
+            super_token,
             let_token,
             pat,
             init,
@@ -449,6 +459,9 @@ pub(crate) mod printing {
     impl ToTokens for Local {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             expr::printing::outer_attrs_to_tokens(&self.attrs, tokens);
+            if let Some(super_token) = &self.super_token {
+                super_token.to_tokens(tokens);
+            }
             self.let_token.to_tokens(tokens);
             self.pat.to_tokens(tokens);
             if let Some(init) = &self.init {

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -237,10 +237,6 @@ static EXCLUDE_FILES: &[&str] = &[
     // https://github.com/dtolnay/syn/issues/1705
     "src/tools/rustfmt/tests/target/cfg_attribute_in_where.rs",
 
-    // TODO: super let
-    // https://github.com/dtolnay/syn/issues/1889
-    "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/let_stmt.rs",
-
     // TODO: "ergonomic clones": `f(obj.use)`, `thread::spawn(use || f(obj))`, `async use`
     // https://github.com/dtolnay/syn/issues/1802
     "tests/codegen-llvm/ergonomic-clones/closure.rs",


### PR DESCRIPTION
I'm interested in some unstable rust features (in particular, this one and #1911), but these are frequently blocked by absence of support in `syn` (via other crates, such as `async-trait` or `serde`), so I've decided to give it a try in adding the required support. I haven't dived deep into the code yet, so I'm still not sure about some parts:
- Condition in `parse_stmt`, `if input.peek(Token![let]) && !input.peek(token::Group)` - does it make sense, can both these peeks return true? Is it correct after my change? What's `token::Group` anyway?
- `ParseStream::parse()` return value seems to be coercible to `Option<>`, can part in `stml_local` be rewritten as simply `let super_token: Option<Token![super]> = input.parse()?;`?
- Most importantly, is this correct approach overall, or do we need maybe a separate `Stmt` kind for `super let`? Is my approach API safe, as presumably client code which processes Local nodes may be unaware of `super_token` addition? Is either approach future safe if, say, `super let` syntax changes?
- Should `Local` docstring be updated to mention `super let`?