### PR TITLE
Accept attributes inside of tuple types

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1965,6 +1965,16 @@ impl Clone for crate::TraitModifiers {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::TupleElementType {
+    fn clone(&self) -> Self {
+        crate::TupleElementType {
+            attrs: self.attrs.clone(),
+            ty: self.ty.clone(),
+        }
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::Type {
     fn clone(&self) -> Self {
         match self {

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -2796,6 +2796,16 @@ impl Debug for crate::TraitModifiers {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::TupleElementType {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("TupleElementType");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("ty", &self.ty);
+        formatter.finish()
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::Type {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("Type::")?;

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1969,6 +1969,16 @@ impl PartialEq for crate::TraitModifiers {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::TupleElementType {}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::TupleElementType {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.ty == other.ty
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::Type {}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -897,6 +897,14 @@ pub trait Fold {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn fold_tuple_element_type(
+        &mut self,
+        i: crate::TupleElementType,
+    ) -> crate::TupleElementType {
+        fold_tuple_element_type(self, i)
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn fold_type(&mut self, i: crate::Type) -> crate::Type {
         fold_type(self, i)
     }
@@ -3548,6 +3556,20 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn fold_tuple_element_type<F>(
+    f: &mut F,
+    node: crate::TupleElementType,
+) -> crate::TupleElementType
+where
+    F: Fold + ?Sized,
+{
+    crate::TupleElementType {
+        attrs: f.fold_attributes(node.attrs),
+        ty: f.fold_type(node.ty),
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn fold_type<F>(f: &mut F, node: crate::Type) -> crate::Type
 where
     F: Fold + ?Sized,
@@ -3805,7 +3827,7 @@ where
 {
     crate::TypeTuple {
         paren_token: node.paren_token,
-        elems: crate::punctuated::fold(node.elems, f, F::fold_type),
+        elems: crate::punctuated::fold(node.elems, f, F::fold_tuple_element_type),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -2477,6 +2477,17 @@ impl Hash for crate::TraitModifiers {
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::TupleElementType {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.ty.hash(state);
+    }
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::Type {
     fn hash<H>(&self, state: &mut H)
     where

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -819,6 +819,11 @@ pub trait Visit<'ast> {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_tuple_element_type(&mut self, i: &'ast crate::TupleElementType) {
+        visit_tuple_element_type(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_type(&mut self, i: &'ast crate::Type) {
         visit_type(self, i);
     }
@@ -3583,6 +3588,17 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_tuple_element_type<'ast, V>(v: &mut V, node: &'ast crate::TupleElementType)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_type(&node.ty);
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_type<'ast, V>(v: &mut V, node: &'ast crate::Type)
 where
     V: Visit<'ast> + ?Sized,
@@ -3829,7 +3845,7 @@ where
     skip!(node.paren_token);
     for el in Punctuated::pairs(&node.elems) {
         let it = el.value();
-        v.visit_type(it);
+        v.visit_tuple_element_type(it);
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -829,6 +829,11 @@ pub trait VisitMut {
     }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+    fn visit_tuple_element_type_mut(&mut self, i: &mut crate::TupleElementType) {
+        visit_tuple_element_type_mut(self, i);
+    }
+    #[cfg(any(feature = "derive", feature = "full"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_type_mut(&mut self, i: &mut crate::Type) {
         visit_type_mut(self, i);
     }
@@ -3408,6 +3413,15 @@ where
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
+pub fn visit_tuple_element_type_mut<V>(v: &mut V, node: &mut crate::TupleElementType)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_type_mut(&mut node.ty);
+}
+#[cfg(any(feature = "derive", feature = "full"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
 pub fn visit_type_mut<V>(v: &mut V, node: &mut crate::Type)
 where
     V: VisitMut + ?Sized,
@@ -3652,7 +3666,7 @@ where
     skip!(node.paren_token);
     for mut el in Punctuated::pairs_mut(&mut node.elems) {
         let it = el.value_mut();
-        v.visit_type_mut(it);
+        v.visit_tuple_element_type_mut(it);
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,9 +540,9 @@ mod ty;
 #[cfg(any(feature = "full", feature = "derive"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
 pub use crate::ty::{
-    Abi, FnPtrArg, FnPtrVariadic, PointerMutability, ReturnType, Type, TypeArray, TypeFnPtr,
-    TypeGroup, TypeImplTrait, TypeInfer, TypeMacro, TypeNever, TypeParen, TypePath, TypePtr,
-    TypeReference, TypeSlice, TypeTraitObject, TypeTuple,
+    Abi, FnPtrArg, FnPtrVariadic, PointerMutability, ReturnType, TupleElementType, Type, TypeArray,
+    TypeFnPtr, TypeGroup, TypeImplTrait, TypeInfer, TypeMacro, TypeNever, TypeParen, TypePath,
+    TypePtr, TypeReference, TypeSlice, TypeTraitObject, TypeTuple,
 };
 
 #[cfg(all(any(feature = "full", feature = "derive"), feature = "parsing"))]

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -224,7 +224,7 @@ ast_struct! {
     #[cfg_attr(docsrs, doc(cfg(any(feature = "full", feature = "derive"))))]
     pub struct TypeTuple {
         pub paren_token: token::Paren,
-        pub elems: Punctuated<Type, Token![,]>,
+        pub elems: Punctuated<TupleElementType, Token![,]>,
     }
 }
 
@@ -281,6 +281,14 @@ ast_enum! {
     }
 }
 
+ast_struct! {
+    /// A type inside a tuple, including its attributes.
+    pub struct TupleElementType {
+        pub attrs: Vec<Attribute>,
+        pub ty: Type,
+    }
+}
+
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::Attribute;
@@ -296,9 +304,9 @@ pub(crate) mod parsing {
     use crate::punctuated::Punctuated;
     use crate::token;
     use crate::ty::{
-        Abi, FnPtrArg, FnPtrVariadic, PointerMutability, ReturnType, Type, TypeArray, TypeFnPtr,
-        TypeGroup, TypeImplTrait, TypeInfer, TypeMacro, TypeNever, TypeParen, TypePath, TypePtr,
-        TypeReference, TypeSlice, TypeTraitObject, TypeTuple,
+        Abi, FnPtrArg, FnPtrVariadic, PointerMutability, ReturnType, TupleElementType, Type,
+        TypeArray, TypeFnPtr, TypeGroup, TypeImplTrait, TypeInfer, TypeMacro, TypeNever, TypeParen,
+        TypePath, TypePtr, TypeReference, TypeSlice, TypeTraitObject, TypeTuple,
     };
     use crate::verbatim;
     use alloc::boxed::Box;
@@ -435,10 +443,16 @@ pub(crate) mod parsing {
                     paren_token,
                     elems: {
                         let mut elems = Punctuated::new();
-                        elems.push_value(first);
+                        elems.push_value(TupleElementType {
+                            attrs: Vec::new(),
+                            ty: first,
+                        });
                         elems.push_punct(content.parse()?);
                         while !content.is_empty() {
-                            elems.push_value(content.parse()?);
+                            elems.push_value(TupleElementType {
+                                attrs: Vec::new(),
+                                ty: content.parse()?,
+                            });
                             if content.is_empty() {
                                 break;
                             }
@@ -765,10 +779,16 @@ pub(crate) mod parsing {
                 paren_token,
                 elems: {
                     let mut elems = Punctuated::new();
-                    elems.push_value(first);
+                    elems.push_value(TupleElementType {
+                        attrs: Vec::new(),
+                        ty: first,
+                    });
                     elems.push_punct(content.parse()?);
                     while !content.is_empty() {
-                        elems.push_value(content.parse()?);
+                        elems.push_value(TupleElementType {
+                            attrs: Vec::new(),
+                            ty: content.parse()?,
+                        });
                         if content.is_empty() {
                             break;
                         }
@@ -1092,6 +1112,17 @@ pub(crate) mod parsing {
             }
         }
     }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
+    impl Parse for TupleElementType {
+        fn parse(input: ParseStream) -> Result<Self> {
+            // TODO https://github.com/rust-lang/rfcs/pull/3532 parse attributes
+            Ok(TupleElementType {
+                attrs: Vec::new(),
+                ty: input.parse()?,
+            })
+        }
+    }
 }
 
 #[cfg(feature = "printing")]
@@ -1100,9 +1131,9 @@ mod printing {
     use crate::path;
     use crate::path::printing::PathStyle;
     use crate::ty::{
-        Abi, FnPtrArg, FnPtrVariadic, PointerMutability, ReturnType, TypeArray, TypeFnPtr,
-        TypeGroup, TypeImplTrait, TypeInfer, TypeMacro, TypeNever, TypeParen, TypePath, TypePtr,
-        TypeReference, TypeSlice, TypeTraitObject, TypeTuple,
+        Abi, FnPtrArg, FnPtrVariadic, PointerMutability, ReturnType, TupleElementType, TypeArray,
+        TypeFnPtr, TypeGroup, TypeImplTrait, TypeInfer, TypeMacro, TypeNever, TypeParen, TypePath,
+        TypePtr, TypeReference, TypeSlice, TypeTraitObject, TypeTuple,
     };
     use proc_macro2::TokenStream;
     use quote::{ToTokens, TokenStreamExt as _};
@@ -1296,6 +1327,14 @@ mod printing {
                 PointerMutability::Const(const_token) => const_token.to_tokens(tokens),
                 PointerMutability::Mut(mut_token) => mut_token.to_tokens(tokens),
             }
+        }
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "printing")))]
+    impl ToTokens for TupleElementType {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            tokens.append_all(self.attrs.outer());
+            self.ty.to_tokens(tokens);
         }
     }
 }

--- a/syn.json
+++ b/syn.json
@@ -4884,6 +4884,25 @@
       "exhaustive": false
     },
     {
+      "ident": "TupleElementType",
+      "features": {
+        "any": [
+          "derive",
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "ty": {
+          "syn": "Type"
+        }
+      }
+    },
+    {
       "ident": "Type",
       "features": {
         "any": [
@@ -5347,7 +5366,7 @@
         "elems": {
           "punctuated": {
             "element": {
-              "syn": "Type"
+              "syn": "TupleElementType"
             },
             "punct": "Comma"
           }

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -4105,6 +4105,16 @@ impl Debug for Lite<syn::TraitModifiers> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::TupleElementType> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("TupleElementType");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("ty", Lite(&self.value.ty));
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::Type> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match &self.value {

--- a/tests/test_ty.rs
+++ b/tests/test_ty.rs
@@ -364,47 +364,59 @@ fn test_tuple_comma() {
 
     expr.elems.push_value(parse_quote!(_));
     // Must not parse to Type::Paren
-    snapshot!(expr.to_token_stream() as Type, @r#"
+    snapshot!(expr.to_token_stream() as Type, @"
     Type::Tuple {
         elems: [
-            Type::Infer,
+            TupleElementType {
+                ty: Type::Infer,
+            },
             Token![,],
         ],
     }
-    "#);
+    ");
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Type, @r#"
+    snapshot!(expr.to_token_stream() as Type, @"
     Type::Tuple {
         elems: [
-            Type::Infer,
+            TupleElementType {
+                ty: Type::Infer,
+            },
             Token![,],
         ],
     }
-    "#);
+    ");
 
     expr.elems.push_value(parse_quote!(_));
-    snapshot!(expr.to_token_stream() as Type, @r#"
+    snapshot!(expr.to_token_stream() as Type, @"
     Type::Tuple {
         elems: [
-            Type::Infer,
+            TupleElementType {
+                ty: Type::Infer,
+            },
             Token![,],
-            Type::Infer,
+            TupleElementType {
+                ty: Type::Infer,
+            },
         ],
     }
-    "#);
+    ");
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Type, @r#"
+    snapshot!(expr.to_token_stream() as Type, @"
     Type::Tuple {
         elems: [
-            Type::Infer,
+            TupleElementType {
+                ty: Type::Infer,
+            },
             Token![,],
-            Type::Infer,
+            TupleElementType {
+                ty: Type::Infer,
+            },
             Token![,],
         ],
     }
-    "#);
+    ");
 }
 
 #[test]


### PR DESCRIPTION
Does not parse attributes yet, but allows the syntax tree to hold attributes for https://github.com/dtolnay/syn/issues/1919.