### PR TITLE
Fix `self::` pattern in first function argument

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -1676,6 +1676,9 @@ pub(crate) mod parsing {
         };
         let mutability: Option<Token![mut]> = input.parse()?;
         let self_token: Token![self] = input.parse()?;
+        if input.peek(Token![::]) {
+            return Err(input.error("expected `:`"));
+        }
         Ok((reference, mutability, self_token))
     }
 


### PR DESCRIPTION
```console
error: expected one of: `for`, parentheses, `fn`, `unsafe`, `extern`, identifier, `::`, `<`, `dyn`, square brackets, `*`, `&`, `!`, `impl`, `_`, lifetime
 --> dev/main.rs:7:15
  |
7 |     fn f(self::S: S) {}
  |               ^
```