### PR TITLE
Disable std prelude

### DIFF
--- a/codegen/src/debug.rs
+++ b/codegen/src/debug.rs
@@ -198,7 +198,7 @@ pub fn generate(defs: &Definitions) -> Result<()> {
         quote! {
             #![allow(unknown_lints, non_local_definitions)]
 
-            use std::fmt::{self, Debug};
+            use core::fmt::{self, Debug};
 
             #impls
         },

--- a/codegen/src/eq.rs
+++ b/codegen/src/eq.rs
@@ -158,6 +158,8 @@ pub fn generate(defs: &Definitions) -> Result<()> {
         quote! {
             #[cfg(any(feature = "derive", feature = "full"))]
             use crate::tt::TokenStreamHelper;
+            #[cfg(feature = "extra-traits")]
+            use alloc::string::ToString;
 
             #impls
         },

--- a/codegen/src/fold.rs
+++ b/codegen/src/fold.rs
@@ -255,6 +255,11 @@ pub fn generate(defs: &Definitions) -> Result<()> {
                 clippy::needless_pass_by_ref_mut,
             )]
 
+            #[cfg(any(feature = "derive", feature = "full"))]
+            use alloc::boxed::Box;
+            #[cfg(any(feature = "derive", feature = "full"))]
+            use alloc::vec::Vec;
+
             #full_macro
 
             /// Syntax tree traversal to transform the nodes of an owned syntax tree.

--- a/codegen/src/hash.rs
+++ b/codegen/src/hash.rs
@@ -160,7 +160,9 @@ pub fn generate(defs: &Definitions) -> Result<()> {
         quote! {
             #[cfg(any(feature = "derive", feature = "full"))]
             use crate::tt::TokenStreamHelper;
-            use std::hash::{Hash, Hasher};
+            #[cfg(feature = "extra-traits")]
+            use alloc::string::ToString;
+            use core::hash::{Hash, Hasher};
 
             #impls
         },

--- a/codegen/src/snapshot.rs
+++ b/codegen/src/snapshot.rs
@@ -363,7 +363,7 @@ pub fn generate(defs: &Definitions) -> Result<()> {
 
             use super::{Lite, Present};
             use ref_cast::RefCast;
-            use std::fmt::{self, Debug, Display};
+            use core::fmt::{self, Debug, Display};
 
             #impls
         },

--- a/codegen/src/visit_mut.rs
+++ b/codegen/src/visit_mut.rs
@@ -233,6 +233,8 @@ pub fn generate(defs: &Definitions) -> Result<()> {
             #![allow(unused_variables)]
             #![allow(clippy::needless_pass_by_ref_mut)]
 
+            #[cfg(any(feature = "derive", feature = "full"))]
+            use alloc::vec::Vec;
             #[cfg(any(feature = "full", feature = "derive"))]
             use crate::punctuated::Punctuated;
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -10,11 +10,15 @@ use crate::meta::{self, ParseNestedMeta};
 use crate::parse::{Parse, ParseStream, Parser};
 use crate::path::Path;
 use crate::token;
+#[cfg(feature = "parsing")]
+use alloc::format;
+#[cfg(feature = "parsing")]
+use alloc::vec::Vec;
+#[cfg(feature = "printing")]
+use core::iter;
+#[cfg(feature = "printing")]
+use core::slice;
 use proc_macro2::TokenStream;
-#[cfg(feature = "printing")]
-use std::iter;
-#[cfg(feature = "printing")]
-use std::slice;
 
 ast_struct! {
     /// An attribute, like `#[repr(transparent)]`.
@@ -653,8 +657,9 @@ pub(crate) mod parsing {
     use crate::parse::{Parse, ParseStream};
     use crate::path::Path;
     use crate::{mac, token};
+    use alloc::vec::Vec;
+    use core::fmt::{self, Display};
     use proc_macro2::Ident;
-    use std::fmt::{self, Display};
 
     pub(crate) fn parse_inner(input: ParseStream, attrs: &mut Vec<Attribute>) -> Result<()> {
         while input.peek(Token![#]) && input.peek2(Token![!]) {

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1,4 +1,6 @@
-use std::ops::{AddAssign, MulAssign};
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::ops::{AddAssign, MulAssign};
 
 // For implementing base10_digits() accessor on LitInt.
 pub(crate) struct BigInt {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,11 +7,13 @@
 
 use crate::ext::TokenStreamExt as _;
 use crate::Lifetime;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::marker::PhantomData;
+use core::ptr;
 use proc_macro2::extra::DelimSpan;
 use proc_macro2::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
-use std::cmp::Ordering;
-use std::marker::PhantomData;
-use std::ptr;
 
 /// Internal type which is used instead of `TokenTree` to represent a token tree
 /// within a `TokenBuffer`.

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -8,10 +8,10 @@ use crate::path::{Path, PathArguments};
 use crate::punctuated::Punctuated;
 #[cfg(any(feature = "printing", feature = "full"))]
 use crate::ty::{ReturnType, Type};
+#[cfg(any(feature = "printing", feature = "full"))]
+use core::ops::ControlFlow;
 #[cfg(feature = "full")]
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
-#[cfg(any(feature = "printing", feature = "full"))]
-use std::ops::ControlFlow;
 
 #[cfg(feature = "full")]
 pub(crate) fn requires_semi_to_be_stmt(expr: &Expr) -> bool {

--- a/src/custom_punctuation.rs
+++ b/src/custom_punctuation.rs
@@ -31,7 +31,7 @@
 ///
 /// ```
 /// use proc_macro2::{TokenStream, TokenTree};
-/// use std::iter;
+/// use core::iter;
 /// use syn::parse::{Parse, ParseStream, Peek, Result};
 /// use syn::punctuated::Punctuated;
 /// use syn::Expr;

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,6 +5,7 @@ use crate::punctuated::{self, Punctuated};
 use crate::restriction::{FieldMutability, Visibility};
 use crate::token;
 use crate::ty::Type;
+use alloc::vec::Vec;
 
 ast_struct! {
     /// An enum variant.

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -5,6 +5,7 @@ use crate::ident::Ident;
 use crate::punctuated::Punctuated;
 use crate::restriction::Visibility;
 use crate::token;
+use alloc::vec::Vec;
 
 ast_struct! {
     /// Data structure sent to a `proc_macro_derive` macro.

--- a/src/discouraged.rs
+++ b/src/discouraged.rs
@@ -3,11 +3,11 @@
 use crate::buffer::Cursor;
 use crate::error::Result;
 use crate::parse::{inner_unexpected, ParseBuffer, Unexpected};
+use alloc::rc::Rc;
+use core::cell::Cell;
+use core::mem;
 use proc_macro2::extra::DelimSpan;
 use proc_macro2::Delimiter;
-use std::cell::Cell;
-use std::mem;
-use std::rc::Rc;
 
 /// Extensions to the `ParseStream` API to support speculative parsing.
 pub trait Speculative {

--- a/src/drops.rs
+++ b/src/drops.rs
@@ -1,8 +1,8 @@
-use std::iter;
-use std::mem::ManuallyDrop;
-use std::ops::{Deref, DerefMut};
-use std::option;
-use std::slice;
+use core::iter;
+use core::mem::ManuallyDrop;
+use core::ops::{Deref, DerefMut};
+use core::option;
+use core::slice;
 
 #[repr(transparent)]
 pub(crate) struct NoDrop<T: ?Sized>(ManuallyDrop<T>);
@@ -39,7 +39,7 @@ impl<T> TrivialDrop for option::IntoIter<&mut T> {}
 
 #[test]
 fn test_needs_drop() {
-    use std::mem::needs_drop;
+    use core::mem::needs_drop;
 
     struct NeedsDrop;
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,33 +1,33 @@
 #[doc(hidden)]
-pub use std::clone::Clone;
+pub use core::clone::Clone;
 #[doc(hidden)]
-pub use std::cmp::{Eq, PartialEq};
+pub use core::cmp::{Eq, PartialEq};
 #[doc(hidden)]
-pub use std::concat;
+pub use core::concat;
 #[doc(hidden)]
-pub use std::default::Default;
+pub use core::default::Default;
 #[doc(hidden)]
-pub use std::fmt::Debug;
+pub use core::fmt::Debug;
 #[doc(hidden)]
-pub use std::hash::{Hash, Hasher};
+pub use core::hash::{Hash, Hasher};
 #[doc(hidden)]
-pub use std::marker::Copy;
+pub use core::marker::Copy;
 #[doc(hidden)]
-pub use std::option::Option::{None, Some};
+pub use core::option::Option::{None, Some};
 #[doc(hidden)]
-pub use std::result::Result::{Err, Ok};
+pub use core::result::Result::{Err, Ok};
 #[doc(hidden)]
-pub use std::stringify;
+pub use core::stringify;
 
 #[doc(hidden)]
-pub type Formatter<'a> = std::fmt::Formatter<'a>;
+pub type Formatter<'a> = core::fmt::Formatter<'a>;
 #[doc(hidden)]
-pub type FmtResult = std::fmt::Result;
+pub type FmtResult = core::fmt::Result;
 
 #[doc(hidden)]
-pub type bool = std::primitive::bool;
+pub type bool = core::primitive::bool;
 #[doc(hidden)]
-pub type str = std::primitive::str;
+pub type str = core::primitive::str;
 
 #[cfg(feature = "printing")]
 #[doc(hidden)]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -23,14 +23,16 @@ use crate::token;
 #[cfg(feature = "full")]
 use crate::ty::ReturnType;
 use crate::ty::Type;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+#[cfg(feature = "printing")]
+use core::fmt::{self, Display};
+use core::hash::{Hash, Hasher};
+#[cfg(all(feature = "parsing", feature = "full"))]
+use core::mem;
 use proc_macro2::{Span, TokenStream};
 #[cfg(feature = "printing")]
 use quote::IdentFragment;
-#[cfg(feature = "printing")]
-use std::fmt::{self, Display};
-use std::hash::{Hash, Hasher};
-#[cfg(all(feature = "parsing", feature = "full"))]
-use std::mem;
 
 ast_enum_of_structs! {
     /// A Rust expression.
@@ -195,7 +197,7 @@ ast_enum_of_structs! {
         /// A parenthesized expression: `(a + b)`.
         Paren(ExprParen),
 
-        /// A path like `std::mem::replace` possibly containing generic
+        /// A path like `core::mem::replace` possibly containing generic
         /// parameters and a qualified self-type.
         ///
         /// A plain identifier like `x` is a path of length 1.
@@ -556,7 +558,7 @@ ast_struct! {
 }
 
 ast_struct! {
-    /// A path like `std::mem::replace` possibly containing generic
+    /// A path like `core::mem::replace` possibly containing generic
     /// parameters and a qualified self-type.
     ///
     /// A plain identifier like `x` is a path of length 1.
@@ -718,7 +720,7 @@ impl Expr {
     ///
     /// ```
     /// use quote::ToTokens;
-    /// use std::mem;
+    /// use core::mem;
     /// use syn::{parse_quote, Expr};
     ///
     /// fn unparenthesize(e: &mut Expr) {
@@ -756,7 +758,7 @@ impl Expr {
     ///
     /// ```
     /// # struct S;
-    /// # impl std::ops::Deref for S {
+    /// # impl core::ops::Deref for S {
     /// #     type Target = bool;
     /// #     fn deref(&self) -> &Self::Target {
     /// #         &true
@@ -1212,9 +1214,13 @@ pub(crate) mod parsing {
     #[cfg(feature = "full")]
     use crate::ty::{ReturnType, Type};
     use crate::verbatim;
+    use alloc::boxed::Box;
+    use alloc::format;
+    use alloc::string::ToString;
+    use alloc::vec::Vec;
+    use core::mem;
     #[cfg(feature = "full")]
     use proc_macro2::{Span, TokenStream};
-    use std::mem;
 
     // When we're parsing expressions which occur before blocks, like in an if
     // statement's condition, we cannot parse a struct literal.

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -12,8 +12,9 @@ use crate::parse::Peek;
 use crate::sealed::lookahead;
 #[cfg(feature = "parsing")]
 use crate::token::CustomToken;
+use alloc::string::ToString;
+use core::iter;
 use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream, TokenTree};
-use std::iter;
 
 /// Additional methods for `Ident` not provided by proc-macro2 or libproc_macro.
 ///

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,5 +1,7 @@
 use crate::attr::Attribute;
 use crate::item::Item;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 ast_struct! {
     /// A complete file of Rust source code.
@@ -89,6 +91,7 @@ pub(crate) mod parsing {
     use crate::error::Result;
     use crate::file::File;
     use crate::parse::{Parse, ParseStream};
+    use alloc::vec::Vec;
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     impl Parse for File {

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -2,7 +2,7 @@
 // It is not intended for manual editing.
 
 #![allow(unknown_lints, non_local_definitions)]
-use std::fmt::{self, Debug};
+use core::fmt::{self, Debug};
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::Abi {

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -3,6 +3,8 @@
 
 #[cfg(any(feature = "derive", feature = "full"))]
 use crate::tt::TokenStreamHelper;
+#[cfg(feature = "extra-traits")]
+use alloc::string::ToString;
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::Abi {}

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -7,6 +7,10 @@
     clippy::needless_match,
     clippy::needless_pass_by_ref_mut,
 )]
+#[cfg(any(feature = "derive", feature = "full"))]
+use alloc::boxed::Box;
+#[cfg(any(feature = "derive", feature = "full"))]
+use alloc::vec::Vec;
 #[cfg(feature = "full")]
 macro_rules! full {
     ($e:expr) => {

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -3,7 +3,9 @@
 
 #[cfg(any(feature = "derive", feature = "full"))]
 use crate::tt::TokenStreamHelper;
-use std::hash::{Hash, Hasher};
+#[cfg(feature = "extra-traits")]
+use alloc::string::ToString;
+use core::hash::{Hash, Hasher};
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::Abi {

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -3,6 +3,8 @@
 
 #![allow(unused_variables)]
 #![allow(clippy::needless_pass_by_ref_mut)]
+#[cfg(any(feature = "derive", feature = "full"))]
+use alloc::vec::Vec;
 #[cfg(any(feature = "full", feature = "derive"))]
 use crate::punctuated::Punctuated;
 #[cfg(feature = "full")]

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -6,11 +6,12 @@ use crate::path::Path;
 use crate::punctuated::{Iter, IterMut, Punctuated};
 use crate::token;
 use crate::ty::Type;
+use alloc::vec::Vec;
+#[cfg(all(feature = "printing", feature = "extra-traits"))]
+use core::fmt::{self, Debug};
+#[cfg(all(feature = "printing", feature = "extra-traits"))]
+use core::hash::{Hash, Hasher};
 use proc_macro2::TokenStream;
-#[cfg(all(feature = "printing", feature = "extra-traits"))]
-use std::fmt::{self, Debug};
-#[cfg(all(feature = "printing", feature = "extra-traits"))]
-use std::hash::{Hash, Hasher};
 
 ast_struct! {
     /// Lifetimes and type parameters attached to a declaration of a function,
@@ -385,7 +386,7 @@ impl LifetimeParam {
 impl From<Ident> for TypeParam {
     fn from(ident: Ident) -> Self {
         TypeParam {
-            attrs: vec![],
+            attrs: Vec::new(),
             ident,
             colon_token: None,
             bounds: Punctuated::new(),

--- a/src/ident.rs
+++ b/src/ident.rs
@@ -54,6 +54,7 @@ mod parsing {
     use crate::error::Result;
     use crate::parse::{Parse, ParseStream};
     use crate::token::Token;
+    use alloc::string::ToString;
     use proc_macro2::Ident;
 
     fn accept_as_ident(ident: &Ident) -> bool {

--- a/src/item.rs
+++ b/src/item.rs
@@ -13,9 +13,11 @@ use crate::restriction::Visibility;
 use crate::stmt::Block;
 use crate::token;
 use crate::ty::{Abi, ReturnType, Type};
-use proc_macro2::TokenStream;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 #[cfg(feature = "parsing")]
-use std::mem;
+use core::mem;
+use proc_macro2::TokenStream;
 
 ast_enum_of_structs! {
     /// Things that can appear directly inside of a module or scope.
@@ -66,13 +68,13 @@ ast_enum_of_structs! {
         /// A trait alias: `pub trait SharableIterator = Iterator + Sync`.
         TraitAlias(ItemTraitAlias),
 
-        /// A type alias: `type Result<T> = std::result::Result<T, MyError>`.
+        /// A type alias: `type Result<T> = core::result::Result<T, MyError>`.
         Type(ItemType),
 
         /// A union definition: `union Foo<A, B> { x: A, y: B }`.
         Union(ItemUnion),
 
-        /// A use declaration: `use std::collections::HashMap`.
+        /// A use declaration: `use alloc::collections::HashMap`.
         Use(ItemUse),
 
         /// Tokens forming an item not interpreted by Syn.
@@ -277,7 +279,7 @@ ast_struct! {
 }
 
 ast_struct! {
-    /// A type alias: `type Result<T> = std::result::Result<T, MyError>`.
+    /// A type alias: `type Result<T> = core::result::Result<T, MyError>`.
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     pub struct ItemType {
         pub attrs: Vec<Attribute>,
@@ -305,7 +307,7 @@ ast_struct! {
 }
 
 ast_struct! {
-    /// A use declaration: `use std::collections::HashMap`.
+    /// A use declaration: `use alloc::collections::HashMap`.
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     pub struct ItemUse {
         pub attrs: Vec<Attribute>,
@@ -431,7 +433,7 @@ ast_enum_of_structs! {
     /// [syntax tree enum]: crate::expr::Expr#syntax-tree-enums
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     pub enum UseTree {
-        /// A path prefix of imports in a `use` item: `std::...`.
+        /// A path prefix of imports in a `use` item: `core::...`.
         Path(UsePath),
 
         /// An identifier imported by a `use` item: `HashMap`.
@@ -449,7 +451,7 @@ ast_enum_of_structs! {
 }
 
 ast_struct! {
-    /// A path prefix of imports in a `use` item: `std::...`.
+    /// A path prefix of imports in a `use` item: `core::...`.
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     pub struct UsePath {
         pub ident: Ident,
@@ -932,6 +934,8 @@ pub(crate) mod parsing {
     use crate::token;
     use crate::ty::{Abi, ReturnType, Type, TypePath, TypeReference};
     use crate::verbatim;
+    use alloc::boxed::Box;
+    use alloc::vec::Vec;
     use proc_macro2::TokenStream;
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,7 @@
 //! - **`proc-macro`** *(enabled by default)* — Runtime dependency on the
 //!   dynamic library libproc_macro from rustc toolchain.
 
+#![no_std]
 #![doc(html_root_url = "https://docs.rs/syn/2.0.113")]
 #![cfg_attr(docsrs, feature(doc_cfg), doc(auto_cfg = false))]
 #![deny(unsafe_op_in_unsafe_fn)]
@@ -308,6 +309,9 @@
     clippy::wildcard_imports,
 )]
 #![allow(unknown_lints, mismatched_lifetime_syntaxes)]
+
+extern crate alloc;
+extern crate std;
 
 extern crate self as syn;
 
@@ -962,6 +966,7 @@ pub fn parse_str<T: parse::Parse>(s: &str) -> Result<T> {
 /// # Examples
 ///
 /// ```no_run
+/// # // TODO(MSRV 1.81.0): use core::error::Error.
 /// use std::error::Error;
 /// use std::fs;
 /// use std::io::Read;
@@ -982,6 +987,8 @@ pub fn parse_str<T: parse::Parse>(s: &str) -> Result<T> {
 #[cfg(all(feature = "parsing", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "parsing", feature = "full"))))]
 pub fn parse_file(mut content: &str) -> Result<File> {
+    use alloc::string::ToString;
+
     // Strip the BOM if it is present
     const BOM: &str = "\u{feff}";
     if content.starts_with(BOM) {

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "parsing")]
 use crate::lookahead;
+use core::cmp::Ordering;
+use core::fmt::{self, Display};
+use core::hash::{Hash, Hasher};
 use proc_macro2::{Ident, Span};
-use std::cmp::Ordering;
-use std::fmt::{self, Display};
-use std::hash::{Hash, Hasher};
 
 /// A Rust lifetime: `'a`.
 ///

--- a/src/lit.rs
+++ b/src/lit.rs
@@ -5,14 +5,20 @@ use crate::lookahead;
 #[cfg(feature = "parsing")]
 use crate::parse::{Parse, Parser};
 use crate::{Error, Result};
+use alloc::boxed::Box;
+use alloc::ffi::CString;
+#[cfg(feature = "parsing")]
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::ffi::CStr;
+use core::fmt::{self, Display};
+#[cfg(feature = "extra-traits")]
+use core::hash::{Hash, Hasher};
+use core::str::{self, FromStr};
 use proc_macro2::{Ident, Literal, Span};
 #[cfg(feature = "parsing")]
 use proc_macro2::{TokenStream, TokenTree};
-use std::ffi::{CStr, CString};
-use std::fmt::{self, Display};
-#[cfg(feature = "extra-traits")]
-use std::hash::{Hash, Hasher};
-use std::str::{self, FromStr};
 
 ast_enum_of_structs! {
     /// A Rust literal such as a string or integer or boolean.
@@ -609,7 +615,7 @@ impl LitBool {
 #[cfg(feature = "extra-traits")]
 mod debug_impls {
     use crate::lit::{LitBool, LitByte, LitByteStr, LitCStr, LitChar, LitFloat, LitInt, LitStr};
-    use std::fmt::{self, Debug};
+    use core::fmt::{self, Debug};
 
     #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
     impl Debug for LitStr {
@@ -865,9 +871,11 @@ pub(crate) mod parsing {
     };
     use crate::parse::{Parse, ParseStream, Unexpected};
     use crate::token::{self, Token};
+    use alloc::boxed::Box;
+    use alloc::rc::Rc;
+    use alloc::string::ToString;
+    use core::cell::Cell;
     use proc_macro2::{Literal, Punct, Span};
-    use std::cell::Cell;
-    use std::rc::Rc;
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     impl Parse for Lit {
@@ -1134,10 +1142,14 @@ mod value {
         Lit, LitBool, LitByte, LitByteStr, LitCStr, LitChar, LitFloat, LitFloatRepr, LitInt,
         LitIntRepr, LitRepr, LitStr,
     };
+    use alloc::borrow::ToOwned;
+    use alloc::boxed::Box;
+    use alloc::ffi::CString;
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
+    use core::char;
+    use core::ops::{Index, RangeFrom};
     use proc_macro2::{Literal, Span};
-    use std::char;
-    use std::ffi::CString;
-    use std::ops::{Index, RangeFrom};
 
     impl Lit {
         /// Interpret a Syn literal from a proc-macro2 literal.

--- a/src/lookahead.rs
+++ b/src/lookahead.rs
@@ -3,9 +3,11 @@ use crate::error::{self, Error};
 use crate::sealed::lookahead::Sealed;
 use crate::span::IntoSpans;
 use crate::token::{CustomToken, Token};
+use alloc::format;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::fmt::{self, Display};
 use proc_macro2::{Delimiter, Span};
-use std::cell::RefCell;
-use std::fmt::{self, Display};
 
 /// Support for checking the next token in a stream to decide how to parse.
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,7 +15,7 @@ macro_rules! ast_struct {
 
         #[cfg(not(feature = "full"))]
         $(#[$attr])* $pub $struct $name {
-            _noconstruct: ::std::marker::PhantomData<::proc_macro2::Span>,
+            _noconstruct: ::core::marker::PhantomData<::proc_macro2::Span>,
         }
 
         #[cfg(all(not(feature = "full"), feature = "printing"))]

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -6,8 +6,8 @@ use crate::lit::Lit;
 use crate::parse::{ParseStream, Parser};
 use crate::path::{Path, PathSegment};
 use crate::punctuated::Punctuated;
+use core::fmt::Display;
 use proc_macro2::Ident;
-use std::fmt::Display;
 
 /// Make a parser that is usable with `parse_macro_input!` in a
 /// `#[proc_macro_attribute]` macro.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -103,7 +103,7 @@
 //! use syn::Type;
 //!
 //! # fn run_parser() -> syn::Result<()> {
-//! let t: Type = syn::parse_str("std::collections::HashMap<String, Value>")?;
+//! let t: Type = syn::parse_str("alloc::collections::HashMap<String, Value>")?;
 //! #     Ok(())
 //! # }
 //! #
@@ -187,19 +187,20 @@ use crate::error;
 use crate::lookahead;
 use crate::punctuated::Punctuated;
 use crate::token::Token;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use core::cell::Cell;
+use core::fmt::{self, Debug, Display};
+#[cfg(feature = "extra-traits")]
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::Deref;
+use core::panic::{RefUnwindSafe, UnwindSafe};
+use core::str::FromStr;
 use proc_macro2::{Delimiter, Group, Literal, Punct, Span, TokenStream, TokenTree};
 #[cfg(feature = "printing")]
 use quote::ToTokens;
-use std::cell::Cell;
-use std::fmt::{self, Debug, Display};
-#[cfg(feature = "extra-traits")]
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Deref;
-use std::panic::{RefUnwindSafe, UnwindSafe};
-use std::rc::Rc;
-use std::str::FromStr;
 
 pub use crate::error::{Error, Result};
 pub use crate::lookahead::{End, Lookahead1, Peek};
@@ -1127,7 +1128,7 @@ impl<'a> ParseBuffer<'a> {
     ///     let mut tokens = TokenStream::new();
     ///     while cursor < end {
     ///         let (token, next) = cursor.token_tree().unwrap();
-    ///         tokens.extend(std::iter::once(token));
+    ///         tokens.extend(core::iter::once(token));
     ///         cursor = next;
     ///     }
     ///     tokens

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -103,7 +103,7 @@ macro_rules! parse_quote {
 ///         ReturnType::Type(_, ret) => quote!(#ret),
 ///     };
 ///     sig.output = parse_quote_spanned! {ret.span()=>
-///         -> ::std::pin::Pin<::std::boxed::Box<dyn ::std::future::Future<Output = #ret>>>
+///         -> ::core::pin::Pin<::alloc::boxed::Box<dyn ::core::future::Future<Output = #ret>>>
 ///     };
 /// }
 /// ```
@@ -120,6 +120,10 @@ macro_rules! parse_quote_spanned {
 
 use crate::error::Result;
 use crate::parse::{Parse, ParseStream, Parser};
+#[cfg(feature = "full")]
+use alloc::boxed::Box;
+#[cfg(any(feature = "full", feature = "derive"))]
+use alloc::vec::Vec;
 use proc_macro2::TokenStream;
 
 // Not public API.

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -5,6 +5,8 @@ use crate::path::{Path, QSelf};
 use crate::punctuated::Punctuated;
 use crate::token;
 use crate::ty::Type;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use proc_macro2::TokenStream;
 
 pub use crate::expr::{
@@ -256,6 +258,8 @@ pub(crate) mod parsing {
     use crate::stmt::Block;
     use crate::token;
     use crate::verbatim;
+    use alloc::boxed::Box;
+    use alloc::vec::Vec;
     use proc_macro2::TokenStream;
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]

--- a/src/path.rs
+++ b/src/path.rs
@@ -7,9 +7,10 @@ use crate::lifetime::Lifetime;
 use crate::punctuated::Punctuated;
 use crate::token;
 use crate::ty::{ReturnType, Type};
+use alloc::boxed::Box;
 
 ast_struct! {
-    /// A path at which a named item is exported (e.g. `std::collections::HashMap`).
+    /// A path at which a named item is exported (e.g. `alloc::collections::HashMap`).
     #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct Path {
         pub leading_colon: Option<Token![::]>,
@@ -130,7 +131,7 @@ ast_enum! {
     ///
     /// ## Angle bracketed
     ///
-    /// The `<'a, T>` in `std::slice::iter<'a, T>`.
+    /// The `<'a, T>` in `core::slice::iter<'a, T>`.
     ///
     /// ## Parenthesized
     ///
@@ -138,7 +139,7 @@ ast_enum! {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub enum PathArguments {
         None,
-        /// The `<'a, T>` in `std::slice::iter<'a, T>`.
+        /// The `<'a, T>` in `core::slice::iter<'a, T>`.
         AngleBracketed(AngleBracketedGenericArguments),
         /// The `(A, B) -> C` in `Fn(A, B) -> C`.
         Parenthesized(ParenthesizedGenericArguments),
@@ -304,6 +305,8 @@ pub(crate) mod parsing {
     use crate::ty::{ReturnType, Type};
     #[cfg(not(feature = "full"))]
     use crate::verbatim;
+    use alloc::boxed::Box;
+    use alloc::vec::Vec;
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     impl Parse for Path {
@@ -555,7 +558,7 @@ pub(crate) mod parsing {
         ///
         /// // A simplified single `use` statement like:
         /// //
-        /// //     use std::collections::HashMap;
+        /// //     use alloc::collections::HashMap;
         /// //
         /// // Note that generic parameters are not allowed in a `use` statement
         /// // so the following must not be accepted.
@@ -706,11 +709,11 @@ pub(crate) mod printing {
     use crate::print::TokensOrDefault;
     #[cfg(feature = "parsing")]
     use crate::spanned::Spanned;
+    use core::cmp;
     #[cfg(feature = "parsing")]
     use proc_macro2::Span;
     use proc_macro2::TokenStream;
     use quote::ToTokens;
-    use std::cmp;
 
     pub(crate) enum PathStyle {
         Expr,

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -12,7 +12,7 @@ use crate::expr::{
 use crate::op::BinOp;
 #[cfg(all(feature = "printing", feature = "full"))]
 use crate::ty::ReturnType;
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 // Reference: https://doc.rust-lang.org/reference/expressions.html#expression-precedence
 pub(crate) enum Precedence {

--- a/src/punctuated.rs
+++ b/src/punctuated.rs
@@ -27,18 +27,19 @@ use crate::error::Result;
 use crate::parse::{Parse, ParseStream};
 #[cfg(feature = "parsing")]
 use crate::token::Token;
+use alloc::boxed::Box;
 #[cfg(all(feature = "fold", any(feature = "full", feature = "derive")))]
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
+use alloc::vec::{self, Vec};
 #[cfg(feature = "extra-traits")]
-use std::fmt::{self, Debug};
+use core::fmt::{self, Debug};
 #[cfg(feature = "extra-traits")]
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 #[cfg(any(feature = "full", feature = "derive"))]
-use std::iter;
-use std::ops::{Index, IndexMut};
-use std::option;
-use std::slice;
-use std::vec;
+use core::iter;
+use core::ops::{Index, IndexMut};
+use core::option;
+use core::slice;
 
 /// **A punctuated sequence of syntax tree nodes of type `T` separated by
 /// punctuation of type `P`.**

--- a/src/restriction.rs
+++ b/src/restriction.rs
@@ -1,5 +1,6 @@
 use crate::path::Path;
 use crate::token;
+use alloc::boxed::Box;
 
 ast_enum! {
     /// The visibility level of an item: inherited or `pub` or
@@ -66,6 +67,7 @@ pub(crate) mod parsing {
     use crate::path::Path;
     use crate::restriction::{VisRestricted, Visibility};
     use crate::token;
+    use alloc::boxed::Box;
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     impl Parse for Visibility {

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -11,7 +11,7 @@
 //! be able to pass a reference to one of those fields across threads.
 //!
 //! [`Type`]: crate::Type
-//! [`Sync`]: std::marker::Sync
+//! [`Sync`]: core::marker::Sync
 //!
 //! If the field type does *not* implement `Sync` as required, we want the
 //! compiler to report an error pointing out exactly which type it was.
@@ -53,7 +53,7 @@
 //! `Sync`. The errors they would see look like the following.
 //!
 //! ```text
-//! error[E0277]: the trait bound `*const i32: std::marker::Sync` is not satisfied
+//! error[E0277]: the trait bound `*const i32: core::marker::Sync` is not satisfied
 //!   --> src/main.rs:10:21
 //!    |
 //! 10 |     bad_field: *const i32,

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -4,6 +4,8 @@ use crate::item::Item;
 use crate::mac::Macro;
 use crate::pat::Pat;
 use crate::token;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 ast_struct! {
     /// A braced block containing Rust statements.
@@ -93,6 +95,8 @@ pub(crate) mod parsing {
     use crate::stmt::{Block, Local, LocalInit, Stmt, StmtMacro};
     use crate::token;
     use crate::ty::Type;
+    use alloc::boxed::Box;
+    use alloc::vec::Vec;
     use proc_macro2::TokenStream;
 
     struct AllowNoSemi(bool);

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug};
+use core::fmt::{self, Debug};
 use std::thread::{self, ThreadId};
 
 /// ThreadBound is a Sync-maker and Send-maker that allows accessing a value
@@ -49,7 +49,7 @@ impl<T: Debug> Debug for ThreadBound<T> {
 //
 // Currently `T: Copy` is sufficient to guarantee that T contains no interior
 // mutability, because _all_ interior mutability in Rust is built on
-// std::cell::UnsafeCell, which has no Copy impl. This impl needs to be
+// core::cell::UnsafeCell, which has no Copy impl. This impl needs to be
 // revisited if that restriction is relaxed in the future.
 impl<T: Copy> Copy for ThreadBound<T> {}
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -100,6 +100,13 @@ use crate::lifetime::Lifetime;
 #[cfg(feature = "parsing")]
 use crate::parse::{Parse, ParseStream};
 use crate::span::IntoSpans;
+#[cfg(feature = "extra-traits")]
+use core::cmp;
+#[cfg(feature = "extra-traits")]
+use core::fmt::{self, Debug};
+#[cfg(feature = "extra-traits")]
+use core::hash::{Hash, Hasher};
+use core::ops::{Deref, DerefMut};
 use proc_macro2::extra::DelimSpan;
 use proc_macro2::Span;
 #[cfg(feature = "printing")]
@@ -110,13 +117,6 @@ use proc_macro2::{Delimiter, Ident};
 use proc_macro2::{Literal, Punct, TokenTree};
 #[cfg(feature = "printing")]
 use quote::{ToTokens, TokenStreamExt as _};
-#[cfg(feature = "extra-traits")]
-use std::cmp;
-#[cfg(feature = "extra-traits")]
-use std::fmt::{self, Debug};
-#[cfg(feature = "extra-traits")]
-use std::hash::{Hash, Hasher};
-use std::ops::{Deref, DerefMut};
 
 /// Marker trait for types that represent single tokens.
 ///
@@ -219,7 +219,7 @@ macro_rules! define_keywords {
                 }
             }
 
-            impl std::default::Default for $name {
+            impl core::default::Default for $name {
                 fn default() -> Self {
                     $name {
                         span: Span::call_site(),
@@ -346,7 +346,7 @@ macro_rules! define_punctuation_structs {
                 }
             }
 
-            impl std::default::Default for $name {
+            impl core::default::Default for $name {
                 fn default() -> Self {
                     $name {
                         spans: [Span::call_site(); $len],
@@ -455,7 +455,7 @@ macro_rules! define_delimiters {
                 }
             }
 
-            impl std::default::Default for $name {
+            impl core::default::Default for $name {
                 fn default() -> Self {
                     $name(Span::call_site())
                 }
@@ -583,7 +583,7 @@ pub fn Group<S: IntoSpans<Span>>(span: S) -> Group {
     }
 }
 
-impl std::default::Default for Group {
+impl core::default::Default for Group {
     fn default() -> Self {
         Group {
             span: Span::call_site(),
@@ -978,6 +978,7 @@ pub(crate) mod parsing {
     use crate::buffer::Cursor;
     use crate::error::{Error, Result};
     use crate::parse::ParseStream;
+    use alloc::format;
     use proc_macro2::{Spacing, Span};
 
     pub(crate) fn keyword(input: ParseStream, token: &str) -> Result<Span> {

--- a/src/tt.rs
+++ b/src/tt.rs
@@ -1,5 +1,6 @@
+use alloc::string::ToString;
+use core::hash::{Hash, Hasher};
 use proc_macro2::{Delimiter, Spacing, TokenStream, TokenTree};
-use std::hash::{Hash, Hasher};
 
 pub(crate) struct TokenTreeHelper<'a>(pub &'a TokenTree);
 

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -8,6 +8,8 @@ use crate::mac::Macro;
 use crate::path::{Path, QSelf};
 use crate::punctuated::Punctuated;
 use crate::token;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use proc_macro2::TokenStream;
 
 ast_enum_of_structs! {
@@ -46,7 +48,7 @@ ast_enum_of_structs! {
         /// A parenthesized type equivalent to the inner type.
         Paren(TypeParen),
 
-        /// A path like `std::slice::Iter`, optionally qualified with a
+        /// A path like `core::slice::Iter`, optionally qualified with a
         /// self-type as in `<Vec<T> as SomeTrait>::Associated`.
         Path(TypePath),
 
@@ -168,7 +170,7 @@ ast_struct! {
 }
 
 ast_struct! {
-    /// A path like `std::slice::Iter`, optionally qualified with a
+    /// A path like `core::slice::Iter`, optionally qualified with a
     /// self-type as in `<Vec<T> as SomeTrait>::Associated`.
     #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypePath {
@@ -290,6 +292,8 @@ pub(crate) mod parsing {
         TypeReference, TypeSlice, TypeTraitObject, TypeTuple,
     };
     use crate::verbatim;
+    use alloc::boxed::Box;
+    use alloc::vec::Vec;
     use proc_macro2::Span;
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]

--- a/src/verbatim.rs
+++ b/src/verbatim.rs
@@ -1,7 +1,7 @@
 use crate::ext::TokenStreamExt as _;
 use crate::parse::ParseStream;
+use core::cmp::Ordering;
 use proc_macro2::{Delimiter, TokenStream};
-use std::cmp::Ordering;
 
 pub(crate) fn between<'a>(begin: ParseStream<'a>, end: ParseStream<'a>) -> TokenStream {
     let end = end.cursor();

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::match_wildcard_for_single_variants)]
 use super::{Lite, Present};
 use ref_cast::RefCast;
-use std::fmt::{self, Debug, Display};
+use core::fmt::{self, Debug, Display};
 impl Debug for Lite<syn::Abi> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("Abi");


### PR DESCRIPTION
This makes visible the dependency on std prelude macros such as
`error::Error`. Helpful for planning how to do no-std.

Tested with `cargo hack clippy --feature-powerset -- --deny warnings`
(all 2112 combinations).

See also https://github.com/dtolnay/proc-macro2/pull/528.
