### PR TITLE
Fix LitByte::new().

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -345,7 +345,7 @@ impl LitCStr {
 
 impl LitByte {
     pub fn new(value: u8, span: Span) -> Self {
-        let mut token = Literal::u8_suffixed(value);
+        let mut token = Literal::byte_character(value);
         token.set_span(span);
         LitByte {
             repr: Box::new(LitRepr {


### PR DESCRIPTION
`LitByte::new` produces invalid `LitByte`.

See https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=d9cc0a12dc929effc4adcc013f9c665d

This PR is a simple fix.