### PR TITLE
Accept attributes inside of tuple patterns

### DIFF
--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -1963,6 +1963,16 @@ impl Clone for crate::TraitModifiers {
         }
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::TupleElementPat {
+    fn clone(&self) -> Self {
+        crate::TupleElementPat {
+            attrs: self.attrs.clone(),
+            pat: self.pat.clone(),
+        }
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
 impl Clone for crate::TupleElementType {

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -2794,6 +2794,16 @@ impl Debug for crate::TraitModifiers {
         formatter.finish()
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::TupleElementPat {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("TupleElementPat");
+        formatter.field("attrs", &self.attrs);
+        formatter.field("pat", &self.pat);
+        formatter.finish()
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Debug for crate::TupleElementType {

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -1967,6 +1967,16 @@ impl PartialEq for crate::TraitModifiers {
         self.auto_token == other.auto_token
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::TupleElementPat {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::TupleElementPat {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.pat == other.pat
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Eq for crate::TupleElementType {}

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -895,6 +895,14 @@ pub trait Fold {
     ) -> crate::TraitModifiers {
         fold_trait_modifiers(self, i)
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_tuple_element_pat(
+        &mut self,
+        i: crate::TupleElementPat,
+    ) -> crate::TupleElementPat {
+        fold_tuple_element_pat(self, i)
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn fold_tuple_element_type(
@@ -3127,7 +3135,7 @@ where
     crate::PatTuple {
         attrs: f.fold_attributes(node.attrs),
         paren_token: node.paren_token,
-        elems: crate::punctuated::fold(node.elems, f, F::fold_pat),
+        elems: crate::punctuated::fold(node.elems, f, F::fold_tuple_element_pat),
     }
 }
 #[cfg(feature = "full")]
@@ -3144,7 +3152,7 @@ where
         qself: (node.qself).map(|it| f.fold_qself(it)),
         path: f.fold_path(node.path),
         paren_token: node.paren_token,
-        elems: crate::punctuated::fold(node.elems, f, F::fold_pat),
+        elems: crate::punctuated::fold(node.elems, f, F::fold_tuple_element_pat),
     }
 }
 #[cfg(feature = "full")]
@@ -3552,6 +3560,20 @@ where
 {
     crate::TraitModifiers {
         auto_token: node.auto_token,
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_tuple_element_pat<F>(
+    f: &mut F,
+    node: crate::TupleElementPat,
+) -> crate::TupleElementPat
+where
+    F: Fold + ?Sized,
+{
+    crate::TupleElementPat {
+        attrs: f.fold_attributes(node.attrs),
+        pat: f.fold_pat(node.pat),
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -2475,6 +2475,17 @@ impl Hash for crate::TraitModifiers {
         self.auto_token.hash(state);
     }
 }
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::TupleElementPat {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.pat.hash(state);
+    }
+}
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl Hash for crate::TupleElementType {

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -817,6 +817,11 @@ pub trait Visit<'ast> {
     fn visit_trait_modifiers(&mut self, i: &'ast crate::TraitModifiers) {
         visit_trait_modifiers(self, i);
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_tuple_element_pat(&mut self, i: &'ast crate::TupleElementPat) {
+        visit_tuple_element_pat(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_tuple_element_type(&mut self, i: &'ast crate::TupleElementType) {
@@ -3159,7 +3164,7 @@ where
     skip!(node.paren_token);
     for el in Punctuated::pairs(&node.elems) {
         let it = el.value();
-        v.visit_pat(it);
+        v.visit_tuple_element_pat(it);
     }
 }
 #[cfg(feature = "full")]
@@ -3178,7 +3183,7 @@ where
     skip!(node.paren_token);
     for el in Punctuated::pairs(&node.elems) {
         let it = el.value();
-        v.visit_pat(it);
+        v.visit_tuple_element_pat(it);
     }
 }
 #[cfg(feature = "full")]
@@ -3585,6 +3590,17 @@ where
     V: Visit<'ast> + ?Sized,
 {
     skip!(node.auto_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_tuple_element_pat<'ast, V>(v: &mut V, node: &'ast crate::TupleElementPat)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_pat(&node.pat);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -827,6 +827,11 @@ pub trait VisitMut {
     fn visit_trait_modifiers_mut(&mut self, i: &mut crate::TraitModifiers) {
         visit_trait_modifiers_mut(self, i);
     }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_tuple_element_pat_mut(&mut self, i: &mut crate::TupleElementPat) {
+        visit_tuple_element_pat_mut(self, i);
+    }
     #[cfg(any(feature = "derive", feature = "full"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]
     fn visit_tuple_element_type_mut(&mut self, i: &mut crate::TupleElementType) {
@@ -3006,7 +3011,7 @@ where
     skip!(node.paren_token);
     for mut el in Punctuated::pairs_mut(&mut node.elems) {
         let it = el.value_mut();
-        v.visit_pat_mut(it);
+        v.visit_tuple_element_pat_mut(it);
     }
 }
 #[cfg(feature = "full")]
@@ -3023,7 +3028,7 @@ where
     skip!(node.paren_token);
     for mut el in Punctuated::pairs_mut(&mut node.elems) {
         let it = el.value_mut();
-        v.visit_pat_mut(it);
+        v.visit_tuple_element_pat_mut(it);
     }
 }
 #[cfg(feature = "full")]
@@ -3410,6 +3415,15 @@ where
     V: VisitMut + ?Sized,
 {
     skip!(node.auto_token);
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_tuple_element_pat_mut<V>(v: &mut V, node: &mut crate::TupleElementPat)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_pat_mut(&mut node.pat);
 }
 #[cfg(any(feature = "derive", feature = "full"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "derive", feature = "full"))))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,7 @@ mod pat;
 pub use crate::pat::{
     FieldPat, Pat, PatConst, PatIdent, PatLit, PatMacro, PatOr, PatParen, PatPath, PatRange,
     PatReference, PatRest, PatSlice, PatStruct, PatTuple, PatTupleStruct, PatType, PatWild,
+    TupleElementPat,
 };
 
 #[cfg(any(feature = "full", feature = "derive"))]

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -187,7 +187,7 @@ ast_struct! {
     pub struct PatTuple {
         pub attrs: Vec<Attribute>,
         pub paren_token: token::Paren,
-        pub elems: Punctuated<Pat, Token![,]>,
+        pub elems: Punctuated<TupleElementPat, Token![,]>,
     }
 }
 
@@ -199,7 +199,7 @@ ast_struct! {
         pub qself: Option<QSelf>,
         pub path: Path,
         pub paren_token: token::Paren,
-        pub elems: Punctuated<Pat, Token![,]>,
+        pub elems: Punctuated<TupleElementPat, Token![,]>,
     }
 }
 
@@ -237,6 +237,15 @@ ast_struct! {
     }
 }
 
+ast_struct! {
+    /// A pattern element inside a tuple (or tuple struct) pattern.
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    pub struct TupleElementPat {
+        pub attrs: Vec<Attribute>,
+        pub pat: Pat,
+    }
+}
+
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::Attribute;
@@ -252,7 +261,7 @@ pub(crate) mod parsing {
     use crate::parse::{Parse, ParseStream};
     use crate::pat::{
         FieldPat, Pat, PatIdent, PatOr, PatParen, PatReference, PatRest, PatSlice, PatStruct,
-        PatTuple, PatTupleStruct, PatType, PatWild,
+        PatTuple, PatTupleStruct, PatType, PatWild, TupleElementPat,
     };
     use crate::path::{self, Path, QSelf};
     use crate::punctuated::Punctuated;
@@ -506,7 +515,10 @@ pub(crate) mod parsing {
         let mut elems = Punctuated::new();
         while !content.is_empty() {
             let value = Pat::parse_multi_with_leading_vert(&content)?;
-            elems.push_value(value);
+            elems.push_value(TupleElementPat {
+                attrs: Vec::new(),
+                pat: value,
+            });
             if content.is_empty() {
                 break;
             }
@@ -660,10 +672,16 @@ pub(crate) mod parsing {
                         pat: Box::new(value),
                     }));
                 }
-                elems.push_value(value);
+                elems.push_value(TupleElementPat {
+                    attrs: Vec::new(),
+                    pat: value,
+                });
                 break;
             }
-            elems.push_value(value);
+            elems.push_value(TupleElementPat {
+                attrs: Vec::new(),
+                pat: value,
+            });
             let punct = content.parse()?;
             elems.push_punct(punct);
         }
@@ -807,6 +825,17 @@ pub(crate) mod parsing {
 
         Ok(verbatim::between(begin, input.cursor()))
     }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
+    impl Parse for TupleElementPat {
+        fn parse(input: ParseStream) -> Result<Self> {
+            // TODO https://github.com/rust-lang/rfcs/pull/3532 parse attributes
+            Ok(TupleElementPat {
+                attrs: Vec::new(),
+                pat: Pat::parse_multi_with_leading_vert(input)?,
+            })
+        }
+    }
 }
 
 #[cfg(feature = "printing")]
@@ -814,7 +843,7 @@ mod printing {
     use crate::attr::FilterAttrs;
     use crate::pat::{
         FieldPat, Pat, PatIdent, PatOr, PatParen, PatReference, PatRest, PatSlice, PatStruct,
-        PatTuple, PatTupleStruct, PatType, PatWild,
+        PatTuple, PatTupleStruct, PatType, PatWild, TupleElementPat,
     };
     use crate::path;
     use crate::path::printing::PathStyle;
@@ -909,7 +938,7 @@ mod printing {
                 // which is a tuple pattern even without comma.
                 if self.elems.len() == 1
                     && !self.elems.trailing_punct()
-                    && !matches!(self.elems[0], Pat::Rest { .. })
+                    && !matches!(self.elems[0].pat, Pat::Rest { .. })
                 {
                     <Token![,]>::default().to_tokens(tokens);
                 }
@@ -954,6 +983,14 @@ mod printing {
                 self.member.to_tokens(tokens);
                 colon_token.to_tokens(tokens);
             }
+            self.pat.to_tokens(tokens);
+        }
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "printing")))]
+    impl ToTokens for TupleElementPat {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            tokens.append_all(self.attrs.outer());
             self.pat.to_tokens(tokens);
         }
     }

--- a/syn.json
+++ b/syn.json
@@ -4102,7 +4102,7 @@
         "elems": {
           "punctuated": {
             "element": {
-              "syn": "Pat"
+              "syn": "TupleElementPat"
             },
             "punct": "Comma"
           }
@@ -4136,7 +4136,7 @@
         "elems": {
           "punctuated": {
             "element": {
-              "syn": "Pat"
+              "syn": "TupleElementPat"
             },
             "punct": "Comma"
           }
@@ -4882,6 +4882,24 @@
         }
       },
       "exhaustive": false
+    },
+    {
+      "ident": "TupleElementPat",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "pat": {
+          "syn": "Pat"
+        }
+      }
     },
     {
       "ident": "TupleElementType",

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -4105,6 +4105,16 @@ impl Debug for Lite<syn::TraitModifiers> {
         formatter.finish()
     }
 }
+impl Debug for Lite<syn::TupleElementPat> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("TupleElementPat");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("pat", Lite(&self.value.pat));
+        formatter.finish()
+    }
+}
 impl Debug for Lite<syn::TupleElementType> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         let mut formatter = formatter.debug_struct("TupleElementType");

--- a/tests/test_parse_quote.rs
+++ b/tests/test_parse_quote.rs
@@ -101,11 +101,13 @@ fn test_pat() {
                     ],
                 },
                 elems: [
-                    Pat::Lit(ExprLit {
-                        lit: Lit::Bool {
-                            value: false,
-                        },
-                    }),
+                    TupleElementPat {
+                        pat: Pat::Lit(ExprLit {
+                            lit: Lit::Bool {
+                                value: false,
+                            },
+                        }),
+                    },
                 ],
             },
             Token![|],

--- a/tests/test_pat.rs
+++ b/tests/test_pat.rs
@@ -67,7 +67,9 @@ fn test_group() {
             ],
         },
         elems: [
-            Pat::Wild,
+            TupleElementPat {
+                pat: Pat::Wild,
+            },
         ],
     }
     "#);
@@ -114,45 +116,57 @@ fn test_tuple_comma() {
 
     expr.elems.push_value(parse_quote!(_));
     // Must not parse to Pat::Paren
-    snapshot!(expr.to_token_stream() as Pat, @r#"
+    snapshot!(expr.to_token_stream() as Pat, @"
     Pat::Tuple {
         elems: [
-            Pat::Wild,
+            TupleElementPat {
+                pat: Pat::Wild,
+            },
             Token![,],
         ],
     }
-    "#);
+    ");
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Pat, @r#"
+    snapshot!(expr.to_token_stream() as Pat, @"
     Pat::Tuple {
         elems: [
-            Pat::Wild,
+            TupleElementPat {
+                pat: Pat::Wild,
+            },
             Token![,],
         ],
     }
-    "#);
+    ");
 
     expr.elems.push_value(parse_quote!(_));
-    snapshot!(expr.to_token_stream() as Pat, @r#"
+    snapshot!(expr.to_token_stream() as Pat, @"
     Pat::Tuple {
         elems: [
-            Pat::Wild,
+            TupleElementPat {
+                pat: Pat::Wild,
+            },
             Token![,],
-            Pat::Wild,
+            TupleElementPat {
+                pat: Pat::Wild,
+            },
         ],
     }
-    "#);
+    ");
 
     expr.elems.push_punct(<Token![,]>::default());
-    snapshot!(expr.to_token_stream() as Pat, @r#"
+    snapshot!(expr.to_token_stream() as Pat, @"
     Pat::Tuple {
         elems: [
-            Pat::Wild,
+            TupleElementPat {
+                pat: Pat::Wild,
+            },
             Token![,],
-            Pat::Wild,
+            TupleElementPat {
+                pat: Pat::Wild,
+            },
             Token![,],
         ],
     }
-    "#);
+    ");
 }

--- a/tests/test_stmt.rs
+++ b/tests/test_stmt.rs
@@ -166,8 +166,10 @@ fn test_let_else() {
                 ],
             },
             elems: [
-                Pat::Ident {
-                    ident: "x",
+                TupleElementPat {
+                    pat: Pat::Ident {
+                        ident: "x",
+                    },
                 },
             ],
         },


### PR DESCRIPTION
Does not parse attributes yet, but allows the syntax tree to hold attributes for https://github.com/dtolnay/syn/issues/2013.