### PR TITLE
Convert TraitBoundModifier into non-exhaustive struct

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1830,7 +1830,7 @@ impl Clone for crate::TraitBound {
     fn clone(&self) -> Self {
         crate::TraitBound {
             paren_token: self.paren_token.clone(),
-            modifier: self.modifier.clone(),
+            modifiers: self.modifiers.clone(),
             lifetimes: self.lifetimes.clone(),
             path: self.path.clone(),
         }
@@ -1838,12 +1838,11 @@ impl Clone for crate::TraitBound {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
-impl Copy for crate::TraitBoundModifier {}
-#[cfg(any(feature = "derive", feature = "full"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
-impl Clone for crate::TraitBoundModifier {
+impl Clone for crate::TraitBoundModifiers {
     fn clone(&self) -> Self {
-        *self
+        crate::TraitBoundModifiers {
+            maybe: self.maybe.clone(),
+        }
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -2620,7 +2620,7 @@ impl Debug for crate::TraitBound {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("TraitBound");
         formatter.field("paren_token", &self.paren_token);
-        formatter.field("modifier", &self.modifier);
+        formatter.field("modifiers", &self.modifiers);
         formatter.field("lifetimes", &self.lifetimes);
         formatter.field("path", &self.path);
         formatter.finish()
@@ -2628,17 +2628,11 @@ impl Debug for crate::TraitBound {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Debug for crate::TraitBoundModifier {
+impl Debug for crate::TraitBoundModifiers {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("TraitBoundModifier::")?;
-        match self {
-            crate::TraitBoundModifier::None => formatter.write_str("None"),
-            crate::TraitBoundModifier::Maybe(v0) => {
-                let mut formatter = formatter.debug_tuple("Maybe");
-                formatter.field(v0);
-                formatter.finish()
-            }
-        }
+        let mut formatter = formatter.debug_struct("TraitBoundModifiers");
+        formatter.field("maybe", &self.maybe);
+        formatter.finish()
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1822,25 +1822,18 @@ impl Eq for crate::TraitBound {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::TraitBound {
     fn eq(&self, other: &Self) -> bool {
-        self.paren_token == other.paren_token && self.modifier == other.modifier
+        self.paren_token == other.paren_token && self.modifiers == other.modifiers
             && self.lifetimes == other.lifetimes && self.path == other.path
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Eq for crate::TraitBoundModifier {}
+impl Eq for crate::TraitBoundModifiers {}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl PartialEq for crate::TraitBoundModifier {
+impl PartialEq for crate::TraitBoundModifiers {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (crate::TraitBoundModifier::None, crate::TraitBoundModifier::None) => true,
-            (
-                crate::TraitBoundModifier::Maybe(_),
-                crate::TraitBoundModifier::Maybe(_),
-            ) => true,
-            _ => false,
-        }
+        self.maybe == other.maybe
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -830,11 +830,11 @@ pub trait Fold {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-    fn fold_trait_bound_modifier(
+    fn fold_trait_bound_modifiers(
         &mut self,
-        i: crate::TraitBoundModifier,
-    ) -> crate::TraitBoundModifier {
-        fold_trait_bound_modifier(self, i)
+        i: crate::TraitBoundModifiers,
+    ) -> crate::TraitBoundModifiers {
+        fold_trait_bound_modifiers(self, i)
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -3344,25 +3344,22 @@ where
 {
     crate::TraitBound {
         paren_token: node.paren_token,
-        modifier: f.fold_trait_bound_modifier(node.modifier),
+        modifiers: f.fold_trait_bound_modifiers(node.modifiers),
         lifetimes: (node.lifetimes).map(|it| f.fold_bound_lifetimes(it)),
         path: f.fold_path(node.path),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-pub fn fold_trait_bound_modifier<F>(
+pub fn fold_trait_bound_modifiers<F>(
     f: &mut F,
-    node: crate::TraitBoundModifier,
-) -> crate::TraitBoundModifier
+    node: crate::TraitBoundModifiers,
+) -> crate::TraitBoundModifiers
 where
     F: Fold + ?Sized,
 {
-    match node {
-        crate::TraitBoundModifier::None => crate::TraitBoundModifier::None,
-        crate::TraitBoundModifier::Maybe(_binding_0) => {
-            crate::TraitBoundModifier::Maybe(_binding_0)
-        }
+    crate::TraitBoundModifiers {
+        maybe: node.maybe,
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -2318,26 +2318,19 @@ impl Hash for crate::TraitBound {
         H: Hasher,
     {
         self.paren_token.hash(state);
-        self.modifier.hash(state);
+        self.modifiers.hash(state);
         self.lifetimes.hash(state);
         self.path.hash(state);
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Hash for crate::TraitBoundModifier {
+impl Hash for crate::TraitBoundModifiers {
     fn hash<H>(&self, state: &mut H)
     where
         H: Hasher,
     {
-        match self {
-            crate::TraitBoundModifier::None => {
-                state.write_u8(0u8);
-            }
-            crate::TraitBoundModifier::Maybe(_) => {
-                state.write_u8(1u8);
-            }
-        }
+        self.maybe.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -764,8 +764,8 @@ pub trait Visit<'ast> {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-    fn visit_trait_bound_modifier(&mut self, i: &'ast crate::TraitBoundModifier) {
-        visit_trait_bound_modifier(self, i);
+    fn visit_trait_bound_modifiers(&mut self, i: &'ast crate::TraitBoundModifiers) {
+        visit_trait_bound_modifiers(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -3395,7 +3395,7 @@ where
     V: Visit<'ast> + ?Sized,
 {
     skip!(node.paren_token);
-    v.visit_trait_bound_modifier(&node.modifier);
+    v.visit_trait_bound_modifiers(&node.modifiers);
     if let Some(it) = &node.lifetimes {
         v.visit_bound_lifetimes(it);
     }
@@ -3403,19 +3403,14 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-pub fn visit_trait_bound_modifier<'ast, V>(
+pub fn visit_trait_bound_modifiers<'ast, V>(
     v: &mut V,
-    node: &'ast crate::TraitBoundModifier,
+    node: &'ast crate::TraitBoundModifiers,
 )
 where
     V: Visit<'ast> + ?Sized,
 {
-    match node {
-        crate::TraitBoundModifier::None => {}
-        crate::TraitBoundModifier::Maybe(_binding_0) => {
-            skip!(_binding_0);
-        }
-    }
+    skip!(node.maybe);
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -774,8 +774,8 @@ pub trait VisitMut {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-    fn visit_trait_bound_modifier_mut(&mut self, i: &mut crate::TraitBoundModifier) {
-        visit_trait_bound_modifier_mut(self, i);
+    fn visit_trait_bound_modifiers_mut(&mut self, i: &mut crate::TraitBoundModifiers) {
+        visit_trait_bound_modifiers_mut(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -3232,7 +3232,7 @@ where
     V: VisitMut + ?Sized,
 {
     skip!(node.paren_token);
-    v.visit_trait_bound_modifier_mut(&mut node.modifier);
+    v.visit_trait_bound_modifiers_mut(&mut node.modifiers);
     if let Some(it) = &mut node.lifetimes {
         v.visit_bound_lifetimes_mut(it);
     }
@@ -3240,16 +3240,14 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-pub fn visit_trait_bound_modifier_mut<V>(v: &mut V, node: &mut crate::TraitBoundModifier)
+pub fn visit_trait_bound_modifiers_mut<V>(
+    v: &mut V,
+    node: &mut crate::TraitBoundModifiers,
+)
 where
     V: VisitMut + ?Sized,
 {
-    match node {
-        crate::TraitBoundModifier::None => {}
-        crate::TraitBoundModifier::Maybe(_binding_0) => {
-            skip!(_binding_0);
-        }
-    }
+    skip!(node.maybe);
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -413,7 +413,7 @@ ast_struct! {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TraitBound {
         pub paren_token: Option<token::Paren>,
-        pub modifier: TraitBoundModifier,
+        pub modifiers: TraitBoundModifiers,
         /// The `for<'a>` in `for<'a> Foo<&'a T>`
         pub lifetimes: Option<BoundLifetimes>,
         /// The `Foo<&'a T>` in `for<'a> Foo<&'a T>`
@@ -421,13 +421,19 @@ ast_struct! {
     }
 }
 
-ast_enum! {
+ast_struct! {
     /// A modifier on a trait bound, currently only used for the `?` in
     /// `?Sized`.
     #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
-    pub enum TraitBoundModifier {
-        None,
-        Maybe(Token![?]),
+    #[non_exhaustive]
+    pub struct TraitBoundModifiers {
+        pub maybe: Option<Token![?]>,
+    }
+}
+
+impl Default for TraitBoundModifiers {
+    fn default() -> Self {
+        TraitBoundModifiers { maybe: None }
     }
 }
 
@@ -521,7 +527,7 @@ pub(crate) mod parsing {
     use crate::ext::IdentExt as _;
     use crate::generics::{
         BoundLifetimes, ConstParam, GenericParam, Generics, LifetimeParam, PredicateLifetime,
-        PredicateType, TraitBound, TraitBoundModifier, TypeParam, TypeParamBound, WhereClause,
+        PredicateType, TraitBound, TraitBoundModifiers, TypeParam, TypeParamBound, WhereClause,
         WherePredicate,
     };
     #[cfg(feature = "full")]
@@ -858,8 +864,8 @@ pub(crate) mod parsing {
                 }
             }
 
-            let modifier: TraitBoundModifier = input.parse()?;
-            if lifetimes.is_none() && matches!(modifier, TraitBoundModifier::Maybe(_)) {
+            let maybe: Option<Token![?]> = input.parse()?;
+            if lifetimes.is_none() && maybe.is_some() {
                 lifetimes = input.parse()?;
             }
 
@@ -874,12 +880,9 @@ pub(crate) mod parsing {
             }
 
             if lifetimes.is_some() {
-                match modifier {
-                    TraitBoundModifier::None => {}
-                    TraitBoundModifier::Maybe(maybe) => {
-                        let msg = "`for<...>` binder not allowed with `?` trait polarity modifier";
-                        return Err(Error::new(maybe.span, msg));
-                    }
+                if let Some(maybe) = maybe {
+                    let msg = "`for<...>` binder not allowed with `?` trait polarity modifier";
+                    return Err(Error::new(maybe.span, msg));
                 }
             }
 
@@ -888,21 +891,10 @@ pub(crate) mod parsing {
             } else {
                 Ok(Some(TraitBound {
                     paren_token: None,
-                    modifier,
+                    modifiers: TraitBoundModifiers { maybe },
                     lifetimes,
                     path,
                 }))
-            }
-        }
-    }
-
-    #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
-    impl Parse for TraitBoundModifier {
-        fn parse(input: ParseStream) -> Result<Self> {
-            if input.peek(Token![?]) {
-                input.parse().map(TraitBoundModifier::Maybe)
-            } else {
-                Ok(TraitBoundModifier::None)
             }
         }
     }
@@ -1154,8 +1146,8 @@ pub(crate) mod printing {
     use crate::fixup::FixupContext;
     use crate::generics::{
         BoundLifetimes, ConstParam, GenericParam, Generics, ImplGenerics, LifetimeParam,
-        PredicateLifetime, PredicateType, TraitBound, TraitBoundModifier, Turbofish, TypeGenerics,
-        TypeParam, WhereClause,
+        PredicateLifetime, PredicateType, TraitBound, Turbofish, TypeGenerics, TypeParam,
+        WhereClause,
     };
     #[cfg(feature = "full")]
     use crate::generics::{CapturedParam, PreciseCapture};
@@ -1347,23 +1339,13 @@ pub(crate) mod printing {
     impl ToTokens for TraitBound {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             let to_tokens = |tokens: &mut TokenStream| {
-                self.modifier.to_tokens(tokens);
+                self.modifiers.maybe.to_tokens(tokens);
                 self.lifetimes.to_tokens(tokens);
                 self.path.to_tokens(tokens);
             };
             match &self.paren_token {
                 Some(paren) => paren.surround(tokens, to_tokens),
                 None => to_tokens(tokens),
-            }
-        }
-    }
-
-    #[cfg_attr(docsrs, doc(cfg(feature = "printing")))]
-    impl ToTokens for TraitBoundModifier {
-        fn to_tokens(&self, tokens: &mut TokenStream) {
-            match self {
-                TraitBoundModifier::None => {}
-                TraitBoundModifier::Maybe(t) => t.to_tokens(tokens),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ mod generics;
 #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
 pub use crate::generics::{
     BoundLifetimes, ConstParam, GenericParam, Generics, LifetimeParam, PredicateLifetime,
-    PredicateType, TraitBound, TraitBoundModifier, TypeParam, TypeParamBound, WhereClause,
+    PredicateType, TraitBound, TraitBoundModifiers, TypeParam, TypeParamBound, WhereClause,
     WherePredicate,
 };
 #[cfg(feature = "full")]

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -277,7 +277,7 @@ pub(crate) mod parsing {
     use crate::attr::Attribute;
     use crate::error::{self, Result};
     use crate::ext::IdentExt as _;
-    use crate::generics::{BoundLifetimes, TraitBound, TraitBoundModifier, TypeParamBound};
+    use crate::generics::{BoundLifetimes, TraitBound, TraitBoundModifiers, TypeParamBound};
     use crate::ident::Ident;
     use crate::lifetime::Lifetime;
     use crate::mac::{self, Macro};
@@ -445,7 +445,7 @@ pub(crate) mod parsing {
                         Type::Path(TypePath { qself: None, path }) => {
                             TypeParamBound::Trait(TraitBound {
                                 paren_token: Some(paren_token),
-                                modifier: TraitBoundModifier::None,
+                                modifiers: TraitBoundModifiers::default(),
                                 lifetimes: None,
                                 path,
                             })
@@ -549,7 +549,7 @@ pub(crate) mod parsing {
                 let mut bounds = Punctuated::new();
                 bounds.push_value(TypeParamBound::Trait(TraitBound {
                     paren_token: None,
-                    modifier: TraitBoundModifier::None,
+                    modifiers: TraitBoundModifiers::default(),
                     lifetimes,
                     path: ty.path,
                 }));

--- a/syn.json
+++ b/syn.json
@@ -4575,8 +4575,8 @@
             "group": "Paren"
           }
         },
-        "modifier": {
-          "syn": "TraitBoundModifier"
+        "modifiers": {
+          "syn": "TraitBoundModifiers"
         },
         "lifetimes": {
           "option": {
@@ -4589,21 +4589,21 @@
       }
     },
     {
-      "ident": "TraitBoundModifier",
+      "ident": "TraitBoundModifiers",
       "features": {
         "any": [
           "derive",
           "full"
         ]
       },
-      "variants": {
-        "None": [],
-        "Maybe": [
-          {
+      "fields": {
+        "maybe": {
+          "option": {
             "token": "Question"
           }
-        ]
-      }
+        }
+      },
+      "exhaustive": false
     },
     {
       "ident": "TraitItem",

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -3857,12 +3857,7 @@ impl Debug for Lite<syn::TraitBound> {
         if self.value.paren_token.is_some() {
             formatter.field("paren_token", &Present);
         }
-        match self.value.modifier {
-            syn::TraitBoundModifier::None => {}
-            _ => {
-                formatter.field("modifier", Lite(&self.value.modifier));
-            }
-        }
+        formatter.field("modifiers", Lite(&self.value.modifiers));
         if let Some(val) = &self.value.lifetimes {
             #[derive(RefCast)]
             #[repr(transparent)]
@@ -3881,17 +3876,13 @@ impl Debug for Lite<syn::TraitBound> {
         formatter.finish()
     }
 }
-impl Debug for Lite<syn::TraitBoundModifier> {
+impl Debug for Lite<syn::TraitBoundModifiers> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match &self.value {
-            syn::TraitBoundModifier::None => {
-                formatter.write_str("TraitBoundModifier::None")
-            }
-            syn::TraitBoundModifier::Maybe(_val) => {
-                formatter.write_str("TraitBoundModifier::Maybe")?;
-                Ok(())
-            }
+        let mut formatter = formatter.debug_struct("TraitBoundModifiers");
+        if self.value.maybe.is_some() {
+            formatter.field("maybe", &Present);
         }
+        formatter.finish()
     }
 }
 impl Debug for Lite<syn::TraitItem> {

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -87,6 +87,7 @@ fn test_split_for_impl() {
                         },
                         bounds: [
                             TypeParamBound::Trait(TraitBound {
+                                modifiers: TraitBoundModifiers,
                                 path: Path {
                                     segments: [
                                         PathSegment {
@@ -151,6 +152,7 @@ fn test_type_param_bound() {
     let tokens = quote!(Debug);
     snapshot!(tokens as TypeParamBound, @r#"
     TypeParamBound::Trait(TraitBound {
+        modifiers: TraitBoundModifiers,
         path: Path {
             segments: [
                 PathSegment {
@@ -164,7 +166,9 @@ fn test_type_param_bound() {
     let tokens = quote!(?Sized);
     snapshot!(tokens as TypeParamBound, @r#"
     TypeParamBound::Trait(TraitBound {
-        modifier: TraitBoundModifier::Maybe,
+        modifiers: TraitBoundModifiers {
+            maybe: Some,
+        },
         path: Path {
             segments: [
                 PathSegment {
@@ -178,6 +182,7 @@ fn test_type_param_bound() {
     let tokens = quote!(for<'a> Trait);
     snapshot!(tokens as TypeParamBound, @r#"
     TypeParamBound::Trait(TraitBound {
+        modifiers: TraitBoundModifiers,
         lifetimes: Some(BoundLifetimes {
             lifetimes: [
                 GenericParam::Lifetime(LifetimeParam {
@@ -251,6 +256,7 @@ fn test_fn_precedence_in_where_clause() {
                             },
                             bounds: [
                                 TypeParamBound::Trait(TraitBound {
+                                    modifiers: TraitBoundModifiers,
                                     path: Path {
                                         segments: [
                                             PathSegment {
@@ -274,6 +280,7 @@ fn test_fn_precedence_in_where_clause() {
                                 }),
                                 Token![+],
                                 TypeParamBound::Trait(TraitBound {
+                                    modifiers: TraitBoundModifiers,
                                     path: Path {
                                         segments: [
                                             PathSegment {

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -184,6 +184,7 @@ fn test_supertraits() {
         colon_token: Some,
         supertraits: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {
@@ -208,6 +209,7 @@ fn test_supertraits() {
         colon_token: Some,
         supertraits: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {
@@ -297,6 +299,7 @@ fn test_impl_trait_trailing_plus() {
                 Type::ImplTrait {
                     bounds: [
                         TypeParamBound::Trait(TraitBound {
+                            modifiers: TraitBoundModifiers,
                             path: Path {
                                 segments: [
                                     PathSegment {

--- a/tests/test_path.rs
+++ b/tests/test_path.rs
@@ -97,6 +97,7 @@ fn parse_parenthesized_path_arguments_with_disambiguator() {
         dyn_token: Some,
         bounds: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -229,6 +229,7 @@ fn test_trait_object() {
         dyn_token: Some,
         bounds: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 lifetimes: Some(BoundLifetimes {
                     lifetimes: [
                         GenericParam::Lifetime(LifetimeParam {
@@ -271,6 +272,7 @@ fn test_trait_object() {
             },
             Token![+],
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {
@@ -296,6 +298,7 @@ fn test_trailing_plus() {
     Type::ImplTrait {
         bounds: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {
@@ -316,6 +319,7 @@ fn test_trailing_plus() {
         dyn_token: Some,
         bounds: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {
@@ -335,6 +339,7 @@ fn test_trailing_plus() {
     Type::TraitObject {
         bounds: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {
@@ -412,6 +417,7 @@ fn test_impl_trait_use() {
     Type::ImplTrait {
         bounds: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {
@@ -448,6 +454,7 @@ fn test_impl_trait_use() {
     Type::ImplTrait {
         bounds: [
             TypeParamBound::Trait(TraitBound {
+                modifiers: TraitBoundModifiers,
                 path: Path {
                     segments: [
                         PathSegment {


### PR DESCRIPTION
This creates space for future syntax for async bounds (https://github.com/dtolnay/syn/issues/1628), const bounds (https://github.com/dtolnay/syn/issues/1761), maybe const bounds, const-if-const bounds, etc.

The commonality of `modifiers` (which are going to be added in some other types) is that they do not implement Parse, do not implement ToTokens, and do implement Default with the default value corresponding to no tokens.