### PR TITLE
Update examples to match ergonomics

### DIFF
--- a/examples/heapsize/heapsize_derive/src/lib.rs
+++ b/examples/heapsize/heapsize_derive/src/lib.rs
@@ -36,7 +36,7 @@ pub fn derive_heap_size(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 // Add a bound `T: HeapSize` to every type parameter T.
 fn add_trait_bounds(mut generics: Generics) -> Generics {
     for param in &mut generics.params {
-        if let GenericParam::Type(ref mut type_param) = *param {
+        if let GenericParam::Type(type_param) = param {
             type_param.bounds.push(parse_quote!(heapsize::HeapSize));
         }
     }
@@ -45,10 +45,10 @@ fn add_trait_bounds(mut generics: Generics) -> Generics {
 
 // Generate an expression to sum up the heap size of each field.
 fn heap_size_sum(data: &Data) -> TokenStream {
-    match *data {
-        Data::Struct(ref data) => {
-            match data.fields {
-                Fields::Named(ref fields) => {
+    match data {
+        Data::Struct(data) => {
+            match &data.fields {
+                Fields::Named(fields) => {
                     // Expands to an expression like
                     //
                     //     0 + self.x.heap_size() + self.y.heap_size() + self.z.heap_size()
@@ -71,7 +71,7 @@ fn heap_size_sum(data: &Data) -> TokenStream {
                         0 #(+ #recurse)*
                     }
                 }
-                Fields::Unnamed(ref fields) => {
+                Fields::Unnamed(fields) => {
                     // Expands to an expression like
                     //
                     //     0 + self.0.heap_size() + self.1.heap_size() + self.2.heap_size()

--- a/examples/lazy-static/lazy-static/src/lib.rs
+++ b/examples/lazy-static/lazy-static/src/lib.rs
@@ -75,7 +75,7 @@ pub fn lazy_static(input: TokenStream) -> TokenStream {
     //        |
     //     10 |     static ref UNIT: () = ();
     //        |                           ^^
-    if let Expr::Tuple(ref init) = init {
+    if let Expr::Tuple(init) = &init {
         if init.elems.is_empty() {
             init.span()
                 .unwrap()

--- a/examples/trace-var/trace-var/src/lib.rs
+++ b/examples/trace-var/trace-var/src/lib.rs
@@ -33,8 +33,8 @@ impl Args {
     /// variables we intend to print. Expressions are used as the left-hand side
     /// of the assignment operator.
     fn should_print_expr(&self, e: &Expr) -> bool {
-        match *e {
-            Expr::Path(ref e) => {
+        match e {
+            Expr::Path(e) => {
                 if e.path.leading_colon.is_some() {
                     false
                 } else if e.path.segments.len() != 1 {
@@ -53,7 +53,7 @@ impl Args {
     /// a `let` binding.
     fn should_print_pat(&self, p: &Pat) -> bool {
         match p {
-            Pat::Ident(ref p) => self.vars.contains(&p.ident),
+            Pat::Ident(p) => self.vars.contains(&p.ident),
             _ => false,
         }
     }
@@ -85,8 +85,8 @@ impl Args {
     fn let_and_print(&mut self, local: Local) -> Stmt {
         let Local { pat, init, .. } = local;
         let init = self.fold_expr(*init.unwrap().expr);
-        let ident = match pat {
-            Pat::Ident(ref p) => &p.ident,
+        let ident = match &pat {
+            Pat::Ident(p) => &p.ident,
             _ => unreachable!(),
         };
         parse_quote! {


### PR DESCRIPTION
Deconflict with 2024 edition binding modes.

```console
error: cannot explicitly borrow within an implicitly-borrowing pattern
  --> examples/trace-var/trace-var/src/lib.rs:56:24
   |
56 |             Pat::Ident(ref p) => self.vars.contains(&p.ident),
   |                        ^^^ explicit `ref` binding modifier not allowed when implicitly borrowing
   |
   = note: for more information, see <https://doc.rust-lang.org/reference/patterns.html#binding-modes>
note: matching on a reference type with a non-reference pattern implicitly borrows the contents
  --> examples/trace-var/trace-var/src/lib.rs:56:13
   |
56 |             Pat::Ident(ref p) => self.vars.contains(&p.ident),
   |             ^^^^^^^^^^^^^^^^^ this non-reference pattern matches on a reference type `&_`
help: remove the unnecessary binding modifier
   |
56 -             Pat::Ident(ref p) => self.vars.contains(&p.ident),
56 +             Pat::Ident(p) => self.vars.contains(&p.ident),
   |
```