### PR TITLE
Fix TypeParam expecting identifier after colon

### DIFF
--- a/src/generics.rs
+++ b/src/generics.rs
@@ -705,7 +705,11 @@ pub(crate) mod parsing {
             let mut bounds = Punctuated::new();
             if colon_token.is_some() {
                 loop {
-                    if input.peek(Token![,]) || input.peek(Token![>]) || input.peek(Token![=]) {
+                    if input.is_empty()
+                        || input.peek(Token![,])
+                        || input.peek(Token![>])
+                        || input.peek(Token![=])
+                    {
                         break;
                     }
                     bounds.push_value({

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -343,3 +343,14 @@ fn no_opaque_drop() {
             lifetime
         });
 }
+
+#[test]
+fn type_param_with_colon_and_no_bounds() {
+    let tokens = quote!(T:);
+    snapshot!(tokens as GenericParam, @r#"
+    GenericParam::Type(TypeParam {
+        ident: "T",
+        colon_token: Some,
+    })
+    "#);
+}


### PR DESCRIPTION
`T:` is a valid `TypeParam`, but te code was not supporting `:` being the last token of a `ParseStream` when parsing a `TypeParam`.

Fixes #1952 