### PR TITLE
Enable GenericArgument::Constraint parsing in non-full mode

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -288,16 +288,13 @@ pub(crate) mod parsing {
     use crate::expr::ExprBlock;
     use crate::expr::{Expr, ExprPath};
     use crate::ext::IdentExt as _;
-    #[cfg(feature = "full")]
     use crate::generics::TypeParamBound;
     use crate::ident::Ident;
     use crate::lifetime::Lifetime;
     use crate::lit::Lit;
     use crate::parse::{Parse, ParseStream};
-    #[cfg(feature = "full")]
-    use crate::path::Constraint;
     use crate::path::{
-        AngleBracketedGenericArguments, AssocConst, AssocType, GenericArgument,
+        AngleBracketedGenericArguments, AssocConst, AssocType, Constraint, GenericArgument,
         ParenthesizedGenericArguments, Path, PathArguments, PathSegment, QSelf,
     };
     use crate::punctuated::Punctuated;
@@ -363,7 +360,6 @@ pub(crate) mod parsing {
                         };
                     }
 
-                    #[cfg(feature = "full")]
                     if let Some(colon_token) = input.parse::<Option<Token![:]>>()? {
                         let segment = ty.path.segments.pop().unwrap().into_value();
                         return Ok(GenericArgument::Constraint(Constraint {


### PR DESCRIPTION
The `where T: Trait<Assoc: Bound>` syntax was "full"-only while it was still unstable, but it has been stabilized since Rust 1.79. https://blog.rust-lang.org/2024/06/13/Rust-1.79.0/#bounds-in-associated-type-position

Closes https://github.com/serde-rs/serde/issues/3033.