### PR TITLE
Move auto and restrictions into TraitModifiers

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1065,13 +1065,6 @@ impl Clone for crate::ImplItemType {
         }
     }
 }
-#[cfg(feature = "full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
-impl Clone for crate::ImplRestriction {
-    fn clone(&self) -> Self {
-        match *self {}
-    }
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::Index {
@@ -1263,9 +1256,8 @@ impl Clone for crate::ItemTrait {
         crate::ItemTrait {
             attrs: self.attrs.clone(),
             vis: self.vis.clone(),
+            modifiers: self.modifiers.clone(),
             unsafety: self.unsafety.clone(),
-            auto_token: self.auto_token.clone(),
-            restriction: self.restriction.clone(),
             trait_token: self.trait_token.clone(),
             ident: self.ident.clone(),
             generics: self.generics.clone(),
@@ -1910,6 +1902,15 @@ impl Clone for crate::TraitItemType {
             bounds: self.bounds.clone(),
             default: self.default.clone(),
             semi_token: self.semi_token.clone(),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::TraitModifiers {
+    fn clone(&self) -> Self {
+        crate::TraitModifiers {
+            auto_token: self.auto_token.clone(),
         }
     }
 }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1588,13 +1588,6 @@ impl crate::ImplItemType {
         formatter.finish()
     }
 }
-#[cfg(feature = "full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Debug for crate::ImplRestriction {
-    fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
-        match *self {}
-    }
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::Index {
@@ -1857,9 +1850,8 @@ impl crate::ItemTrait {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("attrs", &self.attrs);
         formatter.field("vis", &self.vis);
+        formatter.field("modifiers", &self.modifiers);
         formatter.field("unsafety", &self.unsafety);
-        formatter.field("auto_token", &self.auto_token);
-        formatter.field("restriction", &self.restriction);
         formatter.field("trait_token", &self.trait_token);
         formatter.field("ident", &self.ident);
         formatter.field("generics", &self.generics);
@@ -2729,6 +2721,15 @@ impl crate::TraitItemType {
         formatter.field("bounds", &self.bounds);
         formatter.field("default", &self.default);
         formatter.field("semi_token", &self.semi_token);
+        formatter.finish()
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::TraitModifiers {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("TraitModifiers");
+        formatter.field("auto_token", &self.auto_token);
         formatter.finish()
     }
 }

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1088,16 +1088,6 @@ impl PartialEq for crate::ImplItemType {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Eq for crate::ImplRestriction {}
-#[cfg(feature = "full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl PartialEq for crate::ImplRestriction {
-    fn eq(&self, _other: &Self) -> bool {
-        match *self {}
-    }
-}
-#[cfg(feature = "full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::Item {}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
@@ -1256,9 +1246,9 @@ impl Eq for crate::ItemTrait {}
 impl PartialEq for crate::ItemTrait {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis
-            && self.unsafety == other.unsafety && self.auto_token == other.auto_token
-            && self.restriction == other.restriction && self.ident == other.ident
-            && self.generics == other.generics && self.colon_token == other.colon_token
+            && self.modifiers == other.modifiers && self.unsafety == other.unsafety
+            && self.ident == other.ident && self.generics == other.generics
+            && self.colon_token == other.colon_token
             && self.supertraits == other.supertraits && self.items == other.items
     }
 }
@@ -1907,6 +1897,16 @@ impl PartialEq for crate::TraitItemType {
         self.attrs == other.attrs && self.ident == other.ident
             && self.generics == other.generics && self.colon_token == other.colon_token
             && self.bounds == other.bounds && self.default == other.default
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::TraitModifiers {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::TraitModifiers {
+    fn eq(&self, other: &Self) -> bool {
+        self.auto_token == other.auto_token
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -471,14 +471,6 @@ pub trait Fold {
     fn fold_impl_item_type(&mut self, i: crate::ImplItemType) -> crate::ImplItemType {
         fold_impl_item_type(self, i)
     }
-    #[cfg(feature = "full")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-    fn fold_impl_restriction(
-        &mut self,
-        i: crate::ImplRestriction,
-    ) -> crate::ImplRestriction {
-        fold_impl_restriction(self, i)
-    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn fold_index(&mut self, i: crate::Index) -> crate::Index {
@@ -866,6 +858,14 @@ pub trait Fold {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_trait_item_type(&mut self, i: crate::TraitItemType) -> crate::TraitItemType {
         fold_trait_item_type(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_trait_modifiers(
+        &mut self,
+        i: crate::TraitModifiers,
+    ) -> crate::TraitModifiers {
+        fold_trait_modifiers(self, i)
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -2341,17 +2341,6 @@ where
         semi_token: node.semi_token,
     }
 }
-#[cfg(feature = "full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-pub fn fold_impl_restriction<F>(
-    f: &mut F,
-    node: crate::ImplRestriction,
-) -> crate::ImplRestriction
-where
-    F: Fold + ?Sized,
-{
-    match node {}
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn fold_index<F>(f: &mut F, node: crate::Index) -> crate::Index
@@ -2583,9 +2572,8 @@ where
     crate::ItemTrait {
         attrs: f.fold_attributes(node.attrs),
         vis: f.fold_visibility(node.vis),
+        modifiers: f.fold_trait_modifiers(node.modifiers),
         unsafety: node.unsafety,
-        auto_token: node.auto_token,
-        restriction: (node.restriction).map(|it| f.fold_impl_restriction(it)),
         trait_token: node.trait_token,
         ident: f.fold_ident(node.ident),
         generics: f.fold_generics(node.generics),
@@ -3452,6 +3440,19 @@ where
         bounds: crate::punctuated::fold(node.bounds, f, F::fold_type_param_bound),
         default: (node.default).map(|it| ((it).0, f.fold_type((it).1))),
         semi_token: node.semi_token,
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_trait_modifiers<F>(
+    f: &mut F,
+    node: crate::TraitModifiers,
+) -> crate::TraitModifiers
+where
+    F: Fold + ?Sized,
+{
+    crate::TraitModifiers {
+        auto_token: node.auto_token,
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1382,16 +1382,6 @@ impl Hash for crate::ImplItemType {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Hash for crate::ImplRestriction {
-    fn hash<H>(&self, _state: &mut H)
-    where
-        H: Hasher,
-    {
-        match *self {}
-    }
-}
-#[cfg(feature = "full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::Item {
     fn hash<H>(&self, state: &mut H)
     where
@@ -1616,9 +1606,8 @@ impl Hash for crate::ItemTrait {
     {
         self.attrs.hash(state);
         self.vis.hash(state);
+        self.modifiers.hash(state);
         self.unsafety.hash(state);
-        self.auto_token.hash(state);
-        self.restriction.hash(state);
         self.ident.hash(state);
         self.generics.hash(state);
         self.colon_token.hash(state);
@@ -2416,6 +2405,16 @@ impl Hash for crate::TraitItemType {
         self.colon_token.hash(state);
         self.bounds.hash(state);
         self.default.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::TraitModifiers {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.auto_token.hash(state);
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -442,11 +442,6 @@ pub trait Visit<'ast> {
     fn visit_impl_item_type(&mut self, i: &'ast crate::ImplItemType) {
         visit_impl_item_type(self, i);
     }
-    #[cfg(feature = "full")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-    fn visit_impl_restriction(&mut self, i: &'ast crate::ImplRestriction) {
-        visit_impl_restriction(self, i);
-    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_index(&mut self, i: &'ast crate::Index) {
@@ -791,6 +786,11 @@ pub trait Visit<'ast> {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_trait_item_type(&mut self, i: &'ast crate::TraitItemType) {
         visit_trait_item_type(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_trait_modifiers(&mut self, i: &'ast crate::TraitModifiers) {
+        visit_trait_modifiers(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -2355,14 +2355,6 @@ where
     v.visit_type(&node.ty);
     skip!(node.semi_token);
 }
-#[cfg(feature = "full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-pub fn visit_impl_restriction<'ast, V>(v: &mut V, node: &'ast crate::ImplRestriction)
-where
-    V: Visit<'ast> + ?Sized,
-{
-    match *node {}
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_index<'ast, V>(v: &mut V, node: &'ast crate::Index)
@@ -2620,11 +2612,8 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
+    v.visit_trait_modifiers(&node.modifiers);
     skip!(node.unsafety);
-    skip!(node.auto_token);
-    if let Some(it) = &node.restriction {
-        v.visit_impl_restriction(it);
-    }
     skip!(node.trait_token);
     v.visit_ident(&node.ident);
     v.visit_generics(&node.generics);
@@ -3505,6 +3494,14 @@ where
         v.visit_type(&(it).1);
     }
     skip!(node.semi_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_trait_modifiers<'ast, V>(v: &mut V, node: &'ast crate::TraitModifiers)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    skip!(node.auto_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -452,11 +452,6 @@ pub trait VisitMut {
     fn visit_impl_item_type_mut(&mut self, i: &mut crate::ImplItemType) {
         visit_impl_item_type_mut(self, i);
     }
-    #[cfg(feature = "full")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-    fn visit_impl_restriction_mut(&mut self, i: &mut crate::ImplRestriction) {
-        visit_impl_restriction_mut(self, i);
-    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_index_mut(&mut self, i: &mut crate::Index) {
@@ -801,6 +796,11 @@ pub trait VisitMut {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_trait_item_type_mut(&mut self, i: &mut crate::TraitItemType) {
         visit_trait_item_type_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_trait_modifiers_mut(&mut self, i: &mut crate::TraitModifiers) {
+        visit_trait_modifiers_mut(self, i);
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
@@ -2252,14 +2252,6 @@ where
     v.visit_type_mut(&mut node.ty);
     skip!(node.semi_token);
 }
-#[cfg(feature = "full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-pub fn visit_impl_restriction_mut<V>(v: &mut V, node: &mut crate::ImplRestriction)
-where
-    V: VisitMut + ?Sized,
-{
-    match *node {}
-}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_index_mut<V>(v: &mut V, node: &mut crate::Index)
@@ -2495,11 +2487,8 @@ where
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_visibility_mut(&mut node.vis);
+    v.visit_trait_modifiers_mut(&mut node.modifiers);
     skip!(node.unsafety);
-    skip!(node.auto_token);
-    if let Some(it) = &mut node.restriction {
-        v.visit_impl_restriction_mut(it);
-    }
     skip!(node.trait_token);
     v.visit_ident_mut(&mut node.ident);
     v.visit_generics_mut(&mut node.generics);
@@ -3334,6 +3323,14 @@ where
         v.visit_type_mut(&mut (it).1);
     }
     skip!(node.semi_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_trait_modifiers_mut<V>(v: &mut V, node: &mut crate::TraitModifiers)
+where
+    V: VisitMut + ?Sized,
+{
+    skip!(node.auto_token);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]

--- a/src/item.rs
+++ b/src/item.rs
@@ -250,9 +250,8 @@ ast_struct! {
     pub struct ItemTrait {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
+        pub modifiers: TraitModifiers,
         pub unsafety: Option<Token![unsafe]>,
-        pub auto_token: Option<Token![auto]>,
-        pub restriction: Option<ImplRestriction>,
         pub trait_token: Token![trait],
         pub ident: Ident,
         pub generics: Generics,
@@ -260,6 +259,22 @@ ast_struct! {
         pub supertraits: Punctuated<TypeParamBound, Token![+]>,
         pub brace_token: token::Brace,
         pub items: Vec<TraitItem>,
+    }
+}
+
+ast_struct! {
+    /// Information about constness, auto, and impl restrictions on a `trait`
+    /// item.
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    #[non_exhaustive]
+    pub struct TraitModifiers {
+        pub auto_token: Option<Token![auto]>,
+    }
+}
+
+impl Default for TraitModifiers {
+    fn default() -> Self {
+        TraitModifiers { auto_token: None }
     }
 }
 
@@ -887,23 +902,6 @@ ast_enum! {
     }
 }
 
-ast_enum! {
-    /// Unused, but reserved for RFC 3323 restrictions.
-    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
-    #[non_exhaustive]
-    pub enum ImplRestriction {}
-
-
-    // TODO: https://rust-lang.github.io/rfcs/3323-restrictions.html
-    //
-    // pub struct ImplRestriction {
-    //     pub impl_token: Token![impl],
-    //     pub paren_token: token::Paren,
-    //     pub in_token: Option<Token![in]>,
-    //     pub path: Box<Path>,
-    // }
-}
-
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::{self, Attribute};
@@ -920,7 +918,8 @@ pub(crate) mod parsing {
         ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
         ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
         Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
-        TraitItemType, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree, Variadic,
+        TraitItemType, TraitModifiers, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree,
+        Variadic,
     };
     use crate::lifetime::Lifetime;
     use crate::lit::LitStr;
@@ -2290,9 +2289,8 @@ pub(crate) mod parsing {
         Ok(ItemTrait {
             attrs,
             vis,
+            modifiers: TraitModifiers { auto_token },
             unsafety,
-            auto_token,
-            restriction: None,
             trait_token,
             ident,
             generics,
@@ -3176,7 +3174,7 @@ mod printing {
             tokens.append_all(self.attrs.outer());
             self.vis.to_tokens(tokens);
             self.unsafety.to_tokens(tokens);
-            self.auto_token.to_tokens(tokens);
+            self.modifiers.auto_token.to_tokens(tokens);
             self.trait_token.to_tokens(tokens);
             self.ident.to_tokens(tokens);
             self.generics.to_tokens(tokens);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,11 +428,11 @@ mod item;
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub use crate::item::{
     FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
-    ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplRestriction, Item,
-    ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
-    ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
-    Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
-    TraitItemType, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree, Variadic,
+    ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, Item, ItemConst, ItemEnum,
+    ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod, ItemStatic, ItemStruct,
+    ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver, Signature, StaticMutability,
+    TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro, TraitItemType, TraitModifiers, UseGlob,
+    UseGroup, UseName, UsePath, UseRename, UseTree, Variadic,
 };
 
 mod lifetime;

--- a/syn.json
+++ b/syn.json
@@ -2622,16 +2622,6 @@
       }
     },
     {
-      "ident": "ImplRestriction",
-      "features": {
-        "any": [
-          "full"
-        ]
-      },
-      "variants": {},
-      "exhaustive": false
-    },
-    {
       "ident": "Index",
       "features": {
         "any": [
@@ -3156,19 +3146,12 @@
         "vis": {
           "syn": "Visibility"
         },
+        "modifiers": {
+          "syn": "TraitModifiers"
+        },
         "unsafety": {
           "option": {
             "token": "Unsafe"
-          }
-        },
-        "auto_token": {
-          "option": {
-            "token": "Auto"
-          }
-        },
-        "restriction": {
-          "option": {
-            "syn": "ImplRestriction"
           }
         },
         "trait_token": {
@@ -4788,6 +4771,22 @@
           "token": "Semi"
         }
       }
+    },
+    {
+      "ident": "TraitModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "auto_token": {
+          "option": {
+            "token": "Auto"
+          }
+        }
+      },
+      "exhaustive": false
     },
     {
       "ident": "Type",

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -2247,11 +2247,6 @@ impl Debug for Lite<syn::ImplItemType> {
         formatter.finish()
     }
 }
-impl Debug for Lite<syn::ImplRestriction> {
-    fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
-        unreachable!()
-    }
-}
 impl Debug for Lite<syn::Index> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("Index");
@@ -2465,25 +2460,9 @@ impl Debug for Lite<syn::Item> {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
                 formatter.field("vis", Lite(&_val.vis));
+                formatter.field("modifiers", Lite(&_val.modifiers));
                 if _val.unsafety.is_some() {
                     formatter.field("unsafety", &Present);
-                }
-                if _val.auto_token.is_some() {
-                    formatter.field("auto_token", &Present);
-                }
-                if let Some(val) = &_val.restriction {
-                    #[derive(RefCast)]
-                    #[repr(transparent)]
-                    struct Print(syn::ImplRestriction);
-                    impl Debug for Print {
-                        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                            formatter.write_str("Some(")?;
-                            Debug::fmt(Lite(&self.0), formatter)?;
-                            formatter.write_str(")")?;
-                            Ok(())
-                        }
-                    }
-                    formatter.field("restriction", Print::ref_cast(val));
                 }
                 formatter.field("ident", Lite(&_val.ident));
                 formatter.field("generics", Lite(&_val.generics));
@@ -2780,25 +2759,9 @@ impl Debug for Lite<syn::ItemTrait> {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
         formatter.field("vis", Lite(&self.value.vis));
+        formatter.field("modifiers", Lite(&self.value.modifiers));
         if self.value.unsafety.is_some() {
             formatter.field("unsafety", &Present);
-        }
-        if self.value.auto_token.is_some() {
-            formatter.field("auto_token", &Present);
-        }
-        if let Some(val) = &self.value.restriction {
-            #[derive(RefCast)]
-            #[repr(transparent)]
-            struct Print(syn::ImplRestriction);
-            impl Debug for Print {
-                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("Some(")?;
-                    Debug::fmt(Lite(&self.0), formatter)?;
-                    formatter.write_str(")")?;
-                    Ok(())
-                }
-            }
-            formatter.field("restriction", Print::ref_cast(val));
         }
         formatter.field("ident", Lite(&self.value.ident));
         formatter.field("generics", Lite(&self.value.generics));
@@ -4081,6 +4044,15 @@ impl Debug for Lite<syn::TraitItemType> {
                 }
             }
             formatter.field("default", Print::ref_cast(val));
+        }
+        formatter.finish()
+    }
+}
+impl Debug for Lite<syn::TraitModifiers> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("TraitModifiers");
+        if self.value.auto_token.is_some() {
+            formatter.field("auto_token", &Present);
         }
         formatter.finish()
     }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -152,6 +152,7 @@ fn test_supertraits() {
     snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
+        modifiers: TraitModifiers,
         ident: "Trait",
         generics: Generics {
             where_clause: Some(WhereClause),
@@ -164,6 +165,7 @@ fn test_supertraits() {
     snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
+        modifiers: TraitModifiers,
         ident: "Trait",
         generics: Generics {
             where_clause: Some(WhereClause),
@@ -177,6 +179,7 @@ fn test_supertraits() {
     snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
+        modifiers: TraitModifiers,
         ident: "Trait",
         generics: Generics {
             where_clause: Some(WhereClause),
@@ -202,6 +205,7 @@ fn test_supertraits() {
     snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
+        modifiers: TraitModifiers,
         ident: "Trait",
         generics: Generics {
             where_clause: Some(WhereClause),
@@ -236,6 +240,7 @@ fn test_type_empty_bounds() {
     snapshot!(tokens as ItemTrait, @r#"
     ItemTrait {
         vis: Visibility::Inherited,
+        modifiers: TraitModifiers,
         ident: "Foo",
         generics: Generics,
         items: [


### PR DESCRIPTION
Creates space for future syntax for const trait (https://github.com/dtolnay/syn/issues/1887) and impl restrictions (https://github.com/dtolnay/syn/issues/1982).