### PR TITLE
Add FieldModifiers for field mutability and safety

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -2,7 +2,7 @@ use crate::attr::Attribute;
 use crate::expr::{Expr, Index, Member};
 use crate::ident::Ident;
 use crate::punctuated::{self, Punctuated};
-use crate::restriction::{FieldMutability, Visibility};
+use crate::restriction::Visibility;
 use crate::token;
 use crate::ty::Type;
 use alloc::vec::Vec;
@@ -187,7 +187,7 @@ ast_struct! {
 
         pub vis: Visibility,
 
-        pub mutability: FieldMutability,
+        pub modifiers: FieldModifiers,
 
         /// Name of the field, if any.
         ///
@@ -197,6 +197,19 @@ ast_struct! {
         pub colon_token: Option<Token![:]>,
 
         pub ty: Type,
+    }
+}
+
+ast_struct! {
+    /// Information about field mutability and safety.
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
+    #[non_exhaustive]
+    pub struct FieldModifiers {}
+}
+
+impl Default for FieldModifiers {
+    fn default() -> Self {
+        FieldModifiers {}
     }
 }
 
@@ -240,7 +253,7 @@ impl<'a> Clone for Members<'a> {
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::Attribute;
-    use crate::data::{Field, Fields, FieldsNamed, FieldsUnnamed, Variant};
+    use crate::data::{Field, FieldModifiers, Fields, FieldsNamed, FieldsUnnamed, Variant};
     use crate::error::Result;
     use crate::expr::Expr;
     use crate::ext::IdentExt as _;
@@ -248,7 +261,7 @@ pub(crate) mod parsing {
     #[cfg(not(feature = "full"))]
     use crate::parse::discouraged::Speculative as _;
     use crate::parse::{Parse, ParseStream};
-    use crate::restriction::{FieldMutability, Visibility};
+    use crate::restriction::Visibility;
     #[cfg(not(feature = "full"))]
     use crate::scan_expr::scan_expr;
     use crate::token;
@@ -350,7 +363,7 @@ pub(crate) mod parsing {
             Ok(Field {
                 attrs,
                 vis,
-                mutability: FieldMutability::None,
+                modifiers: FieldModifiers::default(),
                 ident: Some(ident),
                 colon_token: Some(colon_token),
                 ty,
@@ -363,7 +376,7 @@ pub(crate) mod parsing {
             Ok(Field {
                 attrs: input.call(Attribute::parse_outer)?,
                 vis: input.parse()?,
-                mutability: FieldMutability::None,
+                modifiers: FieldModifiers::default(),
                 ident: None,
                 colon_token: None,
                 ty: input.parse()?,

--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -762,7 +762,7 @@ impl Clone for crate::Field {
         crate::Field {
             attrs: self.attrs.clone(),
             vis: self.vis.clone(),
-            mutability: self.mutability.clone(),
+            modifiers: self.modifiers.clone(),
             ident: self.ident.clone(),
             colon_token: self.colon_token.clone(),
             ty: self.ty.clone(),
@@ -771,11 +771,9 @@ impl Clone for crate::Field {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
-impl Clone for crate::FieldMutability {
+impl Clone for crate::FieldModifiers {
     fn clone(&self) -> Self {
-        match self {
-            crate::FieldMutability::None => crate::FieldMutability::None,
-        }
+        crate::FieldModifiers {}
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1178,7 +1178,7 @@ impl Debug for crate::Field {
         let mut formatter = formatter.debug_struct("Field");
         formatter.field("attrs", &self.attrs);
         formatter.field("vis", &self.vis);
-        formatter.field("mutability", &self.mutability);
+        formatter.field("modifiers", &self.modifiers);
         formatter.field("ident", &self.ident);
         formatter.field("colon_token", &self.colon_token);
         formatter.field("ty", &self.ty);
@@ -1187,12 +1187,10 @@ impl Debug for crate::Field {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Debug for crate::FieldMutability {
+impl Debug for crate::FieldModifiers {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("FieldMutability::")?;
-        match self {
-            crate::FieldMutability::None => formatter.write_str("None"),
-        }
+        let mut formatter = formatter.debug_struct("FieldModifiers");
+        formatter.finish()
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -748,20 +748,18 @@ impl Eq for crate::Field {}
 impl PartialEq for crate::Field {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis
-            && self.mutability == other.mutability && self.ident == other.ident
+            && self.modifiers == other.modifiers && self.ident == other.ident
             && self.colon_token == other.colon_token && self.ty == other.ty
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Eq for crate::FieldMutability {}
+impl Eq for crate::FieldModifiers {}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl PartialEq for crate::FieldMutability {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (crate::FieldMutability::None, crate::FieldMutability::None) => true,
-        }
+impl PartialEq for crate::FieldModifiers {
+    fn eq(&self, _other: &Self) -> bool {
+        true
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -340,11 +340,11 @@ pub trait Fold {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-    fn fold_field_mutability(
+    fn fold_field_modifiers(
         &mut self,
-        i: crate::FieldMutability,
-    ) -> crate::FieldMutability {
-        fold_field_mutability(self, i)
+        i: crate::FieldModifiers,
+    ) -> crate::FieldModifiers {
+        fold_field_modifiers(self, i)
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -1948,7 +1948,7 @@ where
     crate::Field {
         attrs: f.fold_attributes(node.attrs),
         vis: f.fold_visibility(node.vis),
-        mutability: f.fold_field_mutability(node.mutability),
+        modifiers: f.fold_field_modifiers(node.modifiers),
         ident: (node.ident).map(|it| f.fold_ident(it)),
         colon_token: node.colon_token,
         ty: f.fold_type(node.ty),
@@ -1956,16 +1956,14 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-pub fn fold_field_mutability<F>(
+pub fn fold_field_modifiers<F>(
     f: &mut F,
-    node: crate::FieldMutability,
-) -> crate::FieldMutability
+    node: crate::FieldModifiers,
+) -> crate::FieldModifiers
 where
     F: Fold + ?Sized,
 {
-    match node {
-        crate::FieldMutability::None => crate::FieldMutability::None,
-    }
+    node
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -996,7 +996,7 @@ impl Hash for crate::Field {
     {
         self.attrs.hash(state);
         self.vis.hash(state);
-        self.mutability.hash(state);
+        self.modifiers.hash(state);
         self.ident.hash(state);
         self.colon_token.hash(state);
         self.ty.hash(state);
@@ -1004,17 +1004,11 @@ impl Hash for crate::Field {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
-impl Hash for crate::FieldMutability {
-    fn hash<H>(&self, state: &mut H)
+impl Hash for crate::FieldModifiers {
+    fn hash<H>(&self, _state: &mut H)
     where
         H: Hasher,
-    {
-        match self {
-            crate::FieldMutability::None => {
-                state.write_u8(0u8);
-            }
-        }
-    }
+    {}
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -326,8 +326,8 @@ pub trait Visit<'ast> {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-    fn visit_field_mutability(&mut self, i: &'ast crate::FieldMutability) {
-        visit_field_mutability(self, i);
+    fn visit_field_modifiers(&mut self, i: &'ast crate::FieldModifiers) {
+        visit_field_modifiers(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -1978,7 +1978,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
-    v.visit_field_mutability(&node.mutability);
+    v.visit_field_modifiers(&node.modifiers);
     if let Some(it) = &node.ident {
         v.visit_ident(it);
     }
@@ -1987,14 +1987,10 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-pub fn visit_field_mutability<'ast, V>(v: &mut V, node: &'ast crate::FieldMutability)
+pub fn visit_field_modifiers<'ast, V>(v: &mut V, node: &'ast crate::FieldModifiers)
 where
     V: Visit<'ast> + ?Sized,
-{
-    match node {
-        crate::FieldMutability::None => {}
-    }
-}
+{}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn visit_field_pat<'ast, V>(v: &mut V, node: &'ast crate::FieldPat)

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -336,8 +336,8 @@ pub trait VisitMut {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-    fn visit_field_mutability_mut(&mut self, i: &mut crate::FieldMutability) {
-        visit_field_mutability_mut(self, i);
+    fn visit_field_modifiers_mut(&mut self, i: &mut crate::FieldModifiers) {
+        visit_field_modifiers_mut(self, i);
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
@@ -1902,7 +1902,7 @@ where
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_visibility_mut(&mut node.vis);
-    v.visit_field_mutability_mut(&mut node.mutability);
+    v.visit_field_modifiers_mut(&mut node.modifiers);
     if let Some(it) = &mut node.ident {
         v.visit_ident_mut(it);
     }
@@ -1911,14 +1911,10 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
-pub fn visit_field_mutability_mut<V>(v: &mut V, node: &mut crate::FieldMutability)
+pub fn visit_field_modifiers_mut<V>(v: &mut V, node: &mut crate::FieldModifiers)
 where
     V: VisitMut + ?Sized,
-{
-    match node {
-        crate::FieldMutability::None => {}
-    }
-}
+{}
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub fn visit_field_pat_mut<V>(v: &mut V, node: &mut crate::FieldPat)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ mod custom_punctuation;
 mod data;
 #[cfg(any(feature = "full", feature = "derive"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
-pub use crate::data::{Field, Fields, FieldsNamed, FieldsUnnamed, Variant};
+pub use crate::data::{Field, FieldModifiers, Fields, FieldsNamed, FieldsUnnamed, Variant};
 
 #[cfg(any(feature = "full", feature = "derive"))]
 mod derive;
@@ -511,7 +511,7 @@ pub mod punctuated;
 mod restriction;
 #[cfg(any(feature = "full", feature = "derive"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
-pub use crate::restriction::{FieldMutability, VisRestricted, Visibility};
+pub use crate::restriction::{VisRestricted, Visibility};
 
 mod sealed;
 

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -153,7 +153,7 @@ impl<T: Parse> ParseQuote for T {
 
 use crate::punctuated::Punctuated;
 #[cfg(any(feature = "full", feature = "derive"))]
-use crate::{attr, Attribute, Field, FieldMutability, Ident, Type, Visibility};
+use crate::{attr, Attribute, Field, FieldModifiers, Ident, Type, Visibility};
 #[cfg(feature = "full")]
 use crate::{Arm, Block, Pat, Stmt};
 
@@ -201,7 +201,7 @@ impl ParseQuote for Field {
         Ok(Field {
             attrs,
             vis,
-            mutability: FieldMutability::None,
+            modifiers: FieldModifiers::default(),
             ident,
             colon_token,
             ty,

--- a/src/restriction.rs
+++ b/src/restriction.rs
@@ -37,26 +37,6 @@ ast_struct! {
     }
 }
 
-ast_enum! {
-    /// Unused, but reserved for RFC 3323 restrictions.
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
-    #[non_exhaustive]
-    pub enum FieldMutability {
-        None,
-
-        // TODO: https://rust-lang.github.io/rfcs/3323-restrictions.html
-        //
-        // FieldMutability::Restricted(MutRestricted)
-        //
-        // pub struct MutRestricted {
-        //     pub mut_token: Token![mut],
-        //     pub paren_token: token::Paren,
-        //     pub in_token: Option<Token![in]>,
-        //     pub path: Box<Path>,
-        // }
-    }
-}
-
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::error::Result;

--- a/syn.json
+++ b/syn.json
@@ -1928,8 +1928,8 @@
         "vis": {
           "syn": "Visibility"
         },
-        "mutability": {
-          "syn": "FieldMutability"
+        "modifiers": {
+          "syn": "FieldModifiers"
         },
         "ident": {
           "option": {
@@ -1947,16 +1947,14 @@
       }
     },
     {
-      "ident": "FieldMutability",
+      "ident": "FieldModifiers",
       "features": {
         "any": [
           "derive",
           "full"
         ]
       },
-      "variants": {
-        "None": []
-      },
+      "fields": {},
       "exhaustive": false
     },
     {

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -1702,12 +1702,7 @@ impl Debug for Lite<syn::Field> {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
         formatter.field("vis", Lite(&self.value.vis));
-        match self.value.mutability {
-            syn::FieldMutability::None => {}
-            _ => {
-                formatter.field("mutability", Lite(&self.value.mutability));
-            }
-        }
+        formatter.field("modifiers", Lite(&self.value.modifiers));
         if let Some(val) = &self.value.ident {
             #[derive(RefCast)]
             #[repr(transparent)]
@@ -1729,12 +1724,10 @@ impl Debug for Lite<syn::Field> {
         formatter.finish()
     }
 }
-impl Debug for Lite<syn::FieldMutability> {
+impl Debug for Lite<syn::FieldModifiers> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match &self.value {
-            syn::FieldMutability::None => formatter.write_str("FieldMutability::None"),
-            _ => unreachable!(),
-        }
+        let mut formatter = formatter.debug_struct("FieldModifiers");
+        formatter.finish()
     }
 }
 impl Debug for Lite<syn::FieldPat> {

--- a/tests/test_derive_input.rs
+++ b/tests/test_derive_input.rs
@@ -70,6 +70,7 @@ fn test_struct() {
                 named: [
                     Field {
                         vis: Visibility::Public,
+                        modifiers: FieldModifiers,
                         ident: Some("ident"),
                         colon_token: Some,
                         ty: Type::Path {
@@ -85,6 +86,7 @@ fn test_struct() {
                     Token![,],
                     Field {
                         vis: Visibility::Public,
+                        modifiers: FieldModifiers,
                         ident: Some("attrs"),
                         colon_token: Some,
                         ty: Type::Path {
@@ -158,6 +160,7 @@ fn test_union() {
                 named: [
                     Field {
                         vis: Visibility::Inherited,
+                        modifiers: FieldModifiers,
                         ident: Some("uninit"),
                         colon_token: Some,
                         ty: Type::Tuple,
@@ -165,6 +168,7 @@ fn test_union() {
                     Token![,],
                     Field {
                         vis: Visibility::Inherited,
+                        modifiers: FieldModifiers,
                         ident: Some("value"),
                         colon_token: Some,
                         ty: Type::Path {
@@ -253,6 +257,7 @@ fn test_enum() {
                         unnamed: [
                             Field {
                                 vis: Visibility::Inherited,
+                                modifiers: FieldModifiers,
                                 ty: Type::Path {
                                     path: Path {
                                         segments: [
@@ -273,6 +278,7 @@ fn test_enum() {
                         unnamed: [
                             Field {
                                 vis: Visibility::Inherited,
+                                modifiers: FieldModifiers,
                                 ty: Type::Path {
                                     path: Path {
                                         segments: [
@@ -446,6 +452,7 @@ fn test_pub_restricted() {
                                 ],
                             },
                         },
+                        modifiers: FieldModifiers,
                         ty: Type::Path {
                             path: Path {
                                 segments: [
@@ -591,6 +598,7 @@ fn test_fields_on_named_struct() {
                 named: [
                     Field {
                         vis: Visibility::Inherited,
+                        modifiers: FieldModifiers,
                         ident: Some("foo"),
                         colon_token: Some,
                         ty: Type::Path {
@@ -606,6 +614,7 @@ fn test_fields_on_named_struct() {
                     Token![,],
                     Field {
                         vis: Visibility::Public,
+                        modifiers: FieldModifiers,
                         ident: Some("bar"),
                         colon_token: Some,
                         ty: Type::Path {
@@ -634,6 +643,7 @@ fn test_fields_on_named_struct() {
     [
         Field {
             vis: Visibility::Inherited,
+            modifiers: FieldModifiers,
             ident: Some("foo"),
             colon_token: Some,
             ty: Type::Path {
@@ -648,6 +658,7 @@ fn test_fields_on_named_struct() {
         },
         Field {
             vis: Visibility::Public,
+            modifiers: FieldModifiers,
             ident: Some("bar"),
             colon_token: Some,
             ty: Type::Path {
@@ -680,6 +691,7 @@ fn test_fields_on_tuple_struct() {
                 unnamed: [
                     Field {
                         vis: Visibility::Inherited,
+                        modifiers: FieldModifiers,
                         ty: Type::Path {
                             path: Path {
                                 segments: [
@@ -693,6 +705,7 @@ fn test_fields_on_tuple_struct() {
                     Token![,],
                     Field {
                         vis: Visibility::Public,
+                        modifiers: FieldModifiers,
                         ty: Type::Path {
                             path: Path {
                                 segments: [
@@ -719,6 +732,7 @@ fn test_fields_on_tuple_struct() {
     [
         Field {
             vis: Visibility::Inherited,
+            modifiers: FieldModifiers,
             ty: Type::Path {
                 path: Path {
                     segments: [
@@ -731,6 +745,7 @@ fn test_fields_on_tuple_struct() {
         },
         Field {
             vis: Visibility::Public,
+            modifiers: FieldModifiers,
             ty: Type::Path {
                 path: Path {
                     segments: [
@@ -762,6 +777,7 @@ fn test_ambiguous_crate() {
                 unnamed: [
                     Field {
                         vis: Visibility::Inherited,
+                        modifiers: FieldModifiers,
                         ty: Type::Path {
                             path: Path {
                                 segments: [

--- a/tests/test_parse_quote.rs
+++ b/tests/test_parse_quote.rs
@@ -49,6 +49,7 @@ fn test_field() {
     snapshot!(field, @r#"
     Field {
         vis: Visibility::Public,
+        modifiers: FieldModifiers,
         ident: Some("enabled"),
         colon_token: Some,
         ty: Type::Path {
@@ -67,6 +68,7 @@ fn test_field() {
     snapshot!(field, @r#"
     Field {
         vis: Visibility::Inherited,
+        modifiers: FieldModifiers,
         ty: Type::Path {
             path: Path {
                 segments: [

--- a/tests/test_visibility.rs
+++ b/tests/test_visibility.rs
@@ -133,6 +133,7 @@ fn test_inherited_vis_named_field() {
                 named: [
                     Field {
                         vis: Visibility::Inherited,
+                        modifiers: FieldModifiers,
                         ident: Some("f"),
                         colon_token: Some,
                         ty: Type::Tuple,
@@ -170,6 +171,7 @@ fn test_inherited_vis_unnamed_field() {
                 unnamed: [
                     Field {
                         vis: Visibility::Inherited,
+                        modifiers: FieldModifiers,
                         ty: Type::Group {
                             elem: Type::Path {
                                 path: Path {


### PR DESCRIPTION
Creates space for future syntax for mutability (https://github.com/dtolnay/syn/issues/1987) and safety (https://github.com/dtolnay/syn/issues/1792).