### PR TITLE
Move defaultness and polarity into ImplModifiers

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1065,6 +1065,16 @@ impl Clone for crate::ImplItemType {
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::ImplModifiers {
+    fn clone(&self) -> Self {
+        crate::ImplModifiers {
+            defaultness: self.defaultness.clone(),
+            polarity: self.polarity.clone(),
+        }
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::Index {
@@ -1178,7 +1188,7 @@ impl Clone for crate::ItemImpl {
     fn clone(&self) -> Self {
         crate::ItemImpl {
             attrs: self.attrs.clone(),
-            defaultness: self.defaultness.clone(),
+            modifiers: self.modifiers.clone(),
             unsafety: self.unsafety.clone(),
             impl_token: self.impl_token.clone(),
             generics: self.generics.clone(),

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1588,6 +1588,16 @@ impl crate::ImplItemType {
         formatter.finish()
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::ImplModifiers {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ImplModifiers");
+        formatter.field("defaultness", &self.defaultness);
+        formatter.field("polarity", &self.polarity);
+        formatter.finish()
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::Index {
@@ -1742,7 +1752,7 @@ impl crate::ItemImpl {
     fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("attrs", &self.attrs);
-        formatter.field("defaultness", &self.defaultness);
+        formatter.field("modifiers", &self.modifiers);
         formatter.field("unsafety", &self.unsafety);
         formatter.field("impl_token", &self.impl_token);
         formatter.field("generics", &self.generics);

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1088,6 +1088,16 @@ impl PartialEq for crate::ImplItemType {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::ImplModifiers {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::ImplModifiers {
+    fn eq(&self, other: &Self) -> bool {
+        self.defaultness == other.defaultness && self.polarity == other.polarity
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::Item {}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
@@ -1185,7 +1195,7 @@ impl Eq for crate::ItemImpl {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::ItemImpl {
     fn eq(&self, other: &Self) -> bool {
-        self.attrs == other.attrs && self.defaultness == other.defaultness
+        self.attrs == other.attrs && self.modifiers == other.modifiers
             && self.unsafety == other.unsafety && self.generics == other.generics
             && self.trait_ == other.trait_ && self.self_ty == other.self_ty
             && self.items == other.items

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -471,6 +471,11 @@ pub trait Fold {
     fn fold_impl_item_type(&mut self, i: crate::ImplItemType) -> crate::ImplItemType {
         fold_impl_item_type(self, i)
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_impl_modifiers(&mut self, i: crate::ImplModifiers) -> crate::ImplModifiers {
+        fold_impl_modifiers(self, i)
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn fold_index(&mut self, i: crate::Index) -> crate::Index {
@@ -2341,6 +2346,20 @@ where
         semi_token: node.semi_token,
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_impl_modifiers<F>(
+    f: &mut F,
+    node: crate::ImplModifiers,
+) -> crate::ImplModifiers
+where
+    F: Fold + ?Sized,
+{
+    crate::ImplModifiers {
+        defaultness: node.defaultness,
+        polarity: node.polarity,
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn fold_index<F>(f: &mut F, node: crate::Index) -> crate::Index
@@ -2489,11 +2508,11 @@ where
 {
     crate::ItemImpl {
         attrs: f.fold_attributes(node.attrs),
-        defaultness: node.defaultness,
+        modifiers: f.fold_impl_modifiers(node.modifiers),
         unsafety: node.unsafety,
         impl_token: node.impl_token,
         generics: f.fold_generics(node.generics),
-        trait_: (node.trait_).map(|it| ((it).0, f.fold_path((it).1), (it).2)),
+        trait_: (node.trait_).map(|it| (f.fold_path((it).0), (it).1)),
         self_ty: Box::new(f.fold_type(*node.self_ty)),
         brace_token: node.brace_token,
         items: fold_vec(node.items, f, F::fold_impl_item),

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1382,6 +1382,17 @@ impl Hash for crate::ImplItemType {
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::ImplModifiers {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.defaultness.hash(state);
+        self.polarity.hash(state);
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::Item {
     fn hash<H>(&self, state: &mut H)
     where
@@ -1531,7 +1542,7 @@ impl Hash for crate::ItemImpl {
         H: Hasher,
     {
         self.attrs.hash(state);
-        self.defaultness.hash(state);
+        self.modifiers.hash(state);
         self.unsafety.hash(state);
         self.generics.hash(state);
         self.trait_.hash(state);

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -442,6 +442,11 @@ pub trait Visit<'ast> {
     fn visit_impl_item_type(&mut self, i: &'ast crate::ImplItemType) {
         visit_impl_item_type(self, i);
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_impl_modifiers(&mut self, i: &'ast crate::ImplModifiers) {
+        visit_impl_modifiers(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_index(&mut self, i: &'ast crate::Index) {
@@ -2355,6 +2360,15 @@ where
     v.visit_type(&node.ty);
     skip!(node.semi_token);
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_impl_modifiers<'ast, V>(v: &mut V, node: &'ast crate::ImplModifiers)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    skip!(node.defaultness);
+    skip!(node.polarity);
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_index<'ast, V>(v: &mut V, node: &'ast crate::Index)
@@ -2516,14 +2530,13 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
-    skip!(node.defaultness);
+    v.visit_impl_modifiers(&node.modifiers);
     skip!(node.unsafety);
     skip!(node.impl_token);
     v.visit_generics(&node.generics);
     if let Some(it) = &node.trait_ {
-        skip!((it).0);
-        v.visit_path(&(it).1);
-        skip!((it).2);
+        v.visit_path(&(it).0);
+        skip!((it).1);
     }
     v.visit_type(&*node.self_ty);
     skip!(node.brace_token);

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -452,6 +452,11 @@ pub trait VisitMut {
     fn visit_impl_item_type_mut(&mut self, i: &mut crate::ImplItemType) {
         visit_impl_item_type_mut(self, i);
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_impl_modifiers_mut(&mut self, i: &mut crate::ImplModifiers) {
+        visit_impl_modifiers_mut(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_index_mut(&mut self, i: &mut crate::Index) {
@@ -2252,6 +2257,15 @@ where
     v.visit_type_mut(&mut node.ty);
     skip!(node.semi_token);
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_impl_modifiers_mut<V>(v: &mut V, node: &mut crate::ImplModifiers)
+where
+    V: VisitMut + ?Sized,
+{
+    skip!(node.defaultness);
+    skip!(node.polarity);
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_index_mut<V>(v: &mut V, node: &mut crate::Index)
@@ -2401,14 +2415,13 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_attributes_mut(&mut node.attrs);
-    skip!(node.defaultness);
+    v.visit_impl_modifiers_mut(&mut node.modifiers);
     skip!(node.unsafety);
     skip!(node.impl_token);
     v.visit_generics_mut(&mut node.generics);
     if let Some(it) = &mut node.trait_ {
-        skip!((it).0);
-        v.visit_path_mut(&mut (it).1);
-        skip!((it).2);
+        v.visit_path_mut(&mut (it).0);
+        skip!((it).1);
     }
     v.visit_type_mut(&mut *node.self_ty);
     skip!(node.brace_token);

--- a/src/item.rs
+++ b/src/item.rs
@@ -174,16 +174,36 @@ ast_struct! {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     pub struct ItemImpl {
         pub attrs: Vec<Attribute>,
-        pub defaultness: Option<Token![default]>,
+        pub modifiers: ImplModifiers,
         pub unsafety: Option<Token![unsafe]>,
         pub impl_token: Token![impl],
         pub generics: Generics,
         /// Trait this impl implements.
-        pub trait_: Option<(Option<Token![!]>, Path, Token![for])>,
+        pub trait_: Option<(Path, Token![for])>,
         /// The Self type of the impl.
         pub self_ty: Box<Type>,
         pub brace_token: token::Brace,
         pub items: Vec<ImplItem>,
+    }
+}
+
+ast_struct! {
+    /// Information about constness, polarity, and defaultness on an `impl`
+    /// item.
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    #[non_exhaustive]
+    pub struct ImplModifiers {
+        pub defaultness: Option<Token![default]>,
+        pub polarity: Option<Token![!]>,
+    }
+}
+
+impl Default for ImplModifiers {
+    fn default() -> Self {
+        ImplModifiers {
+            defaultness: None,
+            polarity: None,
+        }
     }
 }
 
@@ -914,8 +934,8 @@ pub(crate) mod parsing {
     use crate::ident::Ident;
     use crate::item::{
         FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
-        ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, Item, ItemConst,
-        ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
+        ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplModifiers, Item,
+        ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
         ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
         Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
         TraitItemType, TraitModifiers, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree,
@@ -2652,7 +2672,7 @@ pub(crate) mod parsing {
                     first_ty = *ty.elem;
                 }
                 if let Type::Path(TypePath { qself: None, path }) = first_ty {
-                    trait_ = Some((polarity, path, for_token));
+                    trait_ = Some((path, for_token));
                 } else {
                     unreachable!();
                 }
@@ -2691,7 +2711,10 @@ pub(crate) mod parsing {
         } else {
             Ok(Some(ItemImpl {
                 attrs,
-                defaultness,
+                modifiers: ImplModifiers {
+                    defaultness,
+                    polarity,
+                },
                 unsafety,
                 impl_token,
                 generics,
@@ -3209,12 +3232,12 @@ mod printing {
     impl ToTokens for ItemImpl {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             tokens.append_all(self.attrs.outer());
-            self.defaultness.to_tokens(tokens);
+            self.modifiers.defaultness.to_tokens(tokens);
             self.unsafety.to_tokens(tokens);
             self.impl_token.to_tokens(tokens);
             self.generics.to_tokens(tokens);
-            if let Some((polarity, path, for_token)) = &self.trait_ {
-                polarity.to_tokens(tokens);
+            self.modifiers.polarity.to_tokens(tokens);
+            if let Some((path, for_token)) = &self.trait_ {
                 path.to_tokens(tokens);
                 for_token.to_tokens(tokens);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,11 +428,12 @@ mod item;
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub use crate::item::{
     FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
-    ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, Item, ItemConst, ItemEnum,
-    ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod, ItemStatic, ItemStruct,
-    ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver, Signature, StaticMutability,
-    TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro, TraitItemType, TraitModifiers, UseGlob,
-    UseGroup, UseName, UsePath, UseRename, UseTree, Variadic,
+    ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplModifiers, Item,
+    ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
+    ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
+    Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
+    TraitItemType, TraitModifiers, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree,
+    Variadic,
 };
 
 mod lifetime;

--- a/syn.json
+++ b/syn.json
@@ -2622,6 +2622,27 @@
       }
     },
     {
+      "ident": "ImplModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "defaultness": {
+          "option": {
+            "token": "Default"
+          }
+        },
+        "polarity": {
+          "option": {
+            "token": "Not"
+          }
+        }
+      },
+      "exhaustive": false
+    },
+    {
       "ident": "Index",
       "features": {
         "any": [
@@ -2925,10 +2946,8 @@
             "syn": "Attribute"
           }
         },
-        "defaultness": {
-          "option": {
-            "token": "Default"
-          }
+        "modifiers": {
+          "syn": "ImplModifiers"
         },
         "unsafety": {
           "option": {
@@ -2944,11 +2963,6 @@
         "trait_": {
           "option": {
             "tuple": [
-              {
-                "option": {
-                  "token": "Not"
-                }
-              },
               {
                 "syn": "Path"
               },

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -2247,6 +2247,18 @@ impl Debug for Lite<syn::ImplItemType> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::ImplModifiers> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("ImplModifiers");
+        if self.value.defaultness.is_some() {
+            formatter.field("defaultness", &Present);
+        }
+        if self.value.polarity.is_some() {
+            formatter.field("polarity", &Present);
+        }
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::Index> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("Index");
@@ -2334,9 +2346,7 @@ impl Debug for Lite<syn::Item> {
                 if !_val.attrs.is_empty() {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
-                if _val.defaultness.is_some() {
-                    formatter.field("defaultness", &Present);
-                }
+                formatter.field("modifiers", Lite(&_val.modifiers));
                 if _val.unsafety.is_some() {
                     formatter.field("unsafety", &Present);
                 }
@@ -2344,19 +2354,11 @@ impl Debug for Lite<syn::Item> {
                 if let Some(val) = &_val.trait_ {
                     #[derive(RefCast)]
                     #[repr(transparent)]
-                    struct Print((Option<syn::token::Not>, syn::Path, syn::token::For));
+                    struct Print((syn::Path, syn::token::For));
                     impl Debug for Print {
                         fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                             formatter.write_str("Some(")?;
-                            Debug::fmt(
-                                &(
-                                    &super::Option {
-                                        present: self.0.0.is_some(),
-                                    },
-                                    Lite(&self.0.1),
-                                ),
-                                formatter,
-                            )?;
+                            Debug::fmt(Lite(&self.0.0), formatter)?;
                             formatter.write_str(")")?;
                             Ok(())
                         }
@@ -2623,9 +2625,7 @@ impl Debug for Lite<syn::ItemImpl> {
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
-        if self.value.defaultness.is_some() {
-            formatter.field("defaultness", &Present);
-        }
+        formatter.field("modifiers", Lite(&self.value.modifiers));
         if self.value.unsafety.is_some() {
             formatter.field("unsafety", &Present);
         }
@@ -2633,19 +2633,11 @@ impl Debug for Lite<syn::ItemImpl> {
         if let Some(val) = &self.value.trait_ {
             #[derive(RefCast)]
             #[repr(transparent)]
-            struct Print((Option<syn::token::Not>, syn::Path, syn::token::For));
+            struct Print((syn::Path, syn::token::For));
             impl Debug for Print {
                 fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                     formatter.write_str("Some(")?;
-                    Debug::fmt(
-                        &(
-                            &super::Option {
-                                present: self.0.0.is_some(),
-                            },
-                            Lite(&self.0.1),
-                        ),
-                        formatter,
-                    )?;
+                    Debug::fmt(Lite(&self.0.0), formatter)?;
                     formatter.write_str(")")?;
                     Ok(())
                 }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -60,12 +60,13 @@ fn test_negative_impl() {
     let tokens = quote! {
         impl ! {}
     };
-    snapshot!(tokens as Item, @r#"
+    snapshot!(tokens as Item, @"
     Item::Impl {
+        modifiers: ImplModifiers,
         generics: Generics,
         self_ty: Type::Never,
     }
-    "#);
+    ");
 
     let tokens = quote! {
         impl !Trait {}
@@ -80,17 +81,17 @@ fn test_negative_impl() {
     };
     snapshot!(tokens as Item, @r#"
     Item::Impl {
+        modifiers: ImplModifiers {
+            polarity: Some,
+        },
         generics: Generics,
-        trait_: Some((
-            Some,
-            Path {
-                segments: [
-                    PathSegment {
-                        ident: "Trait",
-                    },
-                ],
-            },
-        )),
+        trait_: Some(Path {
+            segments: [
+                PathSegment {
+                    ident: "Trait",
+                },
+            ],
+        }),
         self_ty: Type::Path {
             path: Path {
                 segments: [
@@ -117,17 +118,15 @@ fn test_macro_variable_impl() {
 
     snapshot!(tokens as Item, @r#"
     Item::Impl {
+        modifiers: ImplModifiers,
         generics: Generics,
-        trait_: Some((
-            None,
-            Path {
-                segments: [
-                    PathSegment {
-                        ident: "Trait",
-                    },
-                ],
-            },
-        )),
+        trait_: Some(Path {
+            segments: [
+                PathSegment {
+                    ident: "Trait",
+                },
+            ],
+        }),
         self_ty: Type::Group {
             elem: Type::Path {
                 path: Path {
@@ -272,6 +271,7 @@ fn test_impl_type_parameter_defaults() {
     };
     snapshot!(tokens as Item, @r#"
     Item::Impl {
+        modifiers: ImplModifiers,
         generics: Generics {
             lt_token: Some,
             params: [


### PR DESCRIPTION
Creates space for future syntax for const impl (https://github.com/dtolnay/syn/issues/1980).