### PR TITLE
Reduce repetitions of path.segments.first/last.ident.span()

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -8,6 +8,8 @@ use crate::mac::MacroDelimiter;
 use crate::meta::{self, ParseNestedMeta};
 #[cfg(feature = "parsing")]
 use crate::parse::{Parse, ParseStream, Parser};
+#[cfg(feature = "parsing")]
+use crate::path::path_error;
 use crate::path::Path;
 use crate::token;
 use proc_macro2::TokenStream;
@@ -244,9 +246,8 @@ impl Attribute {
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     pub fn parse_args_with<F: Parser>(&self, parser: F) -> Result<F::Output> {
         match &self.meta {
-            Meta::Path(path) => Err(crate::error::new2(
-                path.segments.first().unwrap().ident.span(),
-                path.segments.last().unwrap().ident.span(),
+            Meta::Path(path) => Err(path_error(
+                path,
                 format!(
                     "expected attribute arguments in parentheses: {}[{}(...)]",
                     parsing::DisplayAttrStyle(&self.style),
@@ -532,9 +533,8 @@ impl Meta {
     pub fn require_list(&self) -> Result<&MetaList> {
         match self {
             Meta::List(meta) => Ok(meta),
-            Meta::Path(path) => Err(crate::error::new2(
-                path.segments.first().unwrap().ident.span(),
-                path.segments.last().unwrap().ident.span(),
+            Meta::Path(path) => Err(path_error(
+                path,
                 format!(
                     "expected attribute arguments in parentheses: `{}(...)`",
                     parsing::DisplayPath(path),
@@ -550,9 +550,8 @@ impl Meta {
     pub fn require_name_value(&self) -> Result<&MetaNameValue> {
         match self {
             Meta::NameValue(meta) => Ok(meta),
-            Meta::Path(path) => Err(crate::error::new2(
-                path.segments.first().unwrap().ident.span(),
-                path.segments.last().unwrap().ident.span(),
+            Meta::Path(path) => Err(path_error(
+                path,
                 format!(
                     "expected a value for this attribute: `{} = ...`",
                     parsing::DisplayPath(path),

--- a/src/error.rs
+++ b/src/error.rs
@@ -336,15 +336,16 @@ pub(crate) fn new_at<T: Display>(scope: Span, cursor: Cursor, message: T) -> Err
 
 #[cfg(all(feature = "parsing", any(feature = "full", feature = "derive")))]
 pub(crate) fn new2<T: Display>(start: Span, end: Span, message: T) -> Error {
-    return new2(start, end, message.to_string());
+    return new3(start, end, message.to_string());
+}
 
-    fn new2(start: Span, end: Span, message: String) -> Error {
-        Error {
-            messages: vec![ErrorMessage {
-                span: ThreadBound::new(SpanRange { start, end }),
-                message,
-            }],
-        }
+#[cfg(all(feature = "parsing", any(feature = "full", feature = "derive")))]
+pub(crate) fn new3(start: Span, end: Span, message: String) -> Error {
+    Error {
+        messages: vec![ErrorMessage {
+            span: ThreadBound::new(SpanRange { start, end }),
+            message,
+        }],
     }
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "parsing")]
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::expr::Expr;
 use crate::generics::TypeParamBound;
 use crate::ident::Ident;
@@ -94,14 +94,18 @@ impl Path {
     #[cfg(feature = "parsing")]
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     pub fn require_ident(&self) -> Result<&Ident> {
-        self.get_ident().ok_or_else(|| {
-            crate::error::new2(
-                self.segments.first().unwrap().ident.span(),
-                self.segments.last().unwrap().ident.span(),
-                "expected this path to be an identifier",
-            )
-        })
+        self.get_ident()
+            .ok_or_else(|| path_error(self, "expected this path to be an identifier".to_string()))
     }
+}
+
+#[cfg(feature = "parsing")]
+pub(crate) fn path_error(path: &Path, message: String) -> Error {
+    crate::error::new3(
+        path.segments.first().unwrap().ident.span(),
+        path.segments.last().unwrap().ident.span(),
+        message,
+    )
 }
 
 ast_struct! {


### PR DESCRIPTION
This reduces llvm-lines only by 126  on `rustc 1.91.0`