### PR TITLE
Touch up heapsize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,22 @@ macro as shown in the `heapsize` example, token-based macros in Syn are able to
 trigger errors that directly pinpoint the source of the problem.
 
 ```console
-error[E0277]: the trait bound `std::thread::Thread: HeapSize` is not satisfied
- --> src/main.rs:7:5
+error[E0277]: the trait bound `Thread: HeapSize` is not satisfied
+ --> src/main.rs:9:5
   |
-7 |     bad: std::thread::Thread,
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HeapSize` is not implemented for `std::thread::Thread`
+3 | #[derive(HeapSize)]
+  |          -------- required by a bound introduced by this call
+...
+9 |     bad: std::thread::Thread,
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HeapSize` is not implemented for `Thread`
+  |
+  = help: the following other types implement trait `HeapSize`:
+            &'a T
+            Box<T>
+            Demo<'a, T>
+            String
+            [T]
+            u8
 ```
 
 <br>

--- a/examples/heapsize/README.md
+++ b/examples/heapsize/README.md
@@ -49,24 +49,32 @@ field. Thus we get errors in the right place if any of the field types do not
 implement the `HeapSize` trait.
 
 ```
-error[E0277]: the trait bound `std::thread::Thread: HeapSize` is not satisfied
- --> src/main.rs:7:5
+error[E0277]: the trait bound `Thread: HeapSize` is not satisfied
+ --> src/main.rs:9:5
   |
-7 |     bad: std::thread::Thread,
-  |     ^^^ the trait `HeapSize` is not implemented for `std::thread::Thread`
+3 | #[derive(HeapSize)]
+  |          -------- required by a bound introduced by this call
+...
+9 |     bad: std::thread::Thread,
+  |     ^^^ the trait `HeapSize` is not implemented for `Thread`
+  |
+  = help: the following other types implement trait `HeapSize`:
+            &'a T
+            Box<T>
+            Demo<'a, T>
+            String
+            [T]
+            u8
 ```
 
 Some unstable APIs in the `proc-macro2` crate let us improve this further by
 joining together the span of the field name and the field type. There is no
 difference in our code &mdash; everything is as shown in this directory &mdash;
-but building the example crate with `cargo build` shows errors like the one
-above and building with `RUSTFLAGS='--cfg procmacro2_semver_exempt' cargo build`
-is able to show errors like the following.
+but building the example crate with a stable compiler shows errors like the one
+above (underlining the field name only) and building with nightly is able to
+show errors like the following (underlining the name and type).
 
 ```
-error[E0277]: the trait bound `std::thread::Thread: HeapSize` is not satisfied
- --> src/main.rs:7:5
-  |
-7 |     bad: std::thread::Thread,
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HeapSize` is not implemented for `std::thread::Thread`
+9 |     bad: std::thread::Thread,
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HeapSize` is not implemented for `Thread`
 ```

--- a/examples/heapsize/example/src/main.rs
+++ b/examples/heapsize/example/src/main.rs
@@ -23,6 +23,6 @@ fn main() {
         demo.b.heap_size_of_children(),
         demo.c.heap_size_of_children(),
         demo.d.heap_size_of_children(),
-        demo.heap_size_of_children()
+        demo.heap_size_of_children(),
     );
 }

--- a/examples/heapsize/heapsize/src/lib.rs
+++ b/examples/heapsize/heapsize/src/lib.rs
@@ -35,8 +35,8 @@ where
     T: ?Sized + HeapSize,
 {
     /// A `Box` owns however much heap memory was allocated to hold the value of
-    /// type `T` that we placed on the heap, plus transitively however much `T`
-    /// itself owns.
+    /// type `T` that we placed on the heap, plus transitively however much the
+    /// `T` owns.
     fn heap_size_of_children(&self) -> usize {
         mem::size_of_val(&**self) + (**self).heap_size_of_children()
     }

--- a/examples/heapsize/heapsize_derive/src/lib.rs
+++ b/examples/heapsize/heapsize_derive/src/lib.rs
@@ -14,15 +14,16 @@ pub fn derive_heap_size(input: proc_macro::TokenStream) -> proc_macro::TokenStre
     let name = input.ident;
 
     // Add a bound `T: HeapSize` to every type parameter T.
-    let generics = add_trait_bounds(input.generics);
+    let mut generics = input.generics;
+    add_trait_bounds(&mut generics);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     // Generate an expression to sum up the heap size of each field.
     let sum = heap_size_sum(&input.data);
 
+    // The generated impl.
     let expanded = quote! {
-        // The generated impl.
-        impl #impl_generics heapsize::HeapSize for #name #ty_generics #where_clause {
+        impl #impl_generics ::heapsize::HeapSize for #name #ty_generics #where_clause {
             fn heap_size_of_children(&self) -> usize {
                 #sum
             }
@@ -34,13 +35,12 @@ pub fn derive_heap_size(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 }
 
 // Add a bound `T: HeapSize` to every type parameter T.
-fn add_trait_bounds(mut generics: Generics) -> Generics {
+fn add_trait_bounds(generics: &mut Generics) {
     for param in &mut generics.params {
         if let GenericParam::Type(type_param) = param {
-            type_param.bounds.push(parse_quote!(heapsize::HeapSize));
+            type_param.bounds.push(parse_quote!(::heapsize::HeapSize));
         }
     }
-    generics
 }
 
 // Generate an expression to sum up the heap size of each field.
@@ -63,8 +63,9 @@ fn heap_size_sum(data: &Data) -> TokenStream {
                     // readme of the parent directory.
                     let recurse = fields.named.iter().map(|f| {
                         let name = &f.ident;
-                        quote_spanned! {f.span()=>
-                            heapsize::HeapSize::heap_size_of_children(&self.#name)
+                        let field_access = quote_spanned!(f.span()=> &self.#name);
+                        quote! {
+                            ::heapsize::HeapSize::heap_size_of_children(#field_access)
                         }
                     });
                     quote! {
@@ -77,8 +78,9 @@ fn heap_size_sum(data: &Data) -> TokenStream {
                     //     0 + self.0.heap_size() + self.1.heap_size() + self.2.heap_size()
                     let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
                         let index = Index::from(i);
-                        quote_spanned! {f.span()=>
-                            heapsize::HeapSize::heap_size_of_children(&self.#index)
+                        let field_access = quote_spanned!(f.span()=> &self.#index);
+                        quote! {
+                            ::heapsize::HeapSize::heap_size_of_children(#field_access)
                         }
                     });
                     quote! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,11 +149,22 @@
 //! problem.
 //!
 //! ```text
-//! error[E0277]: the trait bound `std::thread::Thread: HeapSize` is not satisfied
-//!  --> src/main.rs:7:5
+//! error[E0277]: the trait bound `Thread: HeapSize` is not satisfied
+//!  --> src/main.rs:9:5
 //!   |
-//! 7 |     bad: std::thread::Thread,
+//! 3 | #[derive(HeapSize)]
+//!   |          -------- required by a bound introduced by this call
+//! ...
+//! 9 |     bad: std::thread::Thread,
 //!   |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HeapSize` is not implemented for `Thread`
+//!   |
+//!   = help: the following other types implement trait `HeapSize`:
+//!             &'a T
+//!             Box<T>
+//!             Demo<'a, T>
+//!             String
+//!             [T]
+//!             u8
 //! ```
 //!
 //! <br>

--- a/src/parse_quote.rs
+++ b/src/parse_quote.rs
@@ -36,13 +36,12 @@
 /// use syn::{parse_quote, Generics, GenericParam};
 ///
 /// // Add a bound `T: HeapSize` to every type parameter T.
-/// fn add_trait_bounds(mut generics: Generics) -> Generics {
+/// fn add_trait_bounds(generics: &mut Generics) {
 ///     for param in &mut generics.params {
 ///         if let GenericParam::Type(type_param) = param {
-///             type_param.bounds.push(parse_quote!(HeapSize));
+///             type_param.bounds.push(parse_quote!(::heapsize::HeapSize));
 ///         }
 ///     }
-///     generics
 /// }
 /// ```
 ///


### PR DESCRIPTION
**Before:**

```console
error[E0277]: the trait bound `Thread: HeapSize` is not satisfied
 --> examples/heapsize/example/src/main.rs:9:5
  |
9 |     bad: std::thread::Thread,
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HeapSize` is not implemented for `Thread`
  |
help: consider borrowing here
  |
9 |     &bad: std::thread::Thread,
  |     +
```

**After:**

```console
error[E0277]: the trait bound `Thread: HeapSize` is not satisfied
 --> examples/heapsize/example/src/main.rs:9:5
  |
3 | #[derive(HeapSize)]
  |          -------- required by a bound introduced by this call
...
9 |     bad: std::thread::Thread,
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `HeapSize` is not implemented for `Thread`
  |
  = help: the following other types implement trait `HeapSize`:
            &'a T
            Box<T>
            Demo<'a, T>
            String
            [T]
            u8
```