### PR TITLE
expose "safe fn" in extern block as ForeignItemFn

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -879,6 +879,19 @@ impl Clone for crate::FnArg {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ForeignFnSafety {
+    fn clone(&self) -> Self {
+        match self {
+            crate::ForeignFnSafety::Unsafe(v0) => {
+                crate::ForeignFnSafety::Unsafe(v0.clone())
+            }
+            crate::ForeignFnSafety::Safe(v0) => crate::ForeignFnSafety::Safe(v0.clone()),
+            crate::ForeignFnSafety::None => crate::ForeignFnSafety::None,
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::ForeignItem {
     fn clone(&self) -> Self {
         match self {
@@ -940,6 +953,25 @@ impl Clone for crate::ForeignItemType {
             ident: self.ident.clone(),
             generics: self.generics.clone(),
             semi_token: self.semi_token.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ForeignSignature {
+    fn clone(&self) -> Self {
+        crate::ForeignSignature {
+            constness: self.constness.clone(),
+            asyncness: self.asyncness.clone(),
+            safety: self.safety.clone(),
+            abi: self.abi.clone(),
+            fn_token: self.fn_token.clone(),
+            ident: self.ident.clone(),
+            generics: self.generics.clone(),
+            paren_token: self.paren_token.clone(),
+            inputs: self.inputs.clone(),
+            variadic: self.variadic.clone(),
+            output: self.output.clone(),
         }
     }
 }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1318,6 +1318,26 @@ impl Debug for crate::FnArg {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ForeignFnSafety {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("ForeignFnSafety::")?;
+        match self {
+            crate::ForeignFnSafety::Unsafe(v0) => {
+                let mut formatter = formatter.debug_tuple("Unsafe");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::ForeignFnSafety::Safe(v0) => {
+                let mut formatter = formatter.debug_tuple("Safe");
+                formatter.field(v0);
+                formatter.finish()
+            }
+            crate::ForeignFnSafety::None => formatter.write_str("None"),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::ForeignItem {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("ForeignItem::")?;
@@ -1408,6 +1428,25 @@ impl crate::ForeignItemType {
         formatter.field("ident", &self.ident);
         formatter.field("generics", &self.generics);
         formatter.field("semi_token", &self.semi_token);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ForeignSignature {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ForeignSignature");
+        formatter.field("constness", &self.constness);
+        formatter.field("asyncness", &self.asyncness);
+        formatter.field("safety", &self.safety);
+        formatter.field("abi", &self.abi);
+        formatter.field("fn_token", &self.fn_token);
+        formatter.field("ident", &self.ident);
+        formatter.field("generics", &self.generics);
+        formatter.field("paren_token", &self.paren_token);
+        formatter.field("inputs", &self.inputs);
+        formatter.field("variadic", &self.variadic);
+        formatter.field("output", &self.output);
         formatter.finish()
     }
 }

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -874,6 +874,23 @@ impl PartialEq for crate::FnArg {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ForeignFnSafety {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ForeignFnSafety {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (crate::ForeignFnSafety::Unsafe(_), crate::ForeignFnSafety::Unsafe(_)) => {
+                true
+            }
+            (crate::ForeignFnSafety::Safe(_), crate::ForeignFnSafety::Safe(_)) => true,
+            (crate::ForeignFnSafety::None, crate::ForeignFnSafety::None) => true,
+            _ => false,
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::ForeignItem {}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
@@ -942,6 +959,20 @@ impl PartialEq for crate::ForeignItemType {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis && self.ident == other.ident
             && self.generics == other.generics
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ForeignSignature {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ForeignSignature {
+    fn eq(&self, other: &Self) -> bool {
+        self.constness == other.constness && self.asyncness == other.asyncness
+            && self.safety == other.safety && self.abi == other.abi
+            && self.ident == other.ident && self.generics == other.generics
+            && self.inputs == other.inputs && self.variadic == other.variadic
+            && self.output == other.output
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -393,6 +393,14 @@ pub trait Fold {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_foreign_fn_safety(
+        &mut self,
+        i: crate::ForeignFnSafety,
+    ) -> crate::ForeignFnSafety {
+        fold_foreign_fn_safety(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_foreign_item(&mut self, i: crate::ForeignItem) -> crate::ForeignItem {
         fold_foreign_item(self, i)
     }
@@ -424,6 +432,14 @@ pub trait Fold {
         i: crate::ForeignItemType,
     ) -> crate::ForeignItemType {
         fold_foreign_item_type(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_foreign_signature(
+        &mut self,
+        i: crate::ForeignSignature,
+    ) -> crate::ForeignSignature {
+        fold_foreign_signature(self, i)
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -2083,6 +2099,25 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_foreign_fn_safety<F>(
+    f: &mut F,
+    node: crate::ForeignFnSafety,
+) -> crate::ForeignFnSafety
+where
+    F: Fold + ?Sized,
+{
+    match node {
+        crate::ForeignFnSafety::Unsafe(_binding_0) => {
+            crate::ForeignFnSafety::Unsafe(_binding_0)
+        }
+        crate::ForeignFnSafety::Safe(_binding_0) => {
+            crate::ForeignFnSafety::Safe(_binding_0)
+        }
+        crate::ForeignFnSafety::None => crate::ForeignFnSafety::None,
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn fold_foreign_item<F>(f: &mut F, node: crate::ForeignItem) -> crate::ForeignItem
 where
     F: Fold + ?Sized,
@@ -2117,7 +2152,7 @@ where
     crate::ForeignItemFn {
         attrs: f.fold_attributes(node.attrs),
         vis: f.fold_visibility(node.vis),
-        sig: f.fold_signature(node.sig),
+        sig: f.fold_foreign_signature(node.sig),
         semi_token: node.semi_token,
     }
 }
@@ -2172,6 +2207,29 @@ where
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
         semi_token: node.semi_token,
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_foreign_signature<F>(
+    f: &mut F,
+    node: crate::ForeignSignature,
+) -> crate::ForeignSignature
+where
+    F: Fold + ?Sized,
+{
+    crate::ForeignSignature {
+        constness: node.constness,
+        asyncness: node.asyncness,
+        safety: f.fold_foreign_fn_safety(node.safety),
+        abi: (node.abi).map(|it| f.fold_abi(it)),
+        fn_token: node.fn_token,
+        ident: f.fold_ident(node.ident),
+        generics: f.fold_generics(node.generics),
+        paren_token: node.paren_token,
+        inputs: crate::punctuated::fold(node.inputs, f, F::fold_fn_arg),
+        variadic: (node.variadic).map(|it| f.fold_variadic(it)),
+        output: f.fold_return_type(node.output),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1141,6 +1141,26 @@ impl Hash for crate::FnArg {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ForeignFnSafety {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        match self {
+            crate::ForeignFnSafety::Unsafe(_) => {
+                state.write_u8(0u8);
+            }
+            crate::ForeignFnSafety::Safe(_) => {
+                state.write_u8(1u8);
+            }
+            crate::ForeignFnSafety::None => {
+                state.write_u8(2u8);
+            }
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::ForeignItem {
     fn hash<H>(&self, state: &mut H)
     where
@@ -1219,6 +1239,24 @@ impl Hash for crate::ForeignItemType {
         self.vis.hash(state);
         self.ident.hash(state);
         self.generics.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ForeignSignature {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.constness.hash(state);
+        self.asyncness.hash(state);
+        self.safety.hash(state);
+        self.abi.hash(state);
+        self.ident.hash(state);
+        self.generics.hash(state);
+        self.inputs.hash(state);
+        self.variadic.hash(state);
+        self.output.hash(state);
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/token.css
+++ b/src/gen/token.css
@@ -70,6 +70,7 @@ a.struct[title="struct syn::token::RArrow"],
 a.struct[title="struct syn::token::Raw"],
 a.struct[title="struct syn::token::Ref"],
 a.struct[title="struct syn::token::Return"],
+a.struct[title="struct syn::token::Safe"],
 a.struct[title="struct syn::token::SelfType"],
 a.struct[title="struct syn::token::SelfValue"],
 a.struct[title="struct syn::token::Semi"],
@@ -175,6 +176,7 @@ a.struct[title="struct syn::token::RArrow"]::before,
 a.struct[title="struct syn::token::Raw"]::before,
 a.struct[title="struct syn::token::Ref"]::before,
 a.struct[title="struct syn::token::Return"]::before,
+a.struct[title="struct syn::token::Safe"]::before,
 a.struct[title="struct syn::token::SelfType"]::before,
 a.struct[title="struct syn::token::SelfValue"]::before,
 a.struct[title="struct syn::token::Semi"]::before,
@@ -496,6 +498,10 @@ a.struct[title="struct syn::token::Return"]::before {
 	content: "Token![return]";
 }
 
+a.struct[title="struct syn::token::Safe"]::before {
+	content: "Token![safe]";
+}
+
 a.struct[title="struct syn::token::SelfType"]::before {
 	content: "Token![Self]";
 }
@@ -718,6 +724,7 @@ a.struct[title="struct syn::token::Pub"]::after,
 a.struct[title="struct syn::token::Raw"]::after,
 a.struct[title="struct syn::token::Ref"]::after,
 a.struct[title="struct syn::token::Return"]::after,
+a.struct[title="struct syn::token::Safe"]::after,
 a.struct[title="struct syn::token::Static"]::after,
 a.struct[title="struct syn::token::Struct"]::after,
 a.struct[title="struct syn::token::Super"]::after,

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -376,6 +376,11 @@ pub trait Visit<'ast> {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_foreign_fn_safety(&mut self, i: &'ast crate::ForeignFnSafety) {
+        visit_foreign_fn_safety(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_foreign_item(&mut self, i: &'ast crate::ForeignItem) {
         visit_foreign_item(self, i);
     }
@@ -398,6 +403,11 @@ pub trait Visit<'ast> {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_foreign_item_type(&mut self, i: &'ast crate::ForeignItemType) {
         visit_foreign_item_type(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_foreign_signature(&mut self, i: &'ast crate::ForeignSignature) {
+        visit_foreign_signature(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -2118,6 +2128,22 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_foreign_fn_safety<'ast, V>(v: &mut V, node: &'ast crate::ForeignFnSafety)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    match node {
+        crate::ForeignFnSafety::Unsafe(_binding_0) => {
+            skip!(_binding_0);
+        }
+        crate::ForeignFnSafety::Safe(_binding_0) => {
+            skip!(_binding_0);
+        }
+        crate::ForeignFnSafety::None => {}
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn visit_foreign_item<'ast, V>(v: &mut V, node: &'ast crate::ForeignItem)
 where
     V: Visit<'ast> + ?Sized,
@@ -2150,7 +2176,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    v.visit_signature(&node.sig);
+    v.visit_foreign_signature(&node.sig);
     skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
@@ -2199,6 +2225,31 @@ where
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
     skip!(node.semi_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_foreign_signature<'ast, V>(v: &mut V, node: &'ast crate::ForeignSignature)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    skip!(node.constness);
+    skip!(node.asyncness);
+    v.visit_foreign_fn_safety(&node.safety);
+    if let Some(it) = &node.abi {
+        v.visit_abi(it);
+    }
+    skip!(node.fn_token);
+    v.visit_ident(&node.ident);
+    v.visit_generics(&node.generics);
+    skip!(node.paren_token);
+    for el in Punctuated::pairs(&node.inputs) {
+        let it = el.value();
+        v.visit_fn_arg(it);
+    }
+    if let Some(it) = &node.variadic {
+        v.visit_variadic(it);
+    }
+    v.visit_return_type(&node.output);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -386,6 +386,11 @@ pub trait VisitMut {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_foreign_fn_safety_mut(&mut self, i: &mut crate::ForeignFnSafety) {
+        visit_foreign_fn_safety_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_foreign_item_mut(&mut self, i: &mut crate::ForeignItem) {
         visit_foreign_item_mut(self, i);
     }
@@ -408,6 +413,11 @@ pub trait VisitMut {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_foreign_item_type_mut(&mut self, i: &mut crate::ForeignItemType) {
         visit_foreign_item_type_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_foreign_signature_mut(&mut self, i: &mut crate::ForeignSignature) {
+        visit_foreign_signature_mut(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -2032,6 +2042,22 @@ where
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_foreign_fn_safety_mut<V>(v: &mut V, node: &mut crate::ForeignFnSafety)
+where
+    V: VisitMut + ?Sized,
+{
+    match node {
+        crate::ForeignFnSafety::Unsafe(_binding_0) => {
+            skip!(_binding_0);
+        }
+        crate::ForeignFnSafety::Safe(_binding_0) => {
+            skip!(_binding_0);
+        }
+        crate::ForeignFnSafety::None => {}
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn visit_foreign_item_mut<V>(v: &mut V, node: &mut crate::ForeignItem)
 where
     V: VisitMut + ?Sized,
@@ -2062,7 +2088,7 @@ where
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_visibility_mut(&mut node.vis);
-    v.visit_signature_mut(&mut node.sig);
+    v.visit_foreign_signature_mut(&mut node.sig);
     skip!(node.semi_token);
 }
 #[cfg(feature = "full")]
@@ -2102,6 +2128,31 @@ where
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
     skip!(node.semi_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_foreign_signature_mut<V>(v: &mut V, node: &mut crate::ForeignSignature)
+where
+    V: VisitMut + ?Sized,
+{
+    skip!(node.constness);
+    skip!(node.asyncness);
+    v.visit_foreign_fn_safety_mut(&mut node.safety);
+    if let Some(it) = &mut node.abi {
+        v.visit_abi_mut(it);
+    }
+    skip!(node.fn_token);
+    v.visit_ident_mut(&mut node.ident);
+    v.visit_generics_mut(&mut node.generics);
+    skip!(node.paren_token);
+    for mut el in Punctuated::pairs_mut(&mut node.inputs) {
+        let it = el.value_mut();
+        v.visit_fn_arg_mut(it);
+    }
+    if let Some(it) = &mut node.variadic {
+        v.visit_variadic_mut(it);
+    }
+    v.visit_return_type_mut(&mut node.output);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,12 +426,13 @@ mod item;
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub use crate::item::{
-    FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
-    ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplRestriction, Item,
-    ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
-    ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
-    Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
-    TraitItemType, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree, Variadic,
+    FnArg, ForeignFnSafety, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic,
+    ForeignItemType, ForeignSignature, ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro,
+    ImplItemType, ImplRestriction, Item, ItemConst, ItemEnum, ItemExternCrate, ItemFn,
+    ItemForeignMod, ItemImpl, ItemMacro, ItemMod, ItemStatic, ItemStruct, ItemTrait,
+    ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver, Signature, StaticMutability, TraitItem,
+    TraitItemConst, TraitItemFn, TraitItemMacro, TraitItemType, UseGlob, UseGroup, UseName,
+    UsePath, UseRename, UseTree, Variadic,
 };
 
 mod lifetime;

--- a/src/token.rs
+++ b/src/token.rs
@@ -726,6 +726,7 @@ define_keywords! {
     "raw"         pub struct Raw
     "ref"         pub struct Ref
     "return"      pub struct Return
+    "safe"        pub struct Safe
     "Self"        pub struct SelfType
     "self"        pub struct SelfValue
     "static"      pub struct Static
@@ -905,6 +906,7 @@ macro_rules! Token {
     [raw]         => { $crate::token::Raw };
     [ref]         => { $crate::token::Ref };
     [return]      => { $crate::token::Return };
+    [safe]        => { $crate::token::Safe };
     [Self]        => { $crate::token::SelfType };
     [self]        => { $crate::token::SelfValue };
     [static]      => { $crate::token::Static };

--- a/syn.json
+++ b/syn.json
@@ -2193,6 +2193,27 @@
       }
     },
     {
+      "ident": "ForeignFnSafety",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "variants": {
+        "Unsafe": [
+          {
+            "token": "Unsafe"
+          }
+        ],
+        "Safe": [
+          {
+            "token": "Safe"
+          }
+        ],
+        "None": []
+      }
+    },
+    {
       "ident": "ForeignItem",
       "features": {
         "any": [
@@ -2245,7 +2266,7 @@
           "syn": "Visibility"
         },
         "sig": {
-          "syn": "Signature"
+          "syn": "ForeignSignature"
         },
         "semi_token": {
           "token": "Semi"
@@ -2340,6 +2361,62 @@
         },
         "semi_token": {
           "token": "Semi"
+        }
+      }
+    },
+    {
+      "ident": "ForeignSignature",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "constness": {
+          "option": {
+            "token": "Const"
+          }
+        },
+        "asyncness": {
+          "option": {
+            "token": "Async"
+          }
+        },
+        "safety": {
+          "syn": "ForeignFnSafety"
+        },
+        "abi": {
+          "option": {
+            "syn": "Abi"
+          }
+        },
+        "fn_token": {
+          "token": "Fn"
+        },
+        "ident": {
+          "proc_macro2": "Ident"
+        },
+        "generics": {
+          "syn": "Generics"
+        },
+        "paren_token": {
+          "group": "Paren"
+        },
+        "inputs": {
+          "punctuated": {
+            "element": {
+              "syn": "FnArg"
+            },
+            "punct": "Comma"
+          }
+        },
+        "variadic": {
+          "option": {
+            "syn": "Variadic"
+          }
+        },
+        "output": {
+          "syn": "ReturnType"
         }
       }
     },
@@ -5654,6 +5731,7 @@
     "Raw": "raw",
     "Ref": "ref",
     "Return": "return",
+    "Safe": "safe",
     "SelfType": "Self",
     "SelfValue": "self",
     "Semi": ";",

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -1901,6 +1901,21 @@ impl Debug for Lite<syn::FnArg> {
         }
     }
 }
+impl Debug for Lite<syn::ForeignFnSafety> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match &self.value {
+            syn::ForeignFnSafety::Unsafe(_val) => {
+                formatter.write_str("ForeignFnSafety::Unsafe")?;
+                Ok(())
+            }
+            syn::ForeignFnSafety::Safe(_val) => {
+                formatter.write_str("ForeignFnSafety::Safe")?;
+                Ok(())
+            }
+            syn::ForeignFnSafety::None => formatter.write_str("ForeignFnSafety::None"),
+        }
+    }
+}
 impl Debug for Lite<syn::ForeignItem> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match &self.value {
@@ -2012,6 +2027,58 @@ impl Debug for Lite<syn::ForeignItemType> {
         formatter.field("vis", Lite(&self.value.vis));
         formatter.field("ident", Lite(&self.value.ident));
         formatter.field("generics", Lite(&self.value.generics));
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::ForeignSignature> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ForeignSignature");
+        if self.value.constness.is_some() {
+            formatter.field("constness", &Present);
+        }
+        if self.value.asyncness.is_some() {
+            formatter.field("asyncness", &Present);
+        }
+        match self.value.safety {
+            syn::ForeignFnSafety::None => {}
+            _ => {
+                formatter.field("safety", Lite(&self.value.safety));
+            }
+        }
+        if let Some(val) = &self.value.abi {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::Abi);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some(")?;
+                    Debug::fmt(Lite(&self.0), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("abi", Print::ref_cast(val));
+        }
+        formatter.field("ident", Lite(&self.value.ident));
+        formatter.field("generics", Lite(&self.value.generics));
+        if !self.value.inputs.is_empty() {
+            formatter.field("inputs", Lite(&self.value.inputs));
+        }
+        if let Some(val) = &self.value.variadic {
+            #[derive(RefCast)]
+            #[repr(transparent)]
+            struct Print(syn::Variadic);
+            impl Debug for Print {
+                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("Some(")?;
+                    Debug::fmt(Lite(&self.0), formatter)?;
+                    formatter.write_str(")")?;
+                    Ok(())
+                }
+            }
+            formatter.field("variadic", Print::ref_cast(val));
+        }
+        formatter.field("output", Lite(&self.value.output));
         formatter.finish()
     }
 }
@@ -5095,6 +5162,11 @@ impl Debug for Lite<syn::token::Ref> {
 impl Debug for Lite<syn::token::Return> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("Token![return]")
+    }
+}
+impl Debug for Lite<syn::token::Safe> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Token![safe]")
     }
 }
 impl Debug for Lite<syn::token::SelfType> {


### PR DESCRIPTION
Currently when parsing a "safe fn" `syn` will represent this as a `ForeignItem::Verbatim`.
This makes it hard to use them in proc-macros. 

Right now `parse_signature` will return `Ok(Some(sig))` for signatures without the "safe" keyword. If the "safe" keyword is found it returns `Ok(None)` instead. 
If `None` is returned `ForeignItem::parse` will assume that the function signature contains the "safe" keyword and returns a `Verbatim`.

I see 2 possible solutions to improve this:
1. add `Option<Safe>` to `Signature`
2. change `parse_signature` to return `Ok(sig, Some(safe))` and store the "safe" keyword in the `ForeignItemFn`
3. Introduce a `ForeignSignature` that extends `Signature` with the optional safe keyword

There are some Pros/Cons to all 3 approaches
1. The "safe" keyword is only valid within an `extern` block so I am not sure if this is a good abstraction. However this would be the simplest to implement.
2. Still simple to implement, but it stores the "safe" keyword as a field on `ForeignItemFn` which means that there needs to be special handling in `ForeignItemFn::to_tokens` to ensure that the "safe"  keyword is inserted at the correct position.
3. This is the cleanest approach, as it properly represents valid rust code. However it is probably the solution with the most code. In any case I decided to implement this. Option 1 and 2 feel like hacks to me.

Open questions:
1. Are there any tests I should add for this. If so can you point me to an existing test that I could use to orient myself. I'm not sure I fully understand the test framework here.
2. I'm not sure how you handle versioning. This change changes the fields in `ForeignItemFn` and I guess that is a breaking change. However I can't imagine you release a breaking version change every time rust adds a new feature with new syntax. No idea how you want to handle something like this. 
