### PR TITLE
Suppress unused variable warning on variables used in group macro

### DIFF
--- a/src/group.rs
+++ b/src/group.rs
@@ -148,6 +148,7 @@ macro_rules! parenthesized {
         match $crate::__private::parse_parens(&$cursor) {
             $crate::__private::Ok(parens) => {
                 $content = parens.content;
+                _ = $content;
                 parens.token
             }
             $crate::__private::Err(error) => {
@@ -226,6 +227,7 @@ macro_rules! braced {
         match $crate::__private::parse_braces(&$cursor) {
             $crate::__private::Ok(braces) => {
                 $content = braces.content;
+                _ = $content;
                 braces.token
             }
             $crate::__private::Err(error) => {
@@ -281,6 +283,7 @@ macro_rules! bracketed {
         match $crate::__private::parse_brackets(&$cursor) {
             $crate::__private::Ok(brackets) => {
                 $content = brackets.content;
+                _ = $content;
                 brackets.token
             }
             $crate::__private::Err(error) => {


### PR DESCRIPTION
New warning in nightly-2025-11-23 since https://github.com/rust-lang/rust/pull/149072.

```console
warning: variable `brace` is assigned to, but never used
   --> tests/test_meta.rs:168:17
    |
168 |             let brace;
    |                 ^^^^^
    |
    = note: consider using `_brace` instead
    = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
```