### PR TITLE
Add FnModifiers for contracts and final

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -853,6 +853,13 @@ impl Clone for crate::FnArg {
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::FnModifiers {
+    fn clone(&self) -> Self {
+        crate::FnModifiers {}
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::FnPtrArg {
@@ -896,6 +903,7 @@ impl Clone for crate::ForeignItemFn {
         crate::ForeignItemFn {
             attrs: self.attrs.clone(),
             vis: self.vis.clone(),
+            modifiers: self.modifiers.clone(),
             sig: self.sig.clone(),
             semi_token: self.semi_token.clone(),
         }
@@ -1037,6 +1045,7 @@ impl Clone for crate::ImplItemFn {
         crate::ImplItemFn {
             attrs: self.attrs.clone(),
             vis: self.vis.clone(),
+            modifiers: self.modifiers.clone(),
             defaultness: self.defaultness.clone(),
             sig: self.sig.clone(),
             block: self.block.clone(),
@@ -1170,6 +1179,7 @@ impl Clone for crate::ItemFn {
         crate::ItemFn {
             attrs: self.attrs.clone(),
             vis: self.vis.clone(),
+            modifiers: self.modifiers.clone(),
             sig: self.sig.clone(),
             block: self.block.clone(),
         }
@@ -1896,6 +1906,7 @@ impl Clone for crate::TraitItemFn {
     fn clone(&self) -> Self {
         crate::TraitItemFn {
             attrs: self.attrs.clone(),
+            modifiers: self.modifiers.clone(),
             sig: self.sig.clone(),
             default: self.default.clone(),
             semi_token: self.semi_token.clone(),

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -1292,6 +1292,14 @@ impl Debug for crate::FnArg {
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::FnModifiers {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FnModifiers");
+        formatter.finish()
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::FnPtrArg {
@@ -1346,6 +1354,7 @@ impl crate::ForeignItemFn {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("attrs", &self.attrs);
         formatter.field("vis", &self.vis);
+        formatter.field("modifiers", &self.modifiers);
         formatter.field("sig", &self.sig);
         formatter.field("semi_token", &self.semi_token);
         formatter.finish()
@@ -1549,6 +1558,7 @@ impl crate::ImplItemFn {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("attrs", &self.attrs);
         formatter.field("vis", &self.vis);
+        formatter.field("modifiers", &self.modifiers);
         formatter.field("defaultness", &self.defaultness);
         formatter.field("sig", &self.sig);
         formatter.field("block", &self.block);
@@ -1723,6 +1733,7 @@ impl crate::ItemFn {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("attrs", &self.attrs);
         formatter.field("vis", &self.vis);
+        formatter.field("modifiers", &self.modifiers);
         formatter.field("sig", &self.sig);
         formatter.field("block", &self.block);
         formatter.finish()
@@ -2705,6 +2716,7 @@ impl crate::TraitItemFn {
     fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
         let mut formatter = formatter.debug_struct(name);
         formatter.field("attrs", &self.attrs);
+        formatter.field("modifiers", &self.modifiers);
         formatter.field("sig", &self.sig);
         formatter.field("default", &self.default);
         formatter.field("semi_token", &self.semi_token);

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -850,6 +850,16 @@ impl PartialEq for crate::FnArg {
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::FnModifiers {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::FnModifiers {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::FnPtrArg {}
@@ -905,7 +915,8 @@ impl Eq for crate::ForeignItemFn {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::ForeignItemFn {
     fn eq(&self, other: &Self) -> bool {
-        self.attrs == other.attrs && self.vis == other.vis && self.sig == other.sig
+        self.attrs == other.attrs && self.vis == other.vis
+            && self.modifiers == other.modifiers && self.sig == other.sig
     }
 }
 #[cfg(feature = "full")]
@@ -1067,8 +1078,8 @@ impl Eq for crate::ImplItemFn {}
 impl PartialEq for crate::ImplItemFn {
     fn eq(&self, other: &Self) -> bool {
         self.attrs == other.attrs && self.vis == other.vis
-            && self.defaultness == other.defaultness && self.sig == other.sig
-            && self.block == other.block
+            && self.modifiers == other.modifiers && self.defaultness == other.defaultness
+            && self.sig == other.sig && self.block == other.block
     }
 }
 #[cfg(feature = "full")]
@@ -1181,7 +1192,8 @@ impl Eq for crate::ItemFn {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::ItemFn {
     fn eq(&self, other: &Self) -> bool {
-        self.attrs == other.attrs && self.vis == other.vis && self.sig == other.sig
+        self.attrs == other.attrs && self.vis == other.vis
+            && self.modifiers == other.modifiers && self.sig == other.sig
             && self.block == other.block
     }
 }
@@ -1901,8 +1913,9 @@ impl Eq for crate::TraitItemFn {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::TraitItemFn {
     fn eq(&self, other: &Self) -> bool {
-        self.attrs == other.attrs && self.sig == other.sig
-            && self.default == other.default && self.semi_token == other.semi_token
+        self.attrs == other.attrs && self.modifiers == other.modifiers
+            && self.sig == other.sig && self.default == other.default
+            && self.semi_token == other.semi_token
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -381,6 +381,11 @@ pub trait Fold {
     fn fold_fn_arg(&mut self, i: crate::FnArg) -> crate::FnArg {
         fold_fn_arg(self, i)
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_fn_modifiers(&mut self, i: crate::FnModifiers) -> crate::FnModifiers {
+        fold_fn_modifiers(self, i)
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn fold_fn_ptr_arg(&mut self, i: crate::FnPtrArg) -> crate::FnPtrArg {
@@ -2073,6 +2078,14 @@ where
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_fn_modifiers<F>(f: &mut F, node: crate::FnModifiers) -> crate::FnModifiers
+where
+    F: Fold + ?Sized,
+{
+    node
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn fold_fn_ptr_arg<F>(f: &mut F, node: crate::FnPtrArg) -> crate::FnPtrArg
@@ -2137,6 +2150,7 @@ where
     crate::ForeignItemFn {
         attrs: f.fold_attributes(node.attrs),
         vis: f.fold_visibility(node.vis),
+        modifiers: f.fold_fn_modifiers(node.modifiers),
         sig: f.fold_signature(node.sig),
         semi_token: node.semi_token,
     }
@@ -2328,6 +2342,7 @@ where
     crate::ImplItemFn {
         attrs: f.fold_attributes(node.attrs),
         vis: f.fold_visibility(node.vis),
+        modifiers: f.fold_fn_modifiers(node.modifiers),
         defaultness: node.defaultness,
         sig: f.fold_signature(node.sig),
         block: f.fold_block(node.block),
@@ -2502,6 +2517,7 @@ where
     crate::ItemFn {
         attrs: f.fold_attributes(node.attrs),
         vis: f.fold_visibility(node.vis),
+        modifiers: f.fold_fn_modifiers(node.modifiers),
         sig: f.fold_signature(node.sig),
         block: Box::new(f.fold_block(*node.block)),
     }
@@ -3456,6 +3472,7 @@ where
 {
     crate::TraitItemFn {
         attrs: f.fold_attributes(node.attrs),
+        modifiers: f.fold_fn_modifiers(node.modifiers),
         sig: f.fold_signature(node.sig),
         default: (node.default).map(|it| f.fold_block(it)),
         semi_token: node.semi_token,

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -1110,6 +1110,14 @@ impl Hash for crate::FnArg {
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::FnModifiers {
+    fn hash<H>(&self, _state: &mut H)
+    where
+        H: Hasher,
+    {}
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::FnPtrArg {
@@ -1174,6 +1182,7 @@ impl Hash for crate::ForeignItemFn {
     {
         self.attrs.hash(state);
         self.vis.hash(state);
+        self.modifiers.hash(state);
         self.sig.hash(state);
     }
 }
@@ -1351,6 +1360,7 @@ impl Hash for crate::ImplItemFn {
     {
         self.attrs.hash(state);
         self.vis.hash(state);
+        self.modifiers.hash(state);
         self.defaultness.hash(state);
         self.sig.hash(state);
         self.block.hash(state);
@@ -1520,6 +1530,7 @@ impl Hash for crate::ItemFn {
     {
         self.attrs.hash(state);
         self.vis.hash(state);
+        self.modifiers.hash(state);
         self.sig.hash(state);
         self.block.hash(state);
     }
@@ -2398,6 +2409,7 @@ impl Hash for crate::TraitItemFn {
         H: Hasher,
     {
         self.attrs.hash(state);
+        self.modifiers.hash(state);
         self.sig.hash(state);
         self.default.hash(state);
         self.semi_token.hash(state);

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -364,6 +364,11 @@ pub trait Visit<'ast> {
     fn visit_fn_arg(&mut self, i: &'ast crate::FnArg) {
         visit_fn_arg(self, i);
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_fn_modifiers(&mut self, i: &'ast crate::FnModifiers) {
+        visit_fn_modifiers(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_fn_ptr_arg(&mut self, i: &'ast crate::FnPtrArg) {
@@ -2099,6 +2104,12 @@ where
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_fn_modifiers<'ast, V>(v: &mut V, node: &'ast crate::FnModifiers)
+where
+    V: Visit<'ast> + ?Sized,
+{}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_fn_ptr_arg<'ast, V>(v: &mut V, node: &'ast crate::FnPtrArg)
@@ -2164,6 +2175,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
+    v.visit_fn_modifiers(&node.modifiers);
     v.visit_signature(&node.sig);
     skip!(node.semi_token);
 }
@@ -2341,6 +2353,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
+    v.visit_fn_modifiers(&node.modifiers);
     skip!(node.defaultness);
     v.visit_signature(&node.sig);
     v.visit_block(&node.block);
@@ -2517,6 +2530,7 @@ where
         v.visit_attribute(it);
     }
     v.visit_visibility(&node.vis);
+    v.visit_fn_modifiers(&node.modifiers);
     v.visit_signature(&node.sig);
     v.visit_block(&*node.block);
 }
@@ -3489,6 +3503,7 @@ where
     for it in &node.attrs {
         v.visit_attribute(it);
     }
+    v.visit_fn_modifiers(&node.modifiers);
     v.visit_signature(&node.sig);
     if let Some(it) = &node.default {
         v.visit_block(it);

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -374,6 +374,11 @@ pub trait VisitMut {
     fn visit_fn_arg_mut(&mut self, i: &mut crate::FnArg) {
         visit_fn_arg_mut(self, i);
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_fn_modifiers_mut(&mut self, i: &mut crate::FnModifiers) {
+        visit_fn_modifiers_mut(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_fn_ptr_arg_mut(&mut self, i: &mut crate::FnPtrArg) {
@@ -2017,6 +2022,12 @@ where
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_fn_modifiers_mut<V>(v: &mut V, node: &mut crate::FnModifiers)
+where
+    V: VisitMut + ?Sized,
+{}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_fn_ptr_arg_mut<V>(v: &mut V, node: &mut crate::FnPtrArg)
@@ -2076,6 +2087,7 @@ where
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_visibility_mut(&mut node.vis);
+    v.visit_fn_modifiers_mut(&mut node.modifiers);
     v.visit_signature_mut(&mut node.sig);
     skip!(node.semi_token);
 }
@@ -2242,6 +2254,7 @@ where
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_visibility_mut(&mut node.vis);
+    v.visit_fn_modifiers_mut(&mut node.modifiers);
     skip!(node.defaultness);
     v.visit_signature_mut(&mut node.sig);
     v.visit_block_mut(&mut node.block);
@@ -2406,6 +2419,7 @@ where
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_visibility_mut(&mut node.vis);
+    v.visit_fn_modifiers_mut(&mut node.modifiers);
     v.visit_signature_mut(&mut node.sig);
     v.visit_block_mut(&mut *node.block);
 }
@@ -3322,6 +3336,7 @@ where
     V: VisitMut + ?Sized,
 {
     v.visit_attributes_mut(&mut node.attrs);
+    v.visit_fn_modifiers_mut(&mut node.modifiers);
     v.visit_signature_mut(&mut node.sig);
     if let Some(it) = &mut node.default {
         v.visit_block_mut(it);

--- a/src/item.rs
+++ b/src/item.rs
@@ -151,8 +151,22 @@ ast_struct! {
     pub struct ItemFn {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
+        pub modifiers: FnModifiers,
         pub sig: Signature,
         pub block: Box<Block>,
+    }
+}
+
+ast_struct! {
+    /// Information about function contracts and restrictions.
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    #[non_exhaustive]
+    pub struct FnModifiers {}
+}
+
+impl Default for FnModifiers {
+    fn default() -> Self {
+        FnModifiers {}
     }
 }
 
@@ -582,6 +596,7 @@ ast_struct! {
     pub struct ForeignItemFn {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
+        pub modifiers: FnModifiers,
         pub sig: Signature,
         pub semi_token: Token![;],
     }
@@ -691,6 +706,7 @@ ast_struct! {
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     pub struct TraitItemFn {
         pub attrs: Vec<Attribute>,
+        pub modifiers: FnModifiers,
         pub sig: Signature,
         pub default: Option<Block>,
         pub semi_token: Option<Token![;]>,
@@ -792,6 +808,7 @@ ast_struct! {
     pub struct ImplItemFn {
         pub attrs: Vec<Attribute>,
         pub vis: Visibility,
+        pub modifiers: FnModifiers,
         pub defaultness: Option<Token![default]>,
         pub sig: Signature,
         pub block: Block,
@@ -933,13 +950,13 @@ pub(crate) mod parsing {
     use crate::generics::{self, Generics, TypeParamBound};
     use crate::ident::Ident;
     use crate::item::{
-        FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
-        ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplModifiers, Item,
-        ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
-        ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
-        Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
-        TraitItemType, TraitModifiers, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree,
-        Variadic,
+        FnArg, FnModifiers, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic,
+        ForeignItemType, ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType,
+        ImplModifiers, Item, ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod,
+        ItemImpl, ItemMacro, ItemMod, ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType,
+        ItemUnion, ItemUse, Receiver, Signature, StaticMutability, TraitItem, TraitItemConst,
+        TraitItemFn, TraitItemMacro, TraitItemType, TraitModifiers, UseGlob, UseGroup, UseName,
+        UsePath, UseRename, UseTree, Variadic,
     };
     use crate::lifetime::Lifetime;
     use crate::lit::LitStr;
@@ -1599,6 +1616,7 @@ pub(crate) mod parsing {
         Ok(ItemFn {
             attrs,
             vis,
+            modifiers: FnModifiers::default(),
             sig,
             block: Box::new(Block { brace_token, stmts }),
         })
@@ -1916,6 +1934,7 @@ pub(crate) mod parsing {
                     Ok(ForeignItem::Fn(ForeignItemFn {
                         attrs: Vec::new(),
                         vis,
+                        modifiers: FnModifiers::default(),
                         sig: sig.unwrap(),
                         semi_token: semi_token.unwrap(),
                     }))
@@ -1998,6 +2017,7 @@ pub(crate) mod parsing {
             Ok(ForeignItemFn {
                 attrs,
                 vis,
+                modifiers: FnModifiers::default(),
                 sig,
                 semi_token,
             })
@@ -2534,6 +2554,7 @@ pub(crate) mod parsing {
 
             Ok(TraitItemFn {
                 attrs,
+                modifiers: FnModifiers::default(),
                 sig,
                 default: brace_token.map(|brace_token| Block { brace_token, stmts }),
                 semi_token,
@@ -2894,6 +2915,7 @@ pub(crate) mod parsing {
         Ok(Some(ImplItemFn {
             attrs,
             vis,
+            modifiers: FnModifiers::default(),
             defaultness,
             sig,
             block,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,13 +427,13 @@ mod item;
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub use crate::item::{
-    FnArg, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic, ForeignItemType,
-    ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType, ImplModifiers, Item,
-    ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMod,
-    ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion, ItemUse, Receiver,
-    Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn, TraitItemMacro,
-    TraitItemType, TraitModifiers, UseGlob, UseGroup, UseName, UsePath, UseRename, UseTree,
-    Variadic,
+    FnArg, FnModifiers, ForeignItem, ForeignItemFn, ForeignItemMacro, ForeignItemStatic,
+    ForeignItemType, ImplItem, ImplItemConst, ImplItemFn, ImplItemMacro, ImplItemType,
+    ImplModifiers, Item, ItemConst, ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl,
+    ItemMacro, ItemMod, ItemStatic, ItemStruct, ItemTrait, ItemTraitAlias, ItemType, ItemUnion,
+    ItemUse, Receiver, Signature, StaticMutability, TraitItem, TraitItemConst, TraitItemFn,
+    TraitItemMacro, TraitItemType, TraitModifiers, UseGlob, UseGroup, UseName, UsePath, UseRename,
+    UseTree, Variadic,
 };
 
 mod lifetime;

--- a/syn.json
+++ b/syn.json
@@ -2129,6 +2129,16 @@
       }
     },
     {
+      "ident": "FnModifiers",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {},
+      "exhaustive": false
+    },
+    {
       "ident": "FnPtrArg",
       "features": {
         "any": [
@@ -2246,6 +2256,9 @@
         },
         "vis": {
           "syn": "Visibility"
+        },
+        "modifiers": {
+          "syn": "FnModifiers"
         },
         "sig": {
           "syn": "Signature"
@@ -2556,6 +2569,9 @@
         },
         "vis": {
           "syn": "Visibility"
+        },
+        "modifiers": {
+          "syn": "FnModifiers"
         },
         "defaultness": {
           "option": {
@@ -2904,6 +2920,9 @@
         },
         "vis": {
           "syn": "Visibility"
+        },
+        "modifiers": {
+          "syn": "FnModifiers"
         },
         "sig": {
           "syn": "Signature"
@@ -4722,6 +4741,9 @@
           "vec": {
             "syn": "Attribute"
           }
+        },
+        "modifiers": {
+          "syn": "FnModifiers"
         },
         "sig": {
           "syn": "Signature"

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -1857,6 +1857,12 @@ impl Debug for Lite<syn::FnArg> {
         }
     }
 }
+impl Debug for Lite<syn::FnModifiers> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("FnModifiers");
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::FnPtrArg> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("FnPtrArg");
@@ -1916,6 +1922,7 @@ impl Debug for Lite<syn::ForeignItem> {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
                 formatter.field("vis", Lite(&_val.vis));
+                formatter.field("modifiers", Lite(&_val.modifiers));
                 formatter.field("sig", Lite(&_val.sig));
                 formatter.finish()
             }
@@ -1974,6 +1981,7 @@ impl Debug for Lite<syn::ForeignItemFn> {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
         formatter.field("vis", Lite(&self.value.vis));
+        formatter.field("modifiers", Lite(&self.value.modifiers));
         formatter.field("sig", Lite(&self.value.sig));
         formatter.finish()
     }
@@ -2156,6 +2164,7 @@ impl Debug for Lite<syn::ImplItem> {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
                 formatter.field("vis", Lite(&_val.vis));
+                formatter.field("modifiers", Lite(&_val.modifiers));
                 if _val.defaultness.is_some() {
                     formatter.field("defaultness", &Present);
                 }
@@ -2223,6 +2232,7 @@ impl Debug for Lite<syn::ImplItemFn> {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
         formatter.field("vis", Lite(&self.value.vis));
+        formatter.field("modifiers", Lite(&self.value.modifiers));
         if self.value.defaultness.is_some() {
             formatter.field("defaultness", &Present);
         }
@@ -2336,6 +2346,7 @@ impl Debug for Lite<syn::Item> {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
                 formatter.field("vis", Lite(&_val.vis));
+                formatter.field("modifiers", Lite(&_val.modifiers));
                 formatter.field("sig", Lite(&_val.sig));
                 formatter.field("block", Lite(&_val.block));
                 formatter.finish()
@@ -2611,6 +2622,7 @@ impl Debug for Lite<syn::ItemFn> {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
         formatter.field("vis", Lite(&self.value.vis));
+        formatter.field("modifiers", Lite(&self.value.modifiers));
         formatter.field("sig", Lite(&self.value.sig));
         formatter.field("block", Lite(&self.value.block));
         formatter.finish()
@@ -3893,6 +3905,7 @@ impl Debug for Lite<syn::TraitItem> {
                 if !_val.attrs.is_empty() {
                     formatter.field("attrs", Lite(&_val.attrs));
                 }
+                formatter.field("modifiers", Lite(&_val.modifiers));
                 formatter.field("sig", Lite(&_val.sig));
                 if let Some(val) = &_val.default {
                     #[derive(RefCast)]
@@ -3996,6 +4009,7 @@ impl Debug for Lite<syn::TraitItemFn> {
         if !self.value.attrs.is_empty() {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
+        formatter.field("modifiers", Lite(&self.value.modifiers));
         formatter.field("sig", Lite(&self.value.sig));
         if let Some(val) = &self.value.default {
             #[derive(RefCast)]

--- a/tests/test_asyncness.rs
+++ b/tests/test_asyncness.rs
@@ -18,6 +18,7 @@ fn test_async_fn() {
     snapshot!(input as Item, @r#"
     Item::Fn {
         vis: Visibility::Inherited,
+        modifiers: FnModifiers,
         sig: Signature {
             asyncness: Some,
             ident: "process",

--- a/tests/test_generics.rs
+++ b/tests/test_generics.rs
@@ -232,6 +232,7 @@ fn test_fn_precedence_in_where_clause() {
     snapshot!(input as ItemFn, @r#"
     ItemFn {
         vis: Visibility::Inherited,
+        modifiers: FnModifiers,
         sig: Signature {
             ident: "f",
             generics: Generics {

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -41,6 +41,7 @@ fn test_macro_variable_attr() {
             },
         ],
         vis: Visibility::Inherited,
+        modifiers: FnModifiers,
         sig: Signature {
             ident: "f",
             generics: Generics,
@@ -297,6 +298,7 @@ fn test_impl_trait_trailing_plus() {
     snapshot!(tokens as Item, @r#"
     Item::Fn {
         vis: Visibility::Inherited,
+        modifiers: FnModifiers,
         sig: Signature {
             ident: "f",
             generics: Generics,

--- a/tests/test_shebang.rs
+++ b/tests/test_shebang.rs
@@ -19,6 +19,7 @@ fn test_basic() {
         items: [
             Item::Fn {
                 vis: Visibility::Inherited,
+                modifiers: FnModifiers,
                 sig: Signature {
                     ident: "main",
                     generics: Generics,
@@ -58,6 +59,7 @@ fn test_comment() {
         items: [
             Item::Fn {
                 vis: Visibility::Inherited,
+                modifiers: FnModifiers,
                 sig: Signature {
                     ident: "main",
                     generics: Generics,

--- a/tests/test_stmt.rs
+++ b/tests/test_stmt.rs
@@ -88,6 +88,7 @@ fn test_none_group() {
     snapshot!(tokens as Stmt, @r#"
     Stmt::Item(Item::Fn {
         vis: Visibility::Inherited,
+        modifiers: FnModifiers,
         sig: Signature {
             asyncness: Some,
             ident: "f",
@@ -212,6 +213,7 @@ fn test_macros() {
     snapshot!(tokens as Stmt, @r#"
     Stmt::Item(Item::Fn {
         vis: Visibility::Inherited,
+        modifiers: FnModifiers,
         sig: Signature {
             ident: "main",
             generics: Generics,


### PR DESCRIPTION
Creates space for future syntax for final fn (https://github.com/dtolnay/syn/issues/1981), contracts (https://github.com/dtolnay/syn/issues/1892) and generators (https://github.com/dtolnay/syn/issues/1526).