### PR TITLE
Support Default Field Values, backwards compatibly

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -236,6 +236,241 @@ impl<'a> Clone for Members<'a> {
     }
 }
 
+ast_struct! {
+    /// An enum variant.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
+    pub struct VariantWithDefault {
+        pub attrs: Vec<Attribute>,
+
+        /// Name of the variant.
+        pub ident: Ident,
+
+        /// Content stored in the variant.
+        pub fields: FieldsWithDefault,
+
+        /// Explicit discriminant: `Variant = 1`
+        pub discriminant: Option<(Token![=], Expr)>,
+    }
+}
+
+ast_enum_of_structs! {
+    /// Data stored within an enum variant or struct.
+    ///
+    /// # Syntax tree enum
+    ///
+    /// This type is a [syntax tree enum].
+    ///
+    /// [syntax tree enum]: crate::expr::Expr#syntax-tree-enums
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
+    pub enum FieldsWithDefault {
+        /// Named fields of a struct or struct variant such as `Point { x: f64,
+        /// y: f64 }`.
+        Named(FieldsNamedWithDefault),
+
+        /// Unnamed fields of a tuple struct or tuple variant such as `Some(T)`.
+        Unnamed(FieldsUnnamedWithDefault),
+
+        /// Unit struct or unit variant such as `None`.
+        Unit,
+    }
+}
+
+ast_struct! {
+    /// Named fields of a struct or struct variant such as `Point { x: f64,
+    /// y: f64 }`.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
+    pub struct FieldsNamedWithDefault {
+        pub brace_token: token::Brace,
+        pub named: Punctuated<FieldWithDefault, Token![,]>,
+    }
+}
+
+ast_struct! {
+    /// Unnamed fields of a tuple struct or tuple variant such as `Some(T)`.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
+    pub struct FieldsUnnamedWithDefault {
+        pub paren_token: token::Paren,
+        pub unnamed: Punctuated<FieldWithDefault, Token![,]>,
+    }
+}
+
+impl FieldsWithDefault {
+    /// Get an iterator over the borrowed [`Field`] items in this object. This
+    /// iterator can be used to iterate over a named or unnamed struct or
+    /// variant's fields uniformly.
+    pub fn iter(&self) -> punctuated::Iter<FieldWithDefault> {
+        match self {
+            FieldsWithDefault::Unit => crate::punctuated::empty_punctuated_iter(),
+            FieldsWithDefault::Named(f) => f.named.iter(),
+            FieldsWithDefault::Unnamed(f) => f.unnamed.iter(),
+        }
+    }
+
+    /// Get an iterator over the mutably borrowed [`Field`] items in this
+    /// object. This iterator can be used to iterate over a named or unnamed
+    /// struct or variant's fields uniformly.
+    pub fn iter_mut(&mut self) -> punctuated::IterMut<FieldWithDefault> {
+        match self {
+            FieldsWithDefault::Unit => crate::punctuated::empty_punctuated_iter_mut(),
+            FieldsWithDefault::Named(f) => f.named.iter_mut(),
+            FieldsWithDefault::Unnamed(f) => f.unnamed.iter_mut(),
+        }
+    }
+
+    /// Returns the number of fields.
+    pub fn len(&self) -> usize {
+        match self {
+            FieldsWithDefault::Unit => 0,
+            FieldsWithDefault::Named(f) => f.named.len(),
+            FieldsWithDefault::Unnamed(f) => f.unnamed.len(),
+        }
+    }
+
+    /// Returns `true` if there are zero fields.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            FieldsWithDefault::Unit => true,
+            FieldsWithDefault::Named(f) => f.named.is_empty(),
+            FieldsWithDefault::Unnamed(f) => f.unnamed.is_empty(),
+        }
+    }
+
+    return_impl_trait! {
+        /// Get an iterator over the fields of a struct or variant as [`Member`]s.
+        /// This iterator can be used to iterate over a named or unnamed struct or
+        /// variant's fields uniformly.
+        ///
+        /// # Example
+        ///
+        /// The following is a simplistic [`Clone`] derive for structs. (A more
+        /// complete implementation would additionally want to infer trait bounds on
+        /// the generic type parameters.)
+        ///
+        /// ```
+        /// # use quote::quote;
+        /// #
+        /// fn derive_clone(input: &syn::ItemStruct) -> proc_macro2::TokenStream {
+        ///     let ident = &input.ident;
+        ///     let members = input.fields.members();
+        ///     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+        ///     quote! {
+        ///         impl #impl_generics Clone for #ident #ty_generics #where_clause {
+        ///             fn clone(&self) -> Self {
+        ///                 Self {
+        ///                     #(#members: self.#members.clone()),*
+        ///                 }
+        ///             }
+        ///         }
+        ///     }
+        /// }
+        /// ```
+        ///
+        /// For structs with named fields, it produces an expression like `Self { a:
+        /// self.a.clone() }`. For structs with unnamed fields, `Self { 0:
+        /// self.0.clone() }`. And for unit structs, `Self {}`.
+        pub fn members(&self) -> impl Iterator<Item = Member> + Clone + '_ [MembersWithDefault] {
+            MembersWithDefault {
+                fields: self.iter(),
+                index: 0,
+            }
+        }
+    }
+}
+
+impl IntoIterator for FieldsWithDefault {
+    type Item = FieldWithDefault;
+    type IntoIter = punctuated::IntoIter<FieldWithDefault>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            FieldsWithDefault::Unit => Punctuated::<FieldWithDefault, ()>::new().into_iter(),
+            FieldsWithDefault::Named(f) => f.named.into_iter(),
+            FieldsWithDefault::Unnamed(f) => f.unnamed.into_iter(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a FieldsWithDefault {
+    type Item = &'a FieldWithDefault;
+    type IntoIter = punctuated::Iter<'a, FieldWithDefault>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut FieldsWithDefault {
+    type Item = &'a mut FieldWithDefault;
+    type IntoIter = punctuated::IterMut<'a, FieldWithDefault>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+ast_struct! {
+    /// A field of a struct or enum variant, possibly with a provided (const) default.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
+    pub struct FieldWithDefault {
+        pub attrs: Vec<Attribute>,
+
+        pub vis: Visibility,
+
+        pub mutability: FieldMutability,
+
+        /// Name of the field, if any.
+        ///
+        /// Fields of tuple structs have no names.
+        pub ident: Option<Ident>,
+
+        pub colon_token: Option<Token![:]>,
+
+        pub ty: Type,
+
+        /// Default value: `field_name: i32 = 1`
+        ///
+        /// `#![feature(default_field_values)]`
+        pub default: Option<(Token![=], Expr)>,
+    }
+}
+
+pub struct MembersWithDefault<'a> {
+    fields: punctuated::Iter<'a, FieldWithDefault>,
+    index: u32,
+}
+
+impl<'a> Iterator for MembersWithDefault<'a> {
+    type Item = Member;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let field = self.fields.next()?;
+        let member = match &field.ident {
+            Some(ident) => Member::Named(ident.clone()),
+            None => {
+                #[cfg(all(feature = "parsing", feature = "printing"))]
+                let span = crate::spanned::Spanned::span(&field.ty);
+                #[cfg(not(all(feature = "parsing", feature = "printing")))]
+                let span = proc_macro2::Span::call_site();
+                Member::Unnamed(Index {
+                    index: self.index,
+                    span,
+                })
+            }
+        };
+        self.index += 1;
+        Some(member)
+    }
+}
+
+impl<'a> Clone for MembersWithDefault<'a> {
+    fn clone(&self) -> Self {
+        MembersWithDefault {
+            fields: self.fields.clone(),
+            index: self.index,
+        }
+    }
+}
+
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::Attribute;
@@ -250,43 +485,17 @@ pub(crate) mod parsing {
     use crate::restriction::{FieldMutability, Visibility};
     #[cfg(not(feature = "full"))]
     use crate::scan_expr::scan_expr;
-    use crate::token;
     use crate::ty::Type;
     use crate::verbatim;
+    use crate::{
+        token, FieldWithDefault, FieldsNamedWithDefault, FieldsUnnamedWithDefault,
+        FieldsWithDefault, VariantWithDefault,
+    };
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     impl Parse for Variant {
         fn parse(input: ParseStream) -> Result<Self> {
-            let attrs = input.call(Attribute::parse_outer)?;
-            let _visibility: Visibility = input.parse()?;
-            let ident: Ident = input.parse()?;
-            let fields = if input.peek(token::Brace) {
-                Fields::Named(input.parse()?)
-            } else if input.peek(token::Paren) {
-                Fields::Unnamed(input.parse()?)
-            } else {
-                Fields::Unit
-            };
-            let discriminant = if input.peek(Token![=]) {
-                let eq_token: Token![=] = input.parse()?;
-                #[cfg(feature = "full")]
-                let discriminant: Expr = input.parse()?;
-                #[cfg(not(feature = "full"))]
-                let discriminant = {
-                    let begin = input.fork();
-                    let ahead = input.fork();
-                    let mut discriminant: Result<Expr> = ahead.parse();
-                    if discriminant.is_ok() {
-                        input.advance_to(&ahead);
-                    } else if scan_expr(input).is_ok() {
-                        discriminant = Ok(Expr::Verbatim(verbatim::between(&begin, input)));
-                    }
-                    discriminant?
-                };
-                Some((eq_token, discriminant))
-            } else {
-                None
-            };
+            let (attrs, ident, fields, discriminant) = parse_variants(input)?;
             Ok(Variant {
                 attrs,
                 ident,
@@ -294,6 +503,57 @@ pub(crate) mod parsing {
                 discriminant,
             })
         }
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
+    impl Parse for VariantWithDefault {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let (attrs, ident, fields, discriminant) = parse_variants(input)?;
+            Ok(VariantWithDefault {
+                attrs,
+                ident,
+                fields,
+                discriminant,
+            })
+        }
+    }
+
+    // Internal function, only used directly above.
+    #[allow(clippy::type_complexity)]
+    fn parse_variants<F: FieldsStruct>(
+        input: &crate::parse::ParseBuffer<'_>,
+    ) -> Result<(Vec<Attribute>, Ident, F, Option<(Token![=], Expr)>)> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let _visibility: Visibility = input.parse()?;
+        let ident: Ident = input.parse()?;
+        let fields = if input.peek(token::Brace) {
+            F::named(input.parse()?)
+        } else if input.peek(token::Paren) {
+            F::unnamed(input.parse()?)
+        } else {
+            F::unit()
+        };
+        let discriminant = if input.peek(Token![=]) {
+            let eq_token: Token![=] = input.parse()?;
+            #[cfg(feature = "full")]
+            let discriminant: Expr = input.parse()?;
+            #[cfg(not(feature = "full"))]
+            let discriminant = {
+                let begin = input.fork();
+                let ahead = input.fork();
+                let mut discriminant: Result<Expr> = ahead.parse();
+                if discriminant.is_ok() {
+                    input.advance_to(&ahead);
+                } else if scan_expr(input).is_ok() {
+                    discriminant = Ok(Expr::Verbatim(verbatim::between(&begin, input)));
+                }
+                discriminant?
+            };
+            Some((eq_token, discriminant))
+        } else {
+            None
+        };
+        Ok((attrs, ident, fields, discriminant))
     }
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
@@ -318,10 +578,49 @@ pub(crate) mod parsing {
         }
     }
 
+    #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
+    impl Parse for FieldsNamedWithDefault {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let content;
+            Ok(FieldsNamedWithDefault {
+                brace_token: braced!(content in input),
+                named: content.parse_terminated(FieldWithDefault::parse_named, Token![,])?,
+            })
+        }
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
+    impl Parse for FieldsUnnamedWithDefault {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let content;
+            Ok(FieldsUnnamedWithDefault {
+                paren_token: parenthesized!(content in input),
+                unnamed: content.parse_terminated(FieldWithDefault::parse_unnamed, Token![,])?,
+            })
+        }
+    }
+
     impl Field {
         /// Parses a named (braced struct) field.
         #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
         pub fn parse_named(input: ParseStream) -> Result<Self> {
+            let (res, default) = Self::parse_named_with_default(input)?;
+            if let Some((_eq, _)) = default {
+                // We choose not to emit an error in this case, because ignoring it brings implicit support
+                // for ignoring default field values to ecosystem derive macros.
+                // The counterpoint is that it will be confusing for non-derive macros (or external
+                // parsing), although it's much rarer to find those on structs/enums.
+                // (This confusion would be because the corresponding `ToTokens` impl will just silently
+                // exclude the default field value)
+            }
+            Ok(res)
+        }
+
+        /// Parses a named (braced struct) field, optionally returning the default value.
+        #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
+        fn parse_named_with_default(
+            input: ParseStream,
+        ) -> Result<(Self, Option<(Token![=], Expr)>)> {
             let attrs = input.call(Attribute::parse_outer)?;
             let vis: Visibility = input.parse()?;
 
@@ -346,14 +645,23 @@ pub(crate) mod parsing {
                 input.parse()?
             };
 
-            Ok(Field {
-                attrs,
-                vis,
-                mutability: FieldMutability::None,
-                ident: Some(ident),
-                colon_token: Some(colon_token),
-                ty,
-            })
+            let mut default: Option<(Token![=], Expr)> = None;
+            if input.peek(Token![=]) {
+                let eq_token: Token![=] = input.parse()?;
+                default = Some((eq_token, input.parse()?));
+            }
+
+            Ok((
+                Field {
+                    attrs,
+                    vis,
+                    mutability: FieldMutability::None,
+                    ident: Some(ident),
+                    colon_token: Some(colon_token),
+                    ty,
+                },
+                default,
+            ))
         }
 
         /// Parses an unnamed (tuple struct) field.
@@ -369,12 +677,100 @@ pub(crate) mod parsing {
             })
         }
     }
+    impl FieldWithDefault {
+        pub fn parse_named(input: ParseStream) -> Result<Self> {
+            let (
+                Field {
+                    attrs,
+                    vis,
+                    mutability,
+                    ident,
+                    colon_token,
+                    ty,
+                },
+                default,
+            ) = Field::parse_named_with_default(input)?;
+            Ok(Self {
+                attrs,
+                vis,
+                mutability,
+                ident,
+                colon_token,
+                ty,
+                default,
+            })
+        }
+
+        /// Parses an unnamed (tuple struct) field.
+        ///
+        /// There is no need for default field values in.
+        pub fn parse_unnamed(input: ParseStream) -> Result<Self> {
+            let Field {
+                attrs,
+                vis,
+                mutability,
+                ident,
+                colon_token,
+                ty,
+            } = Field::parse_unnamed(input)?;
+            Ok(Self {
+                attrs,
+                vis,
+                mutability,
+                ident,
+                colon_token,
+                ty,
+                default: None,
+            })
+        }
+    }
+
+    /// An internal trait to allow abstracting minimally over [`Fields`] and [`FieldsUnnamed`] in parsing.
+    pub(crate) trait FieldsStruct {
+        type NamedTy: Parse;
+        type UnnamedTy: Parse;
+
+        fn named(named: Self::NamedTy) -> Self;
+        fn unnamed(unnamed: Self::UnnamedTy) -> Self;
+        fn unit() -> Self;
+    }
+
+    impl FieldsStruct for Fields {
+        type NamedTy = FieldsNamed;
+        type UnnamedTy = FieldsUnnamed;
+        fn named(named: Self::NamedTy) -> Self {
+            Self::Named(named)
+        }
+        fn unnamed(unnamed: Self::UnnamedTy) -> Self {
+            Self::Unnamed(unnamed)
+        }
+        fn unit() -> Self {
+            Self::Unit
+        }
+    }
+
+    impl FieldsStruct for FieldsWithDefault {
+        type NamedTy = FieldsNamedWithDefault;
+        type UnnamedTy = FieldsUnnamedWithDefault;
+        fn named(named: Self::NamedTy) -> Self {
+            Self::Named(named)
+        }
+        fn unnamed(unnamed: Self::UnnamedTy) -> Self {
+            Self::Unnamed(unnamed)
+        }
+        fn unit() -> Self {
+            Self::Unit
+        }
+    }
 }
 
 #[cfg(feature = "printing")]
 mod printing {
     use crate::data::{Field, FieldsNamed, FieldsUnnamed, Variant};
     use crate::print::TokensOrDefault;
+    use crate::{
+        FieldWithDefault, FieldsNamedWithDefault, FieldsUnnamedWithDefault, VariantWithDefault,
+    };
     use proc_macro2::TokenStream;
     use quote::{ToTokens, TokenStreamExt as _};
 
@@ -419,6 +815,53 @@ mod printing {
                 TokensOrDefault(&self.colon_token).to_tokens(tokens);
             }
             self.ty.to_tokens(tokens);
+        }
+    }
+    #[cfg_attr(docsrs, doc(cfg(feature = "printing")))]
+    impl ToTokens for VariantWithDefault {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            tokens.append_all(&self.attrs);
+            self.ident.to_tokens(tokens);
+            self.fields.to_tokens(tokens);
+            if let Some((eq_token, disc)) = &self.discriminant {
+                eq_token.to_tokens(tokens);
+                disc.to_tokens(tokens);
+            }
+        }
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "printing")))]
+    impl ToTokens for FieldsNamedWithDefault {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            self.brace_token.surround(tokens, |tokens| {
+                self.named.to_tokens(tokens);
+            });
+        }
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "printing")))]
+    impl ToTokens for FieldsUnnamedWithDefault {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            self.paren_token.surround(tokens, |tokens| {
+                self.unnamed.to_tokens(tokens);
+            });
+        }
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "printing")))]
+    impl ToTokens for FieldWithDefault {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            tokens.append_all(&self.attrs);
+            self.vis.to_tokens(tokens);
+            if let Some(ident) = &self.ident {
+                ident.to_tokens(tokens);
+                TokensOrDefault(&self.colon_token).to_tokens(tokens);
+            }
+            self.ty.to_tokens(tokens);
+            if let Some((eq, default)) = &self.default {
+                eq.to_tokens(tokens);
+                default.to_tokens(tokens);
+            }
         }
     }
 }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,5 +1,7 @@
 use crate::attr::Attribute;
 use crate::data::{Fields, FieldsNamed, Variant};
+
+use crate::data::{FieldsWithDefault, VariantWithDefault};
 use crate::generics::Generics;
 use crate::ident::Ident;
 use crate::punctuated::Punctuated;
@@ -63,11 +65,67 @@ ast_struct! {
     }
 }
 
+ast_struct! {
+    /// Data structure sent to a `proc_macro_derive` macro.
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    pub struct DeriveInputWithDefault {
+        pub attrs: Vec<Attribute>,
+        pub vis: Visibility,
+        pub ident: Ident,
+        pub generics: Generics,
+        pub data: DataWithDefault,
+    }
+}
+
+ast_enum! {
+    /// The storage of a struct, enum or union data structure.
+    ///
+    /// This is a version of [`Data`](crate::Data), with added support for
+    /// the "default_field_values" Rust feature.
+    /// This is used by derive macros which wish to support default field values.
+    ///
+    /// # Syntax tree enum
+    ///
+    /// This type is a [syntax tree enum].
+    ///
+    /// [syntax tree enum]: crate::expr::Expr#syntax-tree-enums
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    pub enum DataWithDefault {
+        Struct(DataStructWithDefault),
+        Enum(DataEnumWithDefault),
+        Union(DataUnion),
+    }
+}
+
+ast_struct! {
+    /// A struct input to a `proc_macro_derive` macro.
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    pub struct DataStructWithDefault {
+        pub struct_token: Token![struct],
+        pub fields: FieldsWithDefault,
+        pub semi_token: Option<Token![;]>,
+    }
+}
+
+ast_struct! {
+    /// An enum input to a `proc_macro_derive` macro.
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    pub struct DataEnumWithDefault {
+        pub enum_token: Token![enum],
+        pub brace_token: token::Brace,
+        pub variants: Punctuated<VariantWithDefault, Token![,]>,
+    }
+}
+
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::Attribute;
-    use crate::data::{Fields, FieldsNamed, Variant};
-    use crate::derive::{Data, DataEnum, DataStruct, DataUnion, DeriveInput};
+    use crate::data::parsing::FieldsStruct;
+    use crate::data::FieldsNamed;
+    use crate::derive::{
+        Data, DataEnum, DataEnumWithDefault, DataStruct, DataStructWithDefault, DataUnion,
+        DataWithDefault, DeriveInput, DeriveInputWithDefault,
+    };
     use crate::error::Result;
     use crate::generics::{Generics, WhereClause};
     use crate::ident::Ident;
@@ -145,9 +203,78 @@ pub(crate) mod parsing {
         }
     }
 
-    pub(crate) fn data_struct(
+    #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
+    impl Parse for DeriveInputWithDefault {
+        fn parse(input: ParseStream) -> Result<Self> {
+            let attrs = input.call(Attribute::parse_outer)?;
+            let vis = input.parse::<Visibility>()?;
+
+            let lookahead = input.lookahead1();
+            if lookahead.peek(Token![struct]) {
+                let struct_token = input.parse::<Token![struct]>()?;
+                let ident = input.parse::<Ident>()?;
+                let generics = input.parse::<Generics>()?;
+                let (where_clause, fields, semi) = data_struct(input)?;
+                Ok(DeriveInputWithDefault {
+                    attrs,
+                    vis,
+                    ident,
+                    generics: Generics {
+                        where_clause,
+                        ..generics
+                    },
+                    data: DataWithDefault::Struct(DataStructWithDefault {
+                        struct_token,
+                        fields,
+                        semi_token: semi,
+                    }),
+                })
+            } else if lookahead.peek(Token![enum]) {
+                let enum_token = input.parse::<Token![enum]>()?;
+                let ident = input.parse::<Ident>()?;
+                let generics = input.parse::<Generics>()?;
+                let (where_clause, brace, variants) = data_enum(input)?;
+                Ok(DeriveInputWithDefault {
+                    attrs,
+                    vis,
+                    ident,
+                    generics: Generics {
+                        where_clause,
+                        ..generics
+                    },
+                    data: DataWithDefault::Enum(DataEnumWithDefault {
+                        enum_token,
+                        brace_token: brace,
+                        variants,
+                    }),
+                })
+            } else if lookahead.peek(Token![union]) {
+                let union_token = input.parse::<Token![union]>()?;
+                let ident = input.parse::<Ident>()?;
+                let generics = input.parse::<Generics>()?;
+                let (where_clause, fields) = data_union(input)?;
+                Ok(DeriveInputWithDefault {
+                    attrs,
+                    vis,
+                    ident,
+                    generics: Generics {
+                        where_clause,
+                        ..generics
+                    },
+                    data: DataWithDefault::Union(DataUnion {
+                        union_token,
+                        fields,
+                    }),
+                })
+            } else {
+                Err(lookahead.error())
+            }
+        }
+    }
+
+    pub(crate) fn data_struct<F: FieldsStruct>(
         input: ParseStream,
-    ) -> Result<(Option<WhereClause>, Fields, Option<Token![;]>)> {
+    ) -> Result<(Option<WhereClause>, F, Option<Token![;]>)> {
         let mut lookahead = input.lookahead1();
         let mut where_clause = None;
         if lookahead.peek(Token![where]) {
@@ -166,33 +293,33 @@ pub(crate) mod parsing {
 
             if lookahead.peek(Token![;]) {
                 let semi = input.parse()?;
-                Ok((where_clause, Fields::Unnamed(fields), Some(semi)))
+                Ok((where_clause, F::unnamed(fields), Some(semi)))
             } else {
                 Err(lookahead.error())
             }
         } else if lookahead.peek(token::Brace) {
             let fields = input.parse()?;
-            Ok((where_clause, Fields::Named(fields), None))
+            Ok((where_clause, F::named(fields), None))
         } else if lookahead.peek(Token![;]) {
             let semi = input.parse()?;
-            Ok((where_clause, Fields::Unit, Some(semi)))
+            Ok((where_clause, F::unit(), Some(semi)))
         } else {
             Err(lookahead.error())
         }
     }
 
-    pub(crate) fn data_enum(
+    pub(crate) fn data_enum<Variants: Parse>(
         input: ParseStream,
     ) -> Result<(
         Option<WhereClause>,
         token::Brace,
-        Punctuated<Variant, Token![,]>,
+        Punctuated<Variants, Token![,]>,
     )> {
         let where_clause = input.parse()?;
 
         let content;
         let brace = braced!(content in input);
-        let variants = content.parse_terminated(Variant::parse, Token![,])?;
+        let variants = content.parse_terminated(Variants::parse, Token![,])?;
 
         Ok((where_clause, brace, variants))
     }

--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -202,9 +202,31 @@ impl Clone for crate::DataEnum {
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::DataEnumWithDefault {
+    fn clone(&self) -> Self {
+        crate::DataEnumWithDefault {
+            enum_token: self.enum_token.clone(),
+            brace_token: self.brace_token.clone(),
+            variants: self.variants.clone(),
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::DataStruct {
     fn clone(&self) -> Self {
         crate::DataStruct {
+            struct_token: self.struct_token.clone(),
+            fields: self.fields.clone(),
+            semi_token: self.semi_token.clone(),
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::DataStructWithDefault {
+    fn clone(&self) -> Self {
+        crate::DataStructWithDefault {
             struct_token: self.struct_token.clone(),
             fields: self.fields.clone(),
             semi_token: self.semi_token.clone(),
@@ -223,9 +245,37 @@ impl Clone for crate::DataUnion {
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::DataWithDefault {
+    fn clone(&self) -> Self {
+        match self {
+            crate::DataWithDefault::Struct(v0) => {
+                crate::DataWithDefault::Struct(v0.clone())
+            }
+            crate::DataWithDefault::Enum(v0) => crate::DataWithDefault::Enum(v0.clone()),
+            crate::DataWithDefault::Union(v0) => {
+                crate::DataWithDefault::Union(v0.clone())
+            }
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::DeriveInput {
     fn clone(&self) -> Self {
         crate::DeriveInput {
+            attrs: self.attrs.clone(),
+            vis: self.vis.clone(),
+            ident: self.ident.clone(),
+            generics: self.generics.clone(),
+            data: self.data.clone(),
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::DeriveInputWithDefault {
+    fn clone(&self) -> Self {
+        crate::DeriveInputWithDefault {
             attrs: self.attrs.clone(),
             vis: self.vis.clone(),
             ident: self.ident.clone(),
@@ -827,6 +877,21 @@ impl Clone for crate::FieldValue {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::FieldWithDefault {
+    fn clone(&self) -> Self {
+        crate::FieldWithDefault {
+            attrs: self.attrs.clone(),
+            vis: self.vis.clone(),
+            mutability: self.mutability.clone(),
+            ident: self.ident.clone(),
+            colon_token: self.colon_token.clone(),
+            ty: self.ty.clone(),
+            default: self.default.clone(),
+        }
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::Fields {
     fn clone(&self) -> Self {
         match self {
@@ -848,6 +913,16 @@ impl Clone for crate::FieldsNamed {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::FieldsNamedWithDefault {
+    fn clone(&self) -> Self {
+        crate::FieldsNamedWithDefault {
+            brace_token: self.brace_token.clone(),
+            named: self.named.clone(),
+        }
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::FieldsUnnamed {
     fn clone(&self) -> Self {
         crate::FieldsUnnamed {
@@ -856,11 +931,47 @@ impl Clone for crate::FieldsUnnamed {
         }
     }
 }
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::FieldsUnnamedWithDefault {
+    fn clone(&self) -> Self {
+        crate::FieldsUnnamedWithDefault {
+            paren_token: self.paren_token.clone(),
+            unnamed: self.unnamed.clone(),
+        }
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::FieldsWithDefault {
+    fn clone(&self) -> Self {
+        match self {
+            crate::FieldsWithDefault::Named(v0) => {
+                crate::FieldsWithDefault::Named(v0.clone())
+            }
+            crate::FieldsWithDefault::Unnamed(v0) => {
+                crate::FieldsWithDefault::Unnamed(v0.clone())
+            }
+            crate::FieldsWithDefault::Unit => crate::FieldsWithDefault::Unit,
+        }
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::File {
     fn clone(&self) -> Self {
         crate::File {
+            shebang: self.shebang.clone(),
+            attrs: self.attrs.clone(),
+            items: self.items.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::FileWithDefault {
+    fn clone(&self) -> Self {
+        crate::FileWithDefault {
             shebang: self.shebang.clone(),
             attrs: self.attrs.clone(),
             items: self.items.clone(),
@@ -1141,6 +1252,21 @@ impl Clone for crate::ItemEnum {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ItemEnumWithDefault {
+    fn clone(&self) -> Self {
+        crate::ItemEnumWithDefault {
+            attrs: self.attrs.clone(),
+            vis: self.vis.clone(),
+            enum_token: self.enum_token.clone(),
+            ident: self.ident.clone(),
+            generics: self.generics.clone(),
+            brace_token: self.brace_token.clone(),
+            variants: self.variants.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::ItemExternCrate {
     fn clone(&self) -> Self {
         crate::ItemExternCrate {
@@ -1225,6 +1351,21 @@ impl Clone for crate::ItemMod {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ItemModWithDefault {
+    fn clone(&self) -> Self {
+        crate::ItemModWithDefault {
+            attrs: self.attrs.clone(),
+            vis: self.vis.clone(),
+            unsafety: self.unsafety.clone(),
+            mod_token: self.mod_token.clone(),
+            ident: self.ident.clone(),
+            content: self.content.clone(),
+            semi: self.semi.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::ItemStatic {
     fn clone(&self) -> Self {
         crate::ItemStatic {
@@ -1246,6 +1387,21 @@ impl Clone for crate::ItemStatic {
 impl Clone for crate::ItemStruct {
     fn clone(&self) -> Self {
         crate::ItemStruct {
+            attrs: self.attrs.clone(),
+            vis: self.vis.clone(),
+            struct_token: self.struct_token.clone(),
+            ident: self.ident.clone(),
+            generics: self.generics.clone(),
+            fields: self.fields.clone(),
+            semi_token: self.semi_token.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ItemStructWithDefault {
+    fn clone(&self) -> Self {
+        crate::ItemStructWithDefault {
             attrs: self.attrs.clone(),
             vis: self.vis.clone(),
             struct_token: self.struct_token.clone(),
@@ -1333,6 +1489,26 @@ impl Clone for crate::ItemUse {
             leading_colon: self.leading_colon.clone(),
             tree: self.tree.clone(),
             semi_token: self.semi_token.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ItemWithDefault {
+    fn clone(&self) -> Self {
+        match self {
+            crate::ItemWithDefault::StructWithDefault(v0) => {
+                crate::ItemWithDefault::StructWithDefault(v0.clone())
+            }
+            crate::ItemWithDefault::EnumWithDefault(v0) => {
+                crate::ItemWithDefault::EnumWithDefault(v0.clone())
+            }
+            crate::ItemWithDefault::ModWithDefault(v0) => {
+                crate::ItemWithDefault::ModWithDefault(v0.clone())
+            }
+            crate::ItemWithDefault::Other(v0) => {
+                crate::ItemWithDefault::Other(v0.clone())
+            }
         }
     }
 }
@@ -2211,6 +2387,18 @@ impl Clone for crate::Variadic {
 impl Clone for crate::Variant {
     fn clone(&self) -> Self {
         crate::Variant {
+            attrs: self.attrs.clone(),
+            ident: self.ident.clone(),
+            fields: self.fields.clone(),
+            discriminant: self.discriminant.clone(),
+        }
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::VariantWithDefault {
+    fn clone(&self) -> Self {
+        crate::VariantWithDefault {
             attrs: self.attrs.clone(),
             ident: self.ident.clone(),
             fields: self.fields.clone(),

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -367,6 +367,17 @@ impl crate::DataEnum {
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::DataEnumWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("DataEnumWithDefault");
+        formatter.field("enum_token", &self.enum_token);
+        formatter.field("brace_token", &self.brace_token);
+        formatter.field("variants", &self.variants);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::DataStruct {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         self.debug(formatter, "DataStruct")
@@ -376,6 +387,17 @@ impl Debug for crate::DataStruct {
 impl crate::DataStruct {
     fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
         let mut formatter = formatter.debug_struct(name);
+        formatter.field("struct_token", &self.struct_token);
+        formatter.field("fields", &self.fields);
+        formatter.field("semi_token", &self.semi_token);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::DataStructWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("DataStructWithDefault");
         formatter.field("struct_token", &self.struct_token);
         formatter.field("fields", &self.fields);
         formatter.field("semi_token", &self.semi_token);
@@ -400,9 +422,46 @@ impl crate::DataUnion {
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::DataWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("DataWithDefault::")?;
+        match self {
+            crate::DataWithDefault::Struct(v0) => {
+                let mut formatter = formatter.debug_tuple("Struct");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::DataWithDefault::Enum(v0) => {
+                let mut formatter = formatter.debug_tuple("Enum");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::DataWithDefault::Union(v0) => {
+                let mut formatter = formatter.debug_tuple("Union");
+                formatter.field(v0);
+                formatter.finish()
+            }
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::DeriveInput {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("DeriveInput");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("vis", &self.vis);
+        formatter.field("ident", &self.ident);
+        formatter.field("generics", &self.generics);
+        formatter.field("data", &self.data);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::DeriveInputWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("DeriveInputWithDefault");
         formatter.field("attrs", &self.attrs);
         formatter.field("vis", &self.vis);
         formatter.field("ident", &self.ident);
@@ -1244,6 +1303,21 @@ impl Debug for crate::FieldValue {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::FieldWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FieldWithDefault");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("vis", &self.vis);
+        formatter.field("mutability", &self.mutability);
+        formatter.field("ident", &self.ident);
+        formatter.field("colon_token", &self.colon_token);
+        formatter.field("ty", &self.ty);
+        formatter.field("default", &self.default);
+        formatter.finish()
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::Fields {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("Fields::")?;
@@ -1272,6 +1346,16 @@ impl crate::FieldsNamed {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::FieldsNamedWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FieldsNamedWithDefault");
+        formatter.field("brace_token", &self.brace_token);
+        formatter.field("named", &self.named);
+        formatter.finish()
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::FieldsUnnamed {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         self.debug(formatter, "FieldsUnnamed")
@@ -1286,11 +1370,52 @@ impl crate::FieldsUnnamed {
         formatter.finish()
     }
 }
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::FieldsUnnamedWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FieldsUnnamedWithDefault");
+        formatter.field("paren_token", &self.paren_token);
+        formatter.field("unnamed", &self.unnamed);
+        formatter.finish()
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::FieldsWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("FieldsWithDefault::")?;
+        match self {
+            crate::FieldsWithDefault::Named(v0) => {
+                let mut formatter = formatter.debug_tuple("Named");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::FieldsWithDefault::Unnamed(v0) => {
+                let mut formatter = formatter.debug_tuple("Unnamed");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::FieldsWithDefault::Unit => formatter.write_str("Unit"),
+        }
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::File {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("File");
+        formatter.field("shebang", &self.shebang);
+        formatter.field("attrs", &self.attrs);
+        formatter.field("items", &self.items);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::FileWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FileWithDefault");
         formatter.field("shebang", &self.shebang);
         formatter.field("attrs", &self.attrs);
         formatter.field("items", &self.items);
@@ -1681,6 +1806,21 @@ impl crate::ItemEnum {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ItemEnumWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ItemEnumWithDefault");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("vis", &self.vis);
+        formatter.field("enum_token", &self.enum_token);
+        formatter.field("ident", &self.ident);
+        formatter.field("generics", &self.generics);
+        formatter.field("brace_token", &self.brace_token);
+        formatter.field("variants", &self.variants);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::ItemExternCrate {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         self.debug(formatter, "ItemExternCrate")
@@ -1801,6 +1941,21 @@ impl crate::ItemMod {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ItemModWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ItemModWithDefault");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("vis", &self.vis);
+        formatter.field("unsafety", &self.unsafety);
+        formatter.field("mod_token", &self.mod_token);
+        formatter.field("ident", &self.ident);
+        formatter.field("content", &self.content);
+        formatter.field("semi", &self.semi);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::ItemStatic {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         self.debug(formatter, "ItemStatic")
@@ -1834,6 +1989,21 @@ impl Debug for crate::ItemStruct {
 impl crate::ItemStruct {
     fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
         let mut formatter = formatter.debug_struct(name);
+        formatter.field("attrs", &self.attrs);
+        formatter.field("vis", &self.vis);
+        formatter.field("struct_token", &self.struct_token);
+        formatter.field("ident", &self.ident);
+        formatter.field("generics", &self.generics);
+        formatter.field("fields", &self.fields);
+        formatter.field("semi_token", &self.semi_token);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ItemStructWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ItemStructWithDefault");
         formatter.field("attrs", &self.attrs);
         formatter.field("vis", &self.vis);
         formatter.field("struct_token", &self.struct_token);
@@ -1952,6 +2122,35 @@ impl crate::ItemUse {
         formatter.field("tree", &self.tree);
         formatter.field("semi_token", &self.semi_token);
         formatter.finish()
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ItemWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("ItemWithDefault::")?;
+        match self {
+            crate::ItemWithDefault::StructWithDefault(v0) => {
+                let mut formatter = formatter.debug_tuple("StructWithDefault");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::ItemWithDefault::EnumWithDefault(v0) => {
+                let mut formatter = formatter.debug_tuple("EnumWithDefault");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::ItemWithDefault::ModWithDefault(v0) => {
+                let mut formatter = formatter.debug_tuple("ModWithDefault");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::ItemWithDefault::Other(v0) => {
+                let mut formatter = formatter.debug_tuple("Other");
+                formatter.field(v0);
+                formatter.finish()
+            }
+        }
     }
 }
 #[cfg(feature = "full")]
@@ -3166,6 +3365,18 @@ impl Debug for crate::Variadic {
 impl Debug for crate::Variant {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("Variant");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("ident", &self.ident);
+        formatter.field("fields", &self.fields);
+        formatter.field("discriminant", &self.discriminant);
+        formatter.finish()
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::VariantWithDefault {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("VariantWithDefault");
         formatter.field("attrs", &self.attrs);
         formatter.field("ident", &self.ident);
         formatter.field("fields", &self.fields);

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -228,10 +228,30 @@ impl PartialEq for crate::DataEnum {
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::DataEnumWithDefault {}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::DataEnumWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        self.variants == other.variants
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::DataStruct {}
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::DataStruct {
+    fn eq(&self, other: &Self) -> bool {
+        self.fields == other.fields && self.semi_token == other.semi_token
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::DataStructWithDefault {}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::DataStructWithDefault {
     fn eq(&self, other: &Self) -> bool {
         self.fields == other.fields && self.semi_token == other.semi_token
     }
@@ -248,10 +268,45 @@ impl PartialEq for crate::DataUnion {
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::DataWithDefault {}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::DataWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                crate::DataWithDefault::Struct(self0),
+                crate::DataWithDefault::Struct(other0),
+            ) => self0 == other0,
+            (
+                crate::DataWithDefault::Enum(self0),
+                crate::DataWithDefault::Enum(other0),
+            ) => self0 == other0,
+            (
+                crate::DataWithDefault::Union(self0),
+                crate::DataWithDefault::Union(other0),
+            ) => self0 == other0,
+            _ => false,
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::DeriveInput {}
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::DeriveInput {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.vis == other.vis && self.ident == other.ident
+            && self.generics == other.generics && self.data == other.data
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::DeriveInputWithDefault {}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::DeriveInputWithDefault {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis && self.ident == other.ident
             && self.generics == other.generics && self.data == other.data
@@ -806,6 +861,19 @@ impl PartialEq for crate::FieldValue {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::FieldWithDefault {}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::FieldWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.vis == other.vis
+            && self.mutability == other.mutability && self.ident == other.ident
+            && self.colon_token == other.colon_token && self.ty == other.ty
+            && self.default == other.default
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::Fields {}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
@@ -835,6 +903,16 @@ impl PartialEq for crate::FieldsNamed {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::FieldsNamedWithDefault {}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::FieldsNamedWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        self.named == other.named
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::FieldsUnnamed {}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
@@ -843,12 +921,54 @@ impl PartialEq for crate::FieldsUnnamed {
         self.unnamed == other.unnamed
     }
 }
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::FieldsUnnamedWithDefault {}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::FieldsUnnamedWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        self.unnamed == other.unnamed
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::FieldsWithDefault {}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::FieldsWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                crate::FieldsWithDefault::Named(self0),
+                crate::FieldsWithDefault::Named(other0),
+            ) => self0 == other0,
+            (
+                crate::FieldsWithDefault::Unnamed(self0),
+                crate::FieldsWithDefault::Unnamed(other0),
+            ) => self0 == other0,
+            (crate::FieldsWithDefault::Unit, crate::FieldsWithDefault::Unit) => true,
+            _ => false,
+        }
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::File {}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::File {
+    fn eq(&self, other: &Self) -> bool {
+        self.shebang == other.shebang && self.attrs == other.attrs
+            && self.items == other.items
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::FileWithDefault {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::FileWithDefault {
     fn eq(&self, other: &Self) -> bool {
         self.shebang == other.shebang && self.attrs == other.attrs
             && self.items == other.items
@@ -1155,6 +1275,17 @@ impl PartialEq for crate::ItemEnum {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ItemEnumWithDefault {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ItemEnumWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.vis == other.vis && self.ident == other.ident
+            && self.generics == other.generics && self.variants == other.variants
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::ItemExternCrate {}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
@@ -1224,6 +1355,18 @@ impl PartialEq for crate::ItemMod {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ItemModWithDefault {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ItemModWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.vis == other.vis
+            && self.unsafety == other.unsafety && self.ident == other.ident
+            && self.content == other.content && self.semi == other.semi
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::ItemStatic {}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
@@ -1240,6 +1383,18 @@ impl Eq for crate::ItemStruct {}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::ItemStruct {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.vis == other.vis && self.ident == other.ident
+            && self.generics == other.generics && self.fields == other.fields
+            && self.semi_token == other.semi_token
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ItemStructWithDefault {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ItemStructWithDefault {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis && self.ident == other.ident
             && self.generics == other.generics && self.fields == other.fields
@@ -1302,6 +1457,34 @@ impl PartialEq for crate::ItemUse {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis
             && self.leading_colon == other.leading_colon && self.tree == other.tree
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ItemWithDefault {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ItemWithDefault {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                crate::ItemWithDefault::StructWithDefault(self0),
+                crate::ItemWithDefault::StructWithDefault(other0),
+            ) => self0 == other0,
+            (
+                crate::ItemWithDefault::EnumWithDefault(self0),
+                crate::ItemWithDefault::EnumWithDefault(other0),
+            ) => self0 == other0,
+            (
+                crate::ItemWithDefault::ModWithDefault(self0),
+                crate::ItemWithDefault::ModWithDefault(other0),
+            ) => self0 == other0,
+            (
+                crate::ItemWithDefault::Other(self0),
+                crate::ItemWithDefault::Other(other0),
+            ) => self0 == other0,
+            _ => false,
+        }
     }
 }
 #[cfg(feature = "full")]
@@ -2242,6 +2425,17 @@ impl Eq for crate::Variant {}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::Variant {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.ident == other.ident
+            && self.fields == other.fields && self.discriminant == other.discriminant
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::VariantWithDefault {}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::VariantWithDefault {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.ident == other.ident
             && self.fields == other.fields && self.discriminant == other.discriminant

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -123,8 +123,24 @@ pub trait Fold {
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn fold_data_enum_with_default(
+        &mut self,
+        i: crate::DataEnumWithDefault,
+    ) -> crate::DataEnumWithDefault {
+        fold_data_enum_with_default(self, i)
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
     fn fold_data_struct(&mut self, i: crate::DataStruct) -> crate::DataStruct {
         fold_data_struct(self, i)
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn fold_data_struct_with_default(
+        &mut self,
+        i: crate::DataStructWithDefault,
+    ) -> crate::DataStructWithDefault {
+        fold_data_struct_with_default(self, i)
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
@@ -133,8 +149,24 @@ pub trait Fold {
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn fold_data_with_default(
+        &mut self,
+        i: crate::DataWithDefault,
+    ) -> crate::DataWithDefault {
+        fold_data_with_default(self, i)
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
     fn fold_derive_input(&mut self, i: crate::DeriveInput) -> crate::DeriveInput {
         fold_derive_input(self, i)
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn fold_derive_input_with_default(
+        &mut self,
+        i: crate::DeriveInputWithDefault,
+    ) -> crate::DeriveInputWithDefault {
+        fold_derive_input_with_default(self, i)
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -364,6 +396,14 @@ pub trait Fold {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn fold_field_with_default(
+        &mut self,
+        i: crate::FieldWithDefault,
+    ) -> crate::FieldWithDefault {
+        fold_field_with_default(self, i)
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn fold_fields(&mut self, i: crate::Fields) -> crate::Fields {
         fold_fields(self, i)
     }
@@ -374,13 +414,45 @@ pub trait Fold {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn fold_fields_named_with_default(
+        &mut self,
+        i: crate::FieldsNamedWithDefault,
+    ) -> crate::FieldsNamedWithDefault {
+        fold_fields_named_with_default(self, i)
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn fold_fields_unnamed(&mut self, i: crate::FieldsUnnamed) -> crate::FieldsUnnamed {
         fold_fields_unnamed(self, i)
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn fold_fields_unnamed_with_default(
+        &mut self,
+        i: crate::FieldsUnnamedWithDefault,
+    ) -> crate::FieldsUnnamedWithDefault {
+        fold_fields_unnamed_with_default(self, i)
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn fold_fields_with_default(
+        &mut self,
+        i: crate::FieldsWithDefault,
+    ) -> crate::FieldsWithDefault {
+        fold_fields_with_default(self, i)
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_file(&mut self, i: crate::File) -> crate::File {
         fold_file(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_file_with_default(
+        &mut self,
+        i: crate::FileWithDefault,
+    ) -> crate::FileWithDefault {
+        fold_file_with_default(self, i)
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -497,6 +569,14 @@ pub trait Fold {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_item_enum_with_default(
+        &mut self,
+        i: crate::ItemEnumWithDefault,
+    ) -> crate::ItemEnumWithDefault {
+        fold_item_enum_with_default(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_item_extern_crate(
         &mut self,
         i: crate::ItemExternCrate,
@@ -533,6 +613,14 @@ pub trait Fold {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_item_mod_with_default(
+        &mut self,
+        i: crate::ItemModWithDefault,
+    ) -> crate::ItemModWithDefault {
+        fold_item_mod_with_default(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_item_static(&mut self, i: crate::ItemStatic) -> crate::ItemStatic {
         fold_item_static(self, i)
     }
@@ -540,6 +628,14 @@ pub trait Fold {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_item_struct(&mut self, i: crate::ItemStruct) -> crate::ItemStruct {
         fold_item_struct(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_item_struct_with_default(
+        &mut self,
+        i: crate::ItemStructWithDefault,
+    ) -> crate::ItemStructWithDefault {
+        fold_item_struct_with_default(self, i)
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -568,6 +664,14 @@ pub trait Fold {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_item_use(&mut self, i: crate::ItemUse) -> crate::ItemUse {
         fold_item_use(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_item_with_default(
+        &mut self,
+        i: crate::ItemWithDefault,
+    ) -> crate::ItemWithDefault {
+        fold_item_with_default(self, i)
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -1001,6 +1105,14 @@ pub trait Fold {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn fold_variant_with_default(
+        &mut self,
+        i: crate::VariantWithDefault,
+    ) -> crate::VariantWithDefault {
+        fold_variant_with_default(self, i)
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn fold_vis_restricted(&mut self, i: crate::VisRestricted) -> crate::VisRestricted {
         fold_vis_restricted(self, i)
     }
@@ -1281,6 +1393,21 @@ where
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn fold_data_enum_with_default<F>(
+    f: &mut F,
+    node: crate::DataEnumWithDefault,
+) -> crate::DataEnumWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::DataEnumWithDefault {
+        enum_token: node.enum_token,
+        brace_token: node.brace_token,
+        variants: crate::punctuated::fold(node.variants, f, F::fold_variant_with_default),
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub fn fold_data_struct<F>(f: &mut F, node: crate::DataStruct) -> crate::DataStruct
 where
     F: Fold + ?Sized,
@@ -1288,6 +1415,21 @@ where
     crate::DataStruct {
         struct_token: node.struct_token,
         fields: f.fold_fields(node.fields),
+        semi_token: node.semi_token,
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn fold_data_struct_with_default<F>(
+    f: &mut F,
+    node: crate::DataStructWithDefault,
+) -> crate::DataStructWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::DataStructWithDefault {
+        struct_token: node.struct_token,
+        fields: f.fold_fields_with_default(node.fields),
         semi_token: node.semi_token,
     }
 }
@@ -1304,6 +1446,27 @@ where
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn fold_data_with_default<F>(
+    f: &mut F,
+    node: crate::DataWithDefault,
+) -> crate::DataWithDefault
+where
+    F: Fold + ?Sized,
+{
+    match node {
+        crate::DataWithDefault::Struct(_binding_0) => {
+            crate::DataWithDefault::Struct(f.fold_data_struct_with_default(_binding_0))
+        }
+        crate::DataWithDefault::Enum(_binding_0) => {
+            crate::DataWithDefault::Enum(f.fold_data_enum_with_default(_binding_0))
+        }
+        crate::DataWithDefault::Union(_binding_0) => {
+            crate::DataWithDefault::Union(f.fold_data_union(_binding_0))
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub fn fold_derive_input<F>(f: &mut F, node: crate::DeriveInput) -> crate::DeriveInput
 where
     F: Fold + ?Sized,
@@ -1314,6 +1477,23 @@ where
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
         data: f.fold_data(node.data),
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn fold_derive_input_with_default<F>(
+    f: &mut F,
+    node: crate::DeriveInputWithDefault,
+) -> crate::DeriveInputWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::DeriveInputWithDefault {
+        attrs: f.fold_attributes(node.attrs),
+        vis: f.fold_visibility(node.vis),
+        ident: f.fold_ident(node.ident),
+        generics: f.fold_generics(node.generics),
+        data: f.fold_data_with_default(node.data),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -2011,6 +2191,25 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn fold_field_with_default<F>(
+    f: &mut F,
+    node: crate::FieldWithDefault,
+) -> crate::FieldWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::FieldWithDefault {
+        attrs: f.fold_attributes(node.attrs),
+        vis: f.fold_visibility(node.vis),
+        mutability: f.fold_field_mutability(node.mutability),
+        ident: (node.ident).map(|it| f.fold_ident(it)),
+        colon_token: node.colon_token,
+        ty: f.fold_type(node.ty),
+        default: (node.default).map(|it| ((it).0, f.fold_expr((it).1))),
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn fold_fields<F>(f: &mut F, node: crate::Fields) -> crate::Fields
 where
     F: Fold + ?Sized,
@@ -2038,6 +2237,20 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn fold_fields_named_with_default<F>(
+    f: &mut F,
+    node: crate::FieldsNamedWithDefault,
+) -> crate::FieldsNamedWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::FieldsNamedWithDefault {
+        brace_token: node.brace_token,
+        named: crate::punctuated::fold(node.named, f, F::fold_field_with_default),
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn fold_fields_unnamed<F>(
     f: &mut F,
     node: crate::FieldsUnnamed,
@@ -2050,6 +2263,41 @@ where
         unnamed: crate::punctuated::fold(node.unnamed, f, F::fold_field),
     }
 }
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn fold_fields_unnamed_with_default<F>(
+    f: &mut F,
+    node: crate::FieldsUnnamedWithDefault,
+) -> crate::FieldsUnnamedWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::FieldsUnnamedWithDefault {
+        paren_token: node.paren_token,
+        unnamed: crate::punctuated::fold(node.unnamed, f, F::fold_field_with_default),
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn fold_fields_with_default<F>(
+    f: &mut F,
+    node: crate::FieldsWithDefault,
+) -> crate::FieldsWithDefault
+where
+    F: Fold + ?Sized,
+{
+    match node {
+        crate::FieldsWithDefault::Named(_binding_0) => {
+            crate::FieldsWithDefault::Named(f.fold_fields_named_with_default(_binding_0))
+        }
+        crate::FieldsWithDefault::Unnamed(_binding_0) => {
+            crate::FieldsWithDefault::Unnamed(
+                f.fold_fields_unnamed_with_default(_binding_0),
+            )
+        }
+        crate::FieldsWithDefault::Unit => crate::FieldsWithDefault::Unit,
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn fold_file<F>(f: &mut F, node: crate::File) -> crate::File
@@ -2060,6 +2308,21 @@ where
         shebang: node.shebang,
         attrs: f.fold_attributes(node.attrs),
         items: fold_vec(node.items, f, F::fold_item),
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_file_with_default<F>(
+    f: &mut F,
+    node: crate::FileWithDefault,
+) -> crate::FileWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::FileWithDefault {
+        shebang: node.shebang,
+        attrs: f.fold_attributes(node.attrs),
+        items: fold_vec(node.items, f, F::fold_item_with_default),
     }
 }
 #[cfg(feature = "full")]
@@ -2441,6 +2704,25 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_item_enum_with_default<F>(
+    f: &mut F,
+    node: crate::ItemEnumWithDefault,
+) -> crate::ItemEnumWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::ItemEnumWithDefault {
+        attrs: f.fold_attributes(node.attrs),
+        vis: f.fold_visibility(node.vis),
+        enum_token: node.enum_token,
+        ident: f.fold_ident(node.ident),
+        generics: f.fold_generics(node.generics),
+        brace_token: node.brace_token,
+        variants: crate::punctuated::fold(node.variants, f, F::fold_variant_with_default),
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn fold_item_extern_crate<F>(
     f: &mut F,
     node: crate::ItemExternCrate,
@@ -2537,6 +2819,26 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_item_mod_with_default<F>(
+    f: &mut F,
+    node: crate::ItemModWithDefault,
+) -> crate::ItemModWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::ItemModWithDefault {
+        attrs: f.fold_attributes(node.attrs),
+        vis: f.fold_visibility(node.vis),
+        unsafety: node.unsafety,
+        mod_token: node.mod_token,
+        ident: f.fold_ident(node.ident),
+        content: (node.content)
+            .map(|it| ((it).0, fold_vec((it).1, f, F::fold_item_with_default))),
+        semi: node.semi,
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn fold_item_static<F>(f: &mut F, node: crate::ItemStatic) -> crate::ItemStatic
 where
     F: Fold + ?Sized,
@@ -2567,6 +2869,25 @@ where
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
         fields: f.fold_fields(node.fields),
+        semi_token: node.semi_token,
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_item_struct_with_default<F>(
+    f: &mut F,
+    node: crate::ItemStructWithDefault,
+) -> crate::ItemStructWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::ItemStructWithDefault {
+        attrs: f.fold_attributes(node.attrs),
+        vis: f.fold_visibility(node.vis),
+        struct_token: node.struct_token,
+        ident: f.fold_ident(node.ident),
+        generics: f.fold_generics(node.generics),
+        fields: f.fold_fields_with_default(node.fields),
         semi_token: node.semi_token,
     }
 }
@@ -2660,6 +2981,36 @@ where
         leading_colon: node.leading_colon,
         tree: f.fold_use_tree(node.tree),
         semi_token: node.semi_token,
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_item_with_default<F>(
+    f: &mut F,
+    node: crate::ItemWithDefault,
+) -> crate::ItemWithDefault
+where
+    F: Fold + ?Sized,
+{
+    match node {
+        crate::ItemWithDefault::StructWithDefault(_binding_0) => {
+            crate::ItemWithDefault::StructWithDefault(
+                f.fold_item_struct_with_default(_binding_0),
+            )
+        }
+        crate::ItemWithDefault::EnumWithDefault(_binding_0) => {
+            crate::ItemWithDefault::EnumWithDefault(
+                f.fold_item_enum_with_default(_binding_0),
+            )
+        }
+        crate::ItemWithDefault::ModWithDefault(_binding_0) => {
+            crate::ItemWithDefault::ModWithDefault(
+                f.fold_item_mod_with_default(_binding_0),
+            )
+        }
+        crate::ItemWithDefault::Other(_binding_0) => {
+            crate::ItemWithDefault::Other(f.fold_item(_binding_0))
+        }
     }
 }
 #[cfg(feature = "full")]
@@ -3830,6 +4181,22 @@ where
         attrs: f.fold_attributes(node.attrs),
         ident: f.fold_ident(node.ident),
         fields: f.fold_fields(node.fields),
+        discriminant: (node.discriminant).map(|it| ((it).0, f.fold_expr((it).1))),
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn fold_variant_with_default<F>(
+    f: &mut F,
+    node: crate::VariantWithDefault,
+) -> crate::VariantWithDefault
+where
+    F: Fold + ?Sized,
+{
+    crate::VariantWithDefault {
+        attrs: f.fold_attributes(node.attrs),
+        ident: f.fold_ident(node.ident),
+        fields: f.fold_fields_with_default(node.fields),
         discriminant: (node.discriminant).map(|it| ((it).0, f.fold_expr((it).1))),
     }
 }

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -310,7 +310,28 @@ impl Hash for crate::DataEnum {
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::DataEnumWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.variants.hash(state);
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::DataStruct {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.fields.hash(state);
+        self.semi_token.hash(state);
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::DataStructWithDefault {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,
@@ -331,7 +352,44 @@ impl Hash for crate::DataUnion {
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::DataWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        match self {
+            crate::DataWithDefault::Struct(v0) => {
+                state.write_u8(0u8);
+                v0.hash(state);
+            }
+            crate::DataWithDefault::Enum(v0) => {
+                state.write_u8(1u8);
+                v0.hash(state);
+            }
+            crate::DataWithDefault::Union(v0) => {
+                state.write_u8(2u8);
+                v0.hash(state);
+            }
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::DeriveInput {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.vis.hash(state);
+        self.ident.hash(state);
+        self.generics.hash(state);
+        self.data.hash(state);
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::DeriveInputWithDefault {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,
@@ -1066,6 +1124,22 @@ impl Hash for crate::FieldValue {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::FieldWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.vis.hash(state);
+        self.mutability.hash(state);
+        self.ident.hash(state);
+        self.colon_token.hash(state);
+        self.ty.hash(state);
+        self.default.hash(state);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::Fields {
     fn hash<H>(&self, state: &mut H)
     where
@@ -1098,6 +1172,16 @@ impl Hash for crate::FieldsNamed {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::FieldsNamedWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.named.hash(state);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::FieldsUnnamed {
     fn hash<H>(&self, state: &mut H)
     where
@@ -1106,9 +1190,53 @@ impl Hash for crate::FieldsUnnamed {
         self.unnamed.hash(state);
     }
 }
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::FieldsUnnamedWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.unnamed.hash(state);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::FieldsWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        match self {
+            crate::FieldsWithDefault::Named(v0) => {
+                state.write_u8(0u8);
+                v0.hash(state);
+            }
+            crate::FieldsWithDefault::Unnamed(v0) => {
+                state.write_u8(1u8);
+                v0.hash(state);
+            }
+            crate::FieldsWithDefault::Unit => {
+                state.write_u8(2u8);
+            }
+        }
+    }
+}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::File {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.shebang.hash(state);
+        self.attrs.hash(state);
+        self.items.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::FileWithDefault {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,
@@ -1494,6 +1622,20 @@ impl Hash for crate::ItemEnum {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ItemEnumWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.vis.hash(state);
+        self.ident.hash(state);
+        self.generics.hash(state);
+        self.variants.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::ItemExternCrate {
     fn hash<H>(&self, state: &mut H)
     where
@@ -1577,6 +1719,21 @@ impl Hash for crate::ItemMod {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ItemModWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.vis.hash(state);
+        self.unsafety.hash(state);
+        self.ident.hash(state);
+        self.content.hash(state);
+        self.semi.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::ItemStatic {
     fn hash<H>(&self, state: &mut H)
     where
@@ -1593,6 +1750,21 @@ impl Hash for crate::ItemStatic {
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::ItemStruct {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.vis.hash(state);
+        self.ident.hash(state);
+        self.generics.hash(state);
+        self.fields.hash(state);
+        self.semi_token.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ItemStructWithDefault {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,
@@ -1677,6 +1849,33 @@ impl Hash for crate::ItemUse {
         self.vis.hash(state);
         self.leading_colon.hash(state);
         self.tree.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ItemWithDefault {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        match self {
+            crate::ItemWithDefault::StructWithDefault(v0) => {
+                state.write_u8(0u8);
+                v0.hash(state);
+            }
+            crate::ItemWithDefault::EnumWithDefault(v0) => {
+                state.write_u8(1u8);
+                v0.hash(state);
+            }
+            crate::ItemWithDefault::ModWithDefault(v0) => {
+                state.write_u8(2u8);
+                v0.hash(state);
+            }
+            crate::ItemWithDefault::Other(v0) => {
+                state.write_u8(3u8);
+                v0.hash(state);
+            }
+        }
     }
 }
 #[cfg(feature = "full")]
@@ -2803,6 +3002,19 @@ impl Hash for crate::Variadic {
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::Variant {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.ident.hash(state);
+        self.fields.hash(state);
+        self.discriminant.hash(state);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::VariantWithDefault {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -116,8 +116,18 @@ pub trait Visit<'ast> {
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn visit_data_enum_with_default(&mut self, i: &'ast crate::DataEnumWithDefault) {
+        visit_data_enum_with_default(self, i);
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
     fn visit_data_struct(&mut self, i: &'ast crate::DataStruct) {
         visit_data_struct(self, i);
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn visit_data_struct_with_default(&mut self, i: &'ast crate::DataStructWithDefault) {
+        visit_data_struct_with_default(self, i);
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
@@ -126,8 +136,21 @@ pub trait Visit<'ast> {
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn visit_data_with_default(&mut self, i: &'ast crate::DataWithDefault) {
+        visit_data_with_default(self, i);
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
     fn visit_derive_input(&mut self, i: &'ast crate::DeriveInput) {
         visit_derive_input(self, i);
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn visit_derive_input_with_default(
+        &mut self,
+        i: &'ast crate::DeriveInputWithDefault,
+    ) {
+        visit_derive_input_with_default(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -351,6 +374,11 @@ pub trait Visit<'ast> {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_field_with_default(&mut self, i: &'ast crate::FieldWithDefault) {
+        visit_field_with_default(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_fields(&mut self, i: &'ast crate::Fields) {
         visit_fields(self, i);
     }
@@ -361,13 +389,39 @@ pub trait Visit<'ast> {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_fields_named_with_default(
+        &mut self,
+        i: &'ast crate::FieldsNamedWithDefault,
+    ) {
+        visit_fields_named_with_default(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_fields_unnamed(&mut self, i: &'ast crate::FieldsUnnamed) {
         visit_fields_unnamed(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_fields_unnamed_with_default(
+        &mut self,
+        i: &'ast crate::FieldsUnnamedWithDefault,
+    ) {
+        visit_fields_unnamed_with_default(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_fields_with_default(&mut self, i: &'ast crate::FieldsWithDefault) {
+        visit_fields_with_default(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_file(&mut self, i: &'ast crate::File) {
         visit_file(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_file_with_default(&mut self, i: &'ast crate::FileWithDefault) {
+        visit_file_with_default(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -469,6 +523,11 @@ pub trait Visit<'ast> {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_item_enum_with_default(&mut self, i: &'ast crate::ItemEnumWithDefault) {
+        visit_item_enum_with_default(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_extern_crate(&mut self, i: &'ast crate::ItemExternCrate) {
         visit_item_extern_crate(self, i);
     }
@@ -499,6 +558,11 @@ pub trait Visit<'ast> {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_item_mod_with_default(&mut self, i: &'ast crate::ItemModWithDefault) {
+        visit_item_mod_with_default(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_static(&mut self, i: &'ast crate::ItemStatic) {
         visit_item_static(self, i);
     }
@@ -506,6 +570,11 @@ pub trait Visit<'ast> {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_struct(&mut self, i: &'ast crate::ItemStruct) {
         visit_item_struct(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_item_struct_with_default(&mut self, i: &'ast crate::ItemStructWithDefault) {
+        visit_item_struct_with_default(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -531,6 +600,11 @@ pub trait Visit<'ast> {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_use(&mut self, i: &'ast crate::ItemUse) {
         visit_item_use(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_item_with_default(&mut self, i: &'ast crate::ItemWithDefault) {
+        visit_item_with_default(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -924,6 +998,11 @@ pub trait Visit<'ast> {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_variant_with_default(&mut self, i: &'ast crate::VariantWithDefault) {
+        visit_variant_with_default(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_vis_restricted(&mut self, i: &'ast crate::VisRestricted) {
         visit_vis_restricted(self, i);
     }
@@ -1270,6 +1349,22 @@ where
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn visit_data_enum_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::DataEnumWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    skip!(node.enum_token);
+    skip!(node.brace_token);
+    for el in Punctuated::pairs(&node.variants) {
+        let it = el.value();
+        v.visit_variant_with_default(it);
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub fn visit_data_struct<'ast, V>(v: &mut V, node: &'ast crate::DataStruct)
 where
     V: Visit<'ast> + ?Sized,
@@ -1280,12 +1375,43 @@ where
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn visit_data_struct_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::DataStructWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    skip!(node.struct_token);
+    v.visit_fields_with_default(&node.fields);
+    skip!(node.semi_token);
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub fn visit_data_union<'ast, V>(v: &mut V, node: &'ast crate::DataUnion)
 where
     V: Visit<'ast> + ?Sized,
 {
     skip!(node.union_token);
     v.visit_fields_named(&node.fields);
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn visit_data_with_default<'ast, V>(v: &mut V, node: &'ast crate::DataWithDefault)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        crate::DataWithDefault::Struct(_binding_0) => {
+            v.visit_data_struct_with_default(_binding_0);
+        }
+        crate::DataWithDefault::Enum(_binding_0) => {
+            v.visit_data_enum_with_default(_binding_0);
+        }
+        crate::DataWithDefault::Union(_binding_0) => {
+            v.visit_data_union(_binding_0);
+        }
+    }
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
@@ -1300,6 +1426,23 @@ where
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
     v.visit_data(&node.data);
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn visit_derive_input_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::DeriveInputWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_visibility(&node.vis);
+    v.visit_ident(&node.ident);
+    v.visit_generics(&node.generics);
+    v.visit_data_with_default(&node.data);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -2049,6 +2192,27 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_field_with_default<'ast, V>(v: &mut V, node: &'ast crate::FieldWithDefault)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_visibility(&node.vis);
+    v.visit_field_mutability(&node.mutability);
+    if let Some(it) = &node.ident {
+        v.visit_ident(it);
+    }
+    skip!(node.colon_token);
+    v.visit_type(&node.ty);
+    if let Some(it) = &node.default {
+        skip!((it).0);
+        v.visit_expr(&(it).1);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_fields<'ast, V>(v: &mut V, node: &'ast crate::Fields)
 where
     V: Visit<'ast> + ?Sized,
@@ -2077,6 +2241,21 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_fields_named_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::FieldsNamedWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    skip!(node.brace_token);
+    for el in Punctuated::pairs(&node.named) {
+        let it = el.value();
+        v.visit_field_with_default(it);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_fields_unnamed<'ast, V>(v: &mut V, node: &'ast crate::FieldsUnnamed)
 where
     V: Visit<'ast> + ?Sized,
@@ -2085,6 +2264,40 @@ where
     for el in Punctuated::pairs(&node.unnamed) {
         let it = el.value();
         v.visit_field(it);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_fields_unnamed_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::FieldsUnnamedWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    skip!(node.paren_token);
+    for el in Punctuated::pairs(&node.unnamed) {
+        let it = el.value();
+        v.visit_field_with_default(it);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_fields_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::FieldsWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        crate::FieldsWithDefault::Named(_binding_0) => {
+            v.visit_fields_named_with_default(_binding_0);
+        }
+        crate::FieldsWithDefault::Unnamed(_binding_0) => {
+            v.visit_fields_unnamed_with_default(_binding_0);
+        }
+        crate::FieldsWithDefault::Unit => {}
     }
 }
 #[cfg(feature = "full")]
@@ -2099,6 +2312,20 @@ where
     }
     for it in &node.items {
         v.visit_item(it);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_file_with_default<'ast, V>(v: &mut V, node: &'ast crate::FileWithDefault)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    skip!(node.shebang);
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    for it in &node.items {
+        v.visit_item_with_default(it);
     }
 }
 #[cfg(feature = "full")]
@@ -2469,6 +2696,28 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_item_enum_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::ItemEnumWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_visibility(&node.vis);
+    skip!(node.enum_token);
+    v.visit_ident(&node.ident);
+    v.visit_generics(&node.generics);
+    skip!(node.brace_token);
+    for el in Punctuated::pairs(&node.variants) {
+        let it = el.value();
+        v.visit_variant_with_default(it);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn visit_item_extern_crate<'ast, V>(v: &mut V, node: &'ast crate::ItemExternCrate)
 where
     V: Visit<'ast> + ?Sized,
@@ -2577,6 +2826,30 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_item_mod_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::ItemModWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_visibility(&node.vis);
+    skip!(node.unsafety);
+    skip!(node.mod_token);
+    v.visit_ident(&node.ident);
+    if let Some(it) = &node.content {
+        skip!((it).0);
+        for it in &(it).1 {
+            v.visit_item_with_default(it);
+        }
+    }
+    skip!(node.semi);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn visit_item_static<'ast, V>(v: &mut V, node: &'ast crate::ItemStatic)
 where
     V: Visit<'ast> + ?Sized,
@@ -2608,6 +2881,25 @@ where
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
     v.visit_fields(&node.fields);
+    skip!(node.semi_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_item_struct_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::ItemStructWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_visibility(&node.vis);
+    skip!(node.struct_token);
+    v.visit_ident(&node.ident);
+    v.visit_generics(&node.generics);
+    v.visit_fields_with_default(&node.fields);
     skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
@@ -2704,6 +2996,27 @@ where
     skip!(node.leading_colon);
     v.visit_use_tree(&node.tree);
     skip!(node.semi_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_item_with_default<'ast, V>(v: &mut V, node: &'ast crate::ItemWithDefault)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        crate::ItemWithDefault::StructWithDefault(_binding_0) => {
+            v.visit_item_struct_with_default(_binding_0);
+        }
+        crate::ItemWithDefault::EnumWithDefault(_binding_0) => {
+            v.visit_item_enum_with_default(_binding_0);
+        }
+        crate::ItemWithDefault::ModWithDefault(_binding_0) => {
+            v.visit_item_mod_with_default(_binding_0);
+        }
+        crate::ItemWithDefault::Other(_binding_0) => {
+            v.visit_item(_binding_0);
+        }
+    }
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -3880,6 +4193,25 @@ where
     }
     v.visit_ident(&node.ident);
     v.visit_fields(&node.fields);
+    if let Some(it) = &node.discriminant {
+        skip!((it).0);
+        v.visit_expr(&(it).1);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_variant_with_default<'ast, V>(
+    v: &mut V,
+    node: &'ast crate::VariantWithDefault,
+)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_ident(&node.ident);
+    v.visit_fields_with_default(&node.fields);
     if let Some(it) = &node.discriminant {
         skip!((it).0);
         v.visit_expr(&(it).1);

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -124,8 +124,21 @@ pub trait VisitMut {
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn visit_data_enum_with_default_mut(&mut self, i: &mut crate::DataEnumWithDefault) {
+        visit_data_enum_with_default_mut(self, i);
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
     fn visit_data_struct_mut(&mut self, i: &mut crate::DataStruct) {
         visit_data_struct_mut(self, i);
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn visit_data_struct_with_default_mut(
+        &mut self,
+        i: &mut crate::DataStructWithDefault,
+    ) {
+        visit_data_struct_with_default_mut(self, i);
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
@@ -134,8 +147,21 @@ pub trait VisitMut {
     }
     #[cfg(feature = "derive")]
     #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn visit_data_with_default_mut(&mut self, i: &mut crate::DataWithDefault) {
+        visit_data_with_default_mut(self, i);
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
     fn visit_derive_input_mut(&mut self, i: &mut crate::DeriveInput) {
         visit_derive_input_mut(self, i);
+    }
+    #[cfg(feature = "derive")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+    fn visit_derive_input_with_default_mut(
+        &mut self,
+        i: &mut crate::DeriveInputWithDefault,
+    ) {
+        visit_derive_input_with_default_mut(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -359,6 +385,11 @@ pub trait VisitMut {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_field_with_default_mut(&mut self, i: &mut crate::FieldWithDefault) {
+        visit_field_with_default_mut(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_fields_mut(&mut self, i: &mut crate::Fields) {
         visit_fields_mut(self, i);
     }
@@ -369,13 +400,39 @@ pub trait VisitMut {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_fields_named_with_default_mut(
+        &mut self,
+        i: &mut crate::FieldsNamedWithDefault,
+    ) {
+        visit_fields_named_with_default_mut(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_fields_unnamed_mut(&mut self, i: &mut crate::FieldsUnnamed) {
         visit_fields_unnamed_mut(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_fields_unnamed_with_default_mut(
+        &mut self,
+        i: &mut crate::FieldsUnnamedWithDefault,
+    ) {
+        visit_fields_unnamed_with_default_mut(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_fields_with_default_mut(&mut self, i: &mut crate::FieldsWithDefault) {
+        visit_fields_with_default_mut(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_file_mut(&mut self, i: &mut crate::File) {
         visit_file_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_file_with_default_mut(&mut self, i: &mut crate::FileWithDefault) {
+        visit_file_with_default_mut(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -477,6 +534,11 @@ pub trait VisitMut {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_item_enum_with_default_mut(&mut self, i: &mut crate::ItemEnumWithDefault) {
+        visit_item_enum_with_default_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_extern_crate_mut(&mut self, i: &mut crate::ItemExternCrate) {
         visit_item_extern_crate_mut(self, i);
     }
@@ -507,6 +569,11 @@ pub trait VisitMut {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_item_mod_with_default_mut(&mut self, i: &mut crate::ItemModWithDefault) {
+        visit_item_mod_with_default_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_static_mut(&mut self, i: &mut crate::ItemStatic) {
         visit_item_static_mut(self, i);
     }
@@ -514,6 +581,14 @@ pub trait VisitMut {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_struct_mut(&mut self, i: &mut crate::ItemStruct) {
         visit_item_struct_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_item_struct_with_default_mut(
+        &mut self,
+        i: &mut crate::ItemStructWithDefault,
+    ) {
+        visit_item_struct_with_default_mut(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -539,6 +614,11 @@ pub trait VisitMut {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_item_use_mut(&mut self, i: &mut crate::ItemUse) {
         visit_item_use_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_item_with_default_mut(&mut self, i: &mut crate::ItemWithDefault) {
+        visit_item_with_default_mut(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -932,6 +1012,11 @@ pub trait VisitMut {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_variant_with_default_mut(&mut self, i: &mut crate::VariantWithDefault) {
+        visit_variant_with_default_mut(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_vis_restricted_mut(&mut self, i: &mut crate::VisRestricted) {
         visit_vis_restricted_mut(self, i);
     }
@@ -1270,12 +1355,41 @@ where
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn visit_data_enum_with_default_mut<V>(
+    v: &mut V,
+    node: &mut crate::DataEnumWithDefault,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    skip!(node.enum_token);
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.variants) {
+        let it = el.value_mut();
+        v.visit_variant_with_default_mut(it);
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub fn visit_data_struct_mut<V>(v: &mut V, node: &mut crate::DataStruct)
 where
     V: VisitMut + ?Sized,
 {
     skip!(node.struct_token);
     v.visit_fields_mut(&mut node.fields);
+    skip!(node.semi_token);
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn visit_data_struct_with_default_mut<V>(
+    v: &mut V,
+    node: &mut crate::DataStructWithDefault,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    skip!(node.struct_token);
+    v.visit_fields_with_default_mut(&mut node.fields);
     skip!(node.semi_token);
 }
 #[cfg(feature = "derive")]
@@ -1289,6 +1403,24 @@ where
 }
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn visit_data_with_default_mut<V>(v: &mut V, node: &mut crate::DataWithDefault)
+where
+    V: VisitMut + ?Sized,
+{
+    match node {
+        crate::DataWithDefault::Struct(_binding_0) => {
+            v.visit_data_struct_with_default_mut(_binding_0);
+        }
+        crate::DataWithDefault::Enum(_binding_0) => {
+            v.visit_data_enum_with_default_mut(_binding_0);
+        }
+        crate::DataWithDefault::Union(_binding_0) => {
+            v.visit_data_union_mut(_binding_0);
+        }
+    }
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub fn visit_derive_input_mut<V>(v: &mut V, node: &mut crate::DeriveInput)
 where
     V: VisitMut + ?Sized,
@@ -1298,6 +1430,21 @@ where
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
     v.visit_data_mut(&mut node.data);
+}
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub fn visit_derive_input_with_default_mut<V>(
+    v: &mut V,
+    node: &mut crate::DeriveInputWithDefault,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_visibility_mut(&mut node.vis);
+    v.visit_ident_mut(&mut node.ident);
+    v.visit_generics_mut(&mut node.generics);
+    v.visit_data_with_default_mut(&mut node.data);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -1963,6 +2110,25 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_field_with_default_mut<V>(v: &mut V, node: &mut crate::FieldWithDefault)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_visibility_mut(&mut node.vis);
+    v.visit_field_mutability_mut(&mut node.mutability);
+    if let Some(it) = &mut node.ident {
+        v.visit_ident_mut(it);
+    }
+    skip!(node.colon_token);
+    v.visit_type_mut(&mut node.ty);
+    if let Some(it) = &mut node.default {
+        skip!((it).0);
+        v.visit_expr_mut(&mut (it).1);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_fields_mut<V>(v: &mut V, node: &mut crate::Fields)
 where
     V: VisitMut + ?Sized,
@@ -1991,6 +2157,21 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_fields_named_with_default_mut<V>(
+    v: &mut V,
+    node: &mut crate::FieldsNamedWithDefault,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.named) {
+        let it = el.value_mut();
+        v.visit_field_with_default_mut(it);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_fields_unnamed_mut<V>(v: &mut V, node: &mut crate::FieldsUnnamed)
 where
     V: VisitMut + ?Sized,
@@ -1999,6 +2180,37 @@ where
     for mut el in Punctuated::pairs_mut(&mut node.unnamed) {
         let it = el.value_mut();
         v.visit_field_mut(it);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_fields_unnamed_with_default_mut<V>(
+    v: &mut V,
+    node: &mut crate::FieldsUnnamedWithDefault,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.unnamed) {
+        let it = el.value_mut();
+        v.visit_field_with_default_mut(it);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_fields_with_default_mut<V>(v: &mut V, node: &mut crate::FieldsWithDefault)
+where
+    V: VisitMut + ?Sized,
+{
+    match node {
+        crate::FieldsWithDefault::Named(_binding_0) => {
+            v.visit_fields_named_with_default_mut(_binding_0);
+        }
+        crate::FieldsWithDefault::Unnamed(_binding_0) => {
+            v.visit_fields_unnamed_with_default_mut(_binding_0);
+        }
+        crate::FieldsWithDefault::Unit => {}
     }
 }
 #[cfg(feature = "full")]
@@ -2011,6 +2223,18 @@ where
     v.visit_attributes_mut(&mut node.attrs);
     for it in &mut node.items {
         v.visit_item_mut(it);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_file_with_default_mut<V>(v: &mut V, node: &mut crate::FileWithDefault)
+where
+    V: VisitMut + ?Sized,
+{
+    skip!(node.shebang);
+    v.visit_attributes_mut(&mut node.attrs);
+    for it in &mut node.items {
+        v.visit_item_with_default_mut(it);
     }
 }
 #[cfg(feature = "full")]
@@ -2360,6 +2584,26 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_item_enum_with_default_mut<V>(
+    v: &mut V,
+    node: &mut crate::ItemEnumWithDefault,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_visibility_mut(&mut node.vis);
+    skip!(node.enum_token);
+    v.visit_ident_mut(&mut node.ident);
+    v.visit_generics_mut(&mut node.generics);
+    skip!(node.brace_token);
+    for mut el in Punctuated::pairs_mut(&mut node.variants) {
+        let it = el.value_mut();
+        v.visit_variant_with_default_mut(it);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn visit_item_extern_crate_mut<V>(v: &mut V, node: &mut crate::ItemExternCrate)
 where
     V: VisitMut + ?Sized,
@@ -2456,6 +2700,28 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_item_mod_with_default_mut<V>(
+    v: &mut V,
+    node: &mut crate::ItemModWithDefault,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_visibility_mut(&mut node.vis);
+    skip!(node.unsafety);
+    skip!(node.mod_token);
+    v.visit_ident_mut(&mut node.ident);
+    if let Some(it) = &mut node.content {
+        skip!((it).0);
+        for it in &mut (it).1 {
+            v.visit_item_with_default_mut(it);
+        }
+    }
+    skip!(node.semi);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn visit_item_static_mut<V>(v: &mut V, node: &mut crate::ItemStatic)
 where
     V: VisitMut + ?Sized,
@@ -2483,6 +2749,23 @@ where
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
     v.visit_fields_mut(&mut node.fields);
+    skip!(node.semi_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_item_struct_with_default_mut<V>(
+    v: &mut V,
+    node: &mut crate::ItemStructWithDefault,
+)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_visibility_mut(&mut node.vis);
+    skip!(node.struct_token);
+    v.visit_ident_mut(&mut node.ident);
+    v.visit_generics_mut(&mut node.generics);
+    v.visit_fields_with_default_mut(&mut node.fields);
     skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
@@ -2569,6 +2852,27 @@ where
     skip!(node.leading_colon);
     v.visit_use_tree_mut(&mut node.tree);
     skip!(node.semi_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_item_with_default_mut<V>(v: &mut V, node: &mut crate::ItemWithDefault)
+where
+    V: VisitMut + ?Sized,
+{
+    match node {
+        crate::ItemWithDefault::StructWithDefault(_binding_0) => {
+            v.visit_item_struct_with_default_mut(_binding_0);
+        }
+        crate::ItemWithDefault::EnumWithDefault(_binding_0) => {
+            v.visit_item_enum_with_default_mut(_binding_0);
+        }
+        crate::ItemWithDefault::ModWithDefault(_binding_0) => {
+            v.visit_item_mod_with_default_mut(_binding_0);
+        }
+        crate::ItemWithDefault::Other(_binding_0) => {
+            v.visit_item_mut(_binding_0);
+        }
+    }
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -3698,6 +4002,20 @@ where
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_ident_mut(&mut node.ident);
     v.visit_fields_mut(&mut node.fields);
+    if let Some(it) = &mut node.discriminant {
+        skip!((it).0);
+        v.visit_expr_mut(&mut (it).1);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_variant_with_default_mut<V>(v: &mut V, node: &mut crate::VariantWithDefault)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_ident_mut(&mut node.ident);
+    v.visit_fields_with_default_mut(&mut node.fields);
     if let Some(it) = &mut node.discriminant {
         skip!((it).0);
         v.visit_expr_mut(&mut (it).1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,36 @@
 //!
 //! <br>
 //!
+//! # Default Field Values
+//!
+//! Syn has support for the `default_field_values` Rust feature ([rfcs#3681]).
+//! However, adding the fields necessary for this directly to Syn was not possible without
+//! breaking backwards compatibility.
+//! As such, this support is instead only present in "version 2" of several major structs.
+//! These are indicated with the `WithDefault` suffix.
+//! For example, if you wish to use the a default field value in a derive macro,
+//! you should use `DeriveInputWithDefault`.
+//!
+//! Note that even if your derive macro does not make use of default fields, they
+//! will now be skipped in parsing, so existing macros do not need to update
+//! for this feature.
+//! However, this cannot be relied upon for attribute procedural macros, as
+//! when you re-print the struct/enum, the default values may inadvertently
+//! not be retained.
+//!
+//! In the hierarchy of items with default field values (e.g. [`ItemWithDefault`]),
+//! structs defined within inner blocks currently do *not* support default field values.
+//! That is, if you tried `fn x() { struct Y { x: u32 = 10 } }`, that would give a parse error.
+//! This is done for simplicity of implementation, as it would otherwise require the parallel
+//! hierarchy cover nearly all of Syn.
+//!
+//! We expect these types to be folded into their non-suffixed equivalents in the
+//! next breaking release.
+//!
+//! [rfcs#3681]: https://github.com/rust-lang/rfcs/pull/3681
+//!
+//! <br>
+//!
 //! # Debugging
 //!
 //! When developing a procedural macro it can be helpful to look at what the
@@ -351,13 +381,19 @@ mod custom_punctuation;
 mod data;
 #[cfg(any(feature = "full", feature = "derive"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
-pub use crate::data::{Field, Fields, FieldsNamed, FieldsUnnamed, Variant};
+pub use crate::data::{
+    Field, FieldWithDefault, Fields, FieldsNamed, FieldsNamedWithDefault, FieldsUnnamed,
+    FieldsUnnamedWithDefault, FieldsWithDefault, Variant, VariantWithDefault,
+};
 
 #[cfg(any(feature = "full", feature = "derive"))]
 mod derive;
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
-pub use crate::derive::{Data, DataEnum, DataStruct, DataUnion, DeriveInput};
+pub use crate::derive::{
+    Data, DataEnum, DataEnumWithDefault, DataStruct, DataStructWithDefault, DataUnion,
+    DataWithDefault, DeriveInput, DeriveInputWithDefault,
+};
 
 mod drops;
 
@@ -390,7 +426,7 @@ pub mod ext;
 mod file;
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-pub use crate::file::File;
+pub use crate::file::{File, FileWithDefault};
 
 #[cfg(all(any(feature = "full", feature = "derive"), feature = "printing"))]
 mod fixup;
@@ -425,10 +461,11 @@ mod item;
 pub use crate::item::{
     FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
     ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplRestriction, Item,
-    ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
-    ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
-    Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
-    TraitItemType, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree, Variadic,
+    ItemConst, ItemEnum, ItemEnumWithDefault, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl,
+    ItemMacro, ItemMod, ItemModWithDefault, ItemStatic, ItemStruct, ItemStructWithDefault,
+    ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, ItemWithDefault, Receiver, Signature,
+    StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro, TraitItemType,
+    UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree, Variadic,
 };
 
 mod lifetime;
@@ -1004,6 +1041,39 @@ pub fn parse_file(mut content: &str) -> Result<File> {
     }
 
     let mut file: File = parse_str(content)?;
+    file.shebang = shebang;
+    Ok(file)
+}
+
+/// Parse the content of a file of Rust code, with support for the default field values feature.
+///
+/// See [`parse_file`] for full docs.
+///
+/// Struct and enum items output by this function support having default field values set.
+#[cfg(all(feature = "parsing", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "parsing", feature = "full"))))]
+pub fn parse_file_with_default(mut content: &str) -> Result<FileWithDefault> {
+    // Strip the BOM if it is present
+    const BOM: &str = "\u{feff}";
+    if content.starts_with(BOM) {
+        content = &content[BOM.len()..];
+    }
+
+    let mut shebang = None;
+    if content.starts_with("#!") {
+        let rest = whitespace::skip(&content[2..]);
+        if !rest.starts_with('[') {
+            if let Some(idx) = content.find('\n') {
+                shebang = Some(content[..idx].to_string());
+                content = &content[idx..];
+            } else {
+                shebang = Some(content.to_string());
+                content = "";
+            }
+        }
+    }
+
+    let mut file: FileWithDefault = parse_str(content)?;
     file.shebang = shebang;
     Ok(file)
 }

--- a/syn.json
+++ b/syn.json
@@ -589,6 +589,30 @@
       }
     },
     {
+      "ident": "DataEnumWithDefault",
+      "features": {
+        "any": [
+          "derive"
+        ]
+      },
+      "fields": {
+        "enum_token": {
+          "token": "Enum"
+        },
+        "brace_token": {
+          "group": "Brace"
+        },
+        "variants": {
+          "punctuated": {
+            "element": {
+              "syn": "VariantWithDefault"
+            },
+            "punct": "Comma"
+          }
+        }
+      }
+    },
+    {
       "ident": "DataStruct",
       "features": {
         "any": [
@@ -601,6 +625,27 @@
         },
         "fields": {
           "syn": "Fields"
+        },
+        "semi_token": {
+          "option": {
+            "token": "Semi"
+          }
+        }
+      }
+    },
+    {
+      "ident": "DataStructWithDefault",
+      "features": {
+        "any": [
+          "derive"
+        ]
+      },
+      "fields": {
+        "struct_token": {
+          "token": "Struct"
+        },
+        "fields": {
+          "syn": "FieldsWithDefault"
         },
         "semi_token": {
           "option": {
@@ -623,6 +668,31 @@
         "fields": {
           "syn": "FieldsNamed"
         }
+      }
+    },
+    {
+      "ident": "DataWithDefault",
+      "features": {
+        "any": [
+          "derive"
+        ]
+      },
+      "variants": {
+        "Struct": [
+          {
+            "syn": "DataStructWithDefault"
+          }
+        ],
+        "Enum": [
+          {
+            "syn": "DataEnumWithDefault"
+          }
+        ],
+        "Union": [
+          {
+            "syn": "DataUnion"
+          }
+        ]
       }
     },
     {
@@ -649,6 +719,33 @@
         },
         "data": {
           "syn": "Data"
+        }
+      }
+    },
+    {
+      "ident": "DeriveInputWithDefault",
+      "features": {
+        "any": [
+          "derive"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "vis": {
+          "syn": "Visibility"
+        },
+        "ident": {
+          "proc_macro2": "Ident"
+        },
+        "generics": {
+          "syn": "Generics"
+        },
+        "data": {
+          "syn": "DataWithDefault"
         }
       }
     },
@@ -2082,6 +2179,53 @@
       }
     },
     {
+      "ident": "FieldWithDefault",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "vis": {
+          "syn": "Visibility"
+        },
+        "mutability": {
+          "syn": "FieldMutability"
+        },
+        "ident": {
+          "option": {
+            "proc_macro2": "Ident"
+          }
+        },
+        "colon_token": {
+          "option": {
+            "token": "Colon"
+          }
+        },
+        "ty": {
+          "syn": "Type"
+        },
+        "default": {
+          "option": {
+            "tuple": [
+              {
+                "token": "Eq"
+              },
+              {
+                "syn": "Expr"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
       "ident": "Fields",
       "features": {
         "any": [
@@ -2126,6 +2270,28 @@
       }
     },
     {
+      "ident": "FieldsNamedWithDefault",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "fields": {
+        "brace_token": {
+          "group": "Brace"
+        },
+        "named": {
+          "punctuated": {
+            "element": {
+              "syn": "FieldWithDefault"
+            },
+            "punct": "Comma"
+          }
+        }
+      }
+    },
+    {
       "ident": "FieldsUnnamed",
       "features": {
         "any": [
@@ -2145,6 +2311,50 @@
             "punct": "Comma"
           }
         }
+      }
+    },
+    {
+      "ident": "FieldsUnnamedWithDefault",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "fields": {
+        "paren_token": {
+          "group": "Paren"
+        },
+        "unnamed": {
+          "punctuated": {
+            "element": {
+              "syn": "FieldWithDefault"
+            },
+            "punct": "Comma"
+          }
+        }
+      }
+    },
+    {
+      "ident": "FieldsWithDefault",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "variants": {
+        "Named": [
+          {
+            "syn": "FieldsNamedWithDefault"
+          }
+        ],
+        "Unnamed": [
+          {
+            "syn": "FieldsUnnamedWithDefault"
+          }
+        ],
+        "Unit": []
       }
     },
     {
@@ -2168,6 +2378,31 @@
         "items": {
           "vec": {
             "syn": "Item"
+          }
+        }
+      }
+    },
+    {
+      "ident": "FileWithDefault",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "shebang": {
+          "option": {
+            "std": "String"
+          }
+        },
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "items": {
+          "vec": {
+            "syn": "ItemWithDefault"
           }
         }
       }
@@ -2824,6 +3059,44 @@
       }
     },
     {
+      "ident": "ItemEnumWithDefault",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "vis": {
+          "syn": "Visibility"
+        },
+        "enum_token": {
+          "token": "Enum"
+        },
+        "ident": {
+          "proc_macro2": "Ident"
+        },
+        "generics": {
+          "syn": "Generics"
+        },
+        "brace_token": {
+          "group": "Brace"
+        },
+        "variants": {
+          "punctuated": {
+            "element": {
+              "syn": "VariantWithDefault"
+            },
+            "punct": "Comma"
+          }
+        }
+      }
+    },
+    {
       "ident": "ItemExternCrate",
       "features": {
         "any": [
@@ -3060,6 +3333,54 @@
       }
     },
     {
+      "ident": "ItemModWithDefault",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "vis": {
+          "syn": "Visibility"
+        },
+        "unsafety": {
+          "option": {
+            "token": "Unsafe"
+          }
+        },
+        "mod_token": {
+          "token": "Mod"
+        },
+        "ident": {
+          "proc_macro2": "Ident"
+        },
+        "content": {
+          "option": {
+            "tuple": [
+              {
+                "group": "Brace"
+              },
+              {
+                "vec": {
+                  "syn": "ItemWithDefault"
+                }
+              }
+            ]
+          }
+        },
+        "semi": {
+          "option": {
+            "token": "Semi"
+          }
+        }
+      }
+    },
+    {
       "ident": "ItemStatic",
       "features": {
         "any": [
@@ -3132,6 +3453,41 @@
         },
         "fields": {
           "syn": "Fields"
+        },
+        "semi_token": {
+          "option": {
+            "token": "Semi"
+          }
+        }
+      }
+    },
+    {
+      "ident": "ItemStructWithDefault",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "vis": {
+          "syn": "Visibility"
+        },
+        "struct_token": {
+          "token": "Struct"
+        },
+        "ident": {
+          "proc_macro2": "Ident"
+        },
+        "generics": {
+          "syn": "Generics"
+        },
+        "fields": {
+          "syn": "FieldsWithDefault"
         },
         "semi_token": {
           "option": {
@@ -3343,6 +3699,37 @@
           "token": "Semi"
         }
       }
+    },
+    {
+      "ident": "ItemWithDefault",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "variants": {
+        "StructWithDefault": [
+          {
+            "syn": "ItemStructWithDefault"
+          }
+        ],
+        "EnumWithDefault": [
+          {
+            "syn": "ItemEnumWithDefault"
+          }
+        ],
+        "ModWithDefault": [
+          {
+            "syn": "ItemModWithDefault"
+          }
+        ],
+        "Other": [
+          {
+            "syn": "Item"
+          }
+        ]
+      },
+      "exhaustive": false
     },
     {
       "ident": "Label",
@@ -5472,6 +5859,40 @@
         },
         "fields": {
           "syn": "Fields"
+        },
+        "discriminant": {
+          "option": {
+            "tuple": [
+              {
+                "token": "Eq"
+              },
+              {
+                "syn": "Expr"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "ident": "VariantWithDefault",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "ident": {
+          "proc_macro2": "Ident"
+        },
+        "fields": {
+          "syn": "FieldsWithDefault"
         },
         "discriminant": {
           "option": {

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -422,9 +422,28 @@ impl Debug for Lite<syn::DataEnum> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::DataEnumWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("DataEnumWithDefault");
+        if !self.value.variants.is_empty() {
+            formatter.field("variants", Lite(&self.value.variants));
+        }
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::DataStruct> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("DataStruct");
+        formatter.field("fields", Lite(&self.value.fields));
+        if self.value.semi_token.is_some() {
+            formatter.field("semi_token", &Present);
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::DataStructWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("DataStructWithDefault");
         formatter.field("fields", Lite(&self.value.fields));
         if self.value.semi_token.is_some() {
             formatter.field("semi_token", &Present);
@@ -439,9 +458,49 @@ impl Debug for Lite<syn::DataUnion> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::DataWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match &self.value {
+            syn::DataWithDefault::Struct(_val) => {
+                formatter.write_str("DataWithDefault::Struct")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            syn::DataWithDefault::Enum(_val) => {
+                formatter.write_str("DataWithDefault::Enum")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            syn::DataWithDefault::Union(_val) => {
+                formatter.write_str("DataWithDefault::Union")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+        }
+    }
+}
 impl Debug for Lite<syn::DeriveInput> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("DeriveInput");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("vis", Lite(&self.value.vis));
+        formatter.field("ident", Lite(&self.value.ident));
+        formatter.field("generics", Lite(&self.value.generics));
+        formatter.field("data", Lite(&self.value.data));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::DeriveInputWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("DeriveInputWithDefault");
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
@@ -1816,6 +1875,54 @@ impl Debug for Lite<syn::FieldValue> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::FieldWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FieldWithDefault");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("vis", Lite(&self.value.vis));
+        match self.value.mutability {
+            syn::FieldMutability::None => {}
+            _ => {
+                formatter.field("mutability", Lite(&self.value.mutability));
+            }
+        }
+        if let Some(val) = &self.value.ident {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(proc_macro2::Ident);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some(")?;
+                    Debug::fmt(Lite(&self.0), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("ident", Print::ref_cast(val));
+        }
+        if self.value.colon_token.is_some() {
+            formatter.field("colon_token", &Present);
+        }
+        formatter.field("ty", Lite(&self.value.ty));
+        if let Some(val) = &self.value.default {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::Eq, syn::Expr));
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some(")?;
+                    Debug::fmt(Lite(&self.0.1), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("default", Print::ref_cast(val));
+        }
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::Fields> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match &self.value {
@@ -1846,6 +1953,15 @@ impl Debug for Lite<syn::FieldsNamed> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::FieldsNamedWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FieldsNamedWithDefault");
+        if !self.value.named.is_empty() {
+            formatter.field("named", Lite(&self.value.named));
+        }
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::FieldsUnnamed> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("FieldsUnnamed");
@@ -1855,9 +1971,67 @@ impl Debug for Lite<syn::FieldsUnnamed> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::FieldsUnnamedWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FieldsUnnamedWithDefault");
+        if !self.value.unnamed.is_empty() {
+            formatter.field("unnamed", Lite(&self.value.unnamed));
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::FieldsWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match &self.value {
+            syn::FieldsWithDefault::Named(_val) => {
+                formatter.write_str("FieldsWithDefault::Named")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            syn::FieldsWithDefault::Unnamed(_val) => {
+                formatter.write_str("FieldsWithDefault::Unnamed")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            syn::FieldsWithDefault::Unit => {
+                formatter.write_str("FieldsWithDefault::Unit")
+            }
+        }
+    }
+}
 impl Debug for Lite<syn::File> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("File");
+        if let Some(val) = &self.value.shebang {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(String);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some(")?;
+                    Debug::fmt(Lite(&self.0), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("shebang", Print::ref_cast(val));
+        }
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        if !self.value.items.is_empty() {
+            formatter.field("items", Lite(&self.value.items));
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::FileWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FileWithDefault");
         if let Some(val) = &self.value.shebang {
             #[derive(RefCast)]
             #[repr(transparent)]
@@ -2586,6 +2760,21 @@ impl Debug for Lite<syn::ItemEnum> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::ItemEnumWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ItemEnumWithDefault");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("vis", Lite(&self.value.vis));
+        formatter.field("ident", Lite(&self.value.ident));
+        formatter.field("generics", Lite(&self.value.generics));
+        if !self.value.variants.is_empty() {
+            formatter.field("variants", Lite(&self.value.variants));
+        }
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::ItemExternCrate> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("ItemExternCrate");
@@ -2739,6 +2928,37 @@ impl Debug for Lite<syn::ItemMod> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::ItemModWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ItemModWithDefault");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("vis", Lite(&self.value.vis));
+        if self.value.unsafety.is_some() {
+            formatter.field("unsafety", &Present);
+        }
+        formatter.field("ident", Lite(&self.value.ident));
+        if let Some(val) = &self.value.content {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::Brace, Vec<syn::ItemWithDefault>));
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some(")?;
+                    Debug::fmt(Lite(&self.0.1), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("content", Print::ref_cast(val));
+        }
+        if self.value.semi.is_some() {
+            formatter.field("semi", &Present);
+        }
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::ItemStatic> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("ItemStatic");
@@ -2761,6 +2981,22 @@ impl Debug for Lite<syn::ItemStatic> {
 impl Debug for Lite<syn::ItemStruct> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("ItemStruct");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("vis", Lite(&self.value.vis));
+        formatter.field("ident", Lite(&self.value.ident));
+        formatter.field("generics", Lite(&self.value.generics));
+        formatter.field("fields", Lite(&self.value.fields));
+        if self.value.semi_token.is_some() {
+            formatter.field("semi_token", &Present);
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ItemStructWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ItemStructWithDefault");
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
@@ -2868,6 +3104,41 @@ impl Debug for Lite<syn::ItemUse> {
         }
         formatter.field("tree", Lite(&self.value.tree));
         formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ItemWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match &self.value {
+            syn::ItemWithDefault::StructWithDefault(_val) => {
+                formatter.write_str("ItemWithDefault::StructWithDefault")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            syn::ItemWithDefault::EnumWithDefault(_val) => {
+                formatter.write_str("ItemWithDefault::EnumWithDefault")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            syn::ItemWithDefault::ModWithDefault(_val) => {
+                formatter.write_str("ItemWithDefault::ModWithDefault")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            syn::ItemWithDefault::Other(_val) => {
+                formatter.write_str("ItemWithDefault::Other")?;
+                formatter.write_str("(")?;
+                Debug::fmt(Lite(_val), formatter)?;
+                formatter.write_str(")")?;
+                Ok(())
+            }
+            _ => unreachable!(),
+        }
     }
 }
 impl Debug for Lite<syn::Label> {
@@ -4656,6 +4927,31 @@ impl Debug for Lite<syn::Variadic> {
 impl Debug for Lite<syn::Variant> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("Variant");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("ident", Lite(&self.value.ident));
+        formatter.field("fields", Lite(&self.value.fields));
+        if let Some(val) = &self.value.discriminant {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print((syn::token::Eq, syn::Expr));
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some(")?;
+                    Debug::fmt(Lite(&self.0.1), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("discriminant", Print::ref_cast(val));
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::VariantWithDefault> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("VariantWithDefault");
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -11,7 +11,7 @@ mod debug;
 
 use proc_macro2::{Delimiter, Group, Ident, Span, TokenStream, TokenTree};
 use quote::quote;
-use syn::{Item, ItemTrait};
+use syn::{Item, ItemTrait, ItemWithDefault};
 
 #[test]
 fn test_macro_variable_attr() {
@@ -312,5 +312,97 @@ fn test_impl_trait_trailing_plus() {
             stmts: [],
         },
     }
+    "#);
+}
+
+#[test]
+fn test_struct_default_field_values() {
+    let tokens = quote! {
+        struct Foo {
+            field: i32 = const { 42 },
+        }
+    };
+    snapshot!(tokens as ItemWithDefault, @r#"
+    ItemWithDefault::StructWithDefault(ItemStructWithDefault {
+        vis: Visibility::Inherited,
+        ident: "Foo",
+        generics: Generics,
+        fields: FieldsWithDefault::Named(FieldsNamedWithDefault {
+            named: [
+                FieldWithDefault {
+                    vis: Visibility::Inherited,
+                    ident: Some("field"),
+                    colon_token: Some,
+                    ty: Type::Path {
+                        path: Path {
+                            segments: [
+                                PathSegment {
+                                    ident: "i32",
+                                },
+                            ],
+                        },
+                    },
+                    default: Some(Expr::Const {
+                        block: Block {
+                            stmts: [
+                                Stmt::Expr(
+                                    Expr::Lit {
+                                        lit: 42,
+                                    },
+                                    None,
+                                ),
+                            ],
+                        },
+                    }),
+                },
+                Token![,],
+            ],
+        }),
+    })
+    "#);
+}
+
+#[test]
+fn test_enum_default_field_values() {
+    let tokens = quote! {
+        enum Foo {
+            Bar {
+                field: i32 = 42,
+            }
+        }
+    };
+    snapshot!(tokens as ItemWithDefault, @r#"
+    ItemWithDefault::EnumWithDefault(ItemEnumWithDefault {
+        vis: Visibility::Inherited,
+        ident: "Foo",
+        generics: Generics,
+        variants: [
+            VariantWithDefault {
+                ident: "Bar",
+                fields: FieldsWithDefault::Named(FieldsNamedWithDefault {
+                    named: [
+                        FieldWithDefault {
+                            vis: Visibility::Inherited,
+                            ident: Some("field"),
+                            colon_token: Some,
+                            ty: Type::Path {
+                                path: Path {
+                                    segments: [
+                                        PathSegment {
+                                            ident: "i32",
+                                        },
+                                    ],
+                                },
+                            },
+                            default: Some(Expr::Lit {
+                                lit: 42,
+                            }),
+                        },
+                        Token![,],
+                    ],
+                }),
+            },
+        ],
+    })
     "#);
 }


### PR DESCRIPTION
This PR incorporates work from @estebank in #1851. See also https://github.com/rust-lang/rust/issues/132162#issuecomment-3647488349 for context; this is the PR for "solution 2", to unblock the language feature.

Fixes #1774

* RFC: https://github.com/rust-lang/rfcs/pull/3681
* Tracking issue: https://github.com/rust-lang/rust/issues/132162
* Feature gate: `#![feature(default_field_values)]`

```rust
#[derive(Default)]
struct Pet {
    name: Option<String>,
    age: i128 = 42,
    //        ^^^^
}
```

By running `cargo-semver-checks --all-features` (v0.45.0), I have confirmed that this is not a breaking change.

This PR has two related changes:
1) It exposes `FieldWithDefault`, which is a version of `Field`, with the addition of the optional `default` field. This is then used to create a parallel hierarchy of all Syn types, with the same naming pattern. That is, it also creates `FieldsNamedWithDefault`, `FieldsWithDefault`, `VariantsWithDefault`, `DataStructWithDefault`, etc.
2) The parsing for this is shared with `Field`, to allow for as much shared code as possible. There is one subtle change here; the parsing for `Field` (and therefore `FieldsNamed`, `Fields`, `DeriveInput`, etc.) will now ignore any default value provided (i.e. not give an error, but also not reflect it in the AST). This enables a silent upgrade of most derive macros to support their same codegen as if the default field values didn't exist, which will be extremely valuable in the ecosystem.

This is explicitly not https://github.com/dtolnay/syn/issues/1911; instead, that issue would likely be updated to mean "revert this PR, and land #1851 as part of v3.x".

The new structs in this PR is *not* behind a feature flag. This is because the current infrastructure in `syn-internal-codegen` only supports "`any`" style feature flags, whereas this would need to be handled as "all" style feature flags.
I'm not going to make the changes to the codegen infrastructure myself. I would move these types behind feature flags if:
- You say that you want this code to be in its own modules (and therefore under two feature flags); OR
- You provide the patches to the infrastructure which means it supports the "all" style flags.

The silent ignoring of the default values would definitely be reasonable to object to. I think it's the least bad option on an ecosystem level, but I'm happy to change it (either some form of logging, or just throwing an error).

The parallel hierarchy is not complete. That is, we do not support structs with default field values inside blocks (i.e. inside functions/block expressions/etc.). That's because it requires changing so much more code. (But obviously if they exist, they'll be silently ignored).

A reasonable alternative would be to implement #1870 for those nested fields.