### PR TITLE
Move Arm guard into a Pat::Guard variant

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1212,7 +1212,6 @@ ast_struct! {
     pub struct Arm {
         pub attrs: Vec<Attribute>,
         pub pat: Pat,
-        pub guard: Option<(Token![if], Box<Expr>)>,
         pub fat_arrow_token: Token![=>],
         pub body: Box<Expr>,
         pub comma: Option<Token![,]>,
@@ -1296,7 +1295,7 @@ pub(crate) mod parsing {
     use crate::parse::discouraged::Speculative as _;
     use crate::parse::{Parse, ParseStream};
     #[cfg(feature = "full")]
-    use crate::pat::{Pat, PatType};
+    use crate::pat::{Pat, PatGuard, PatType};
     use crate::path::{self, AngleBracketedGenericArguments, Path, QSelf};
     use crate::precedence::Precedence;
     use crate::punctuated::Punctuated;
@@ -2713,6 +2712,7 @@ pub(crate) mod parsing {
         } else {
             match &mut pat {
                 Pat::Const(pat) => pat.attrs = attrs,
+                Pat::Guard(_) => unreachable!(),
                 Pat::Ident(pat) => pat.attrs = attrs,
                 Pat::Lit(pat) => pat.attrs = attrs,
                 Pat::Macro(pat) => pat.attrs = attrs,
@@ -3101,15 +3101,19 @@ pub(crate) mod parsing {
             let requires_comma;
             Ok(Arm {
                 attrs: input.call(Attribute::parse_outer)?,
-                pat: Pat::parse_multi_with_leading_vert(input)?,
-                guard: {
+                pat: {
+                    let mut pat = Pat::parse_multi_with_leading_vert(input)?;
                     if input.peek(Token![if]) {
                         let if_token: Token![if] = input.parse()?;
                         let guard: Expr = input.parse()?;
-                        Some((if_token, Box::new(guard)))
-                    } else {
-                        None
+                        pat = Pat::Guard(PatGuard {
+                            attrs: Vec::new(),
+                            pat: Box::new(pat),
+                            if_token,
+                            guard: Box::new(guard),
+                        });
                     }
+                    pat
                 },
                 fat_arrow_token: input.parse()?,
                 body: {
@@ -4184,10 +4188,6 @@ pub(crate) mod printing {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             tokens.append_all(&self.attrs);
             self.pat.to_tokens(tokens);
-            if let Some((if_token, guard)) = &self.guard {
-                if_token.to_tokens(tokens);
-                guard.to_tokens(tokens);
-            }
             self.fat_arrow_token.to_tokens(tokens);
             print_expr(&self.body, tokens, FixupContext::new_match_arm());
             self.comma.to_tokens(tokens);

--- a/src/gen/clone.rs
+++ b/src/gen/clone.rs
@@ -31,7 +31,6 @@ impl Clone for crate::Arm {
         crate::Arm {
             attrs: self.attrs.clone(),
             pat: self.pat.clone(),
-            guard: self.guard.clone(),
             fat_arrow_token: self.fat_arrow_token.clone(),
             body: self.body.clone(),
             comma: self.comma.clone(),
@@ -1537,6 +1536,7 @@ impl Clone for crate::Pat {
     fn clone(&self) -> Self {
         match self {
             crate::Pat::Const(v0) => crate::Pat::Const(v0.clone()),
+            crate::Pat::Guard(v0) => crate::Pat::Guard(v0.clone()),
             crate::Pat::Ident(v0) => crate::Pat::Ident(v0.clone()),
             crate::Pat::Lit(v0) => crate::Pat::Lit(v0.clone()),
             crate::Pat::Macro(v0) => crate::Pat::Macro(v0.clone()),
@@ -1553,6 +1553,18 @@ impl Clone for crate::Pat {
             crate::Pat::Type(v0) => crate::Pat::Type(v0.clone()),
             crate::Pat::Verbatim(v0) => crate::Pat::Verbatim(v0.clone()),
             crate::Pat::Wild(v0) => crate::Pat::Wild(v0.clone()),
+        }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clone-impls")))]
+impl Clone for crate::PatGuard {
+    fn clone(&self) -> Self {
+        crate::PatGuard {
+            attrs: self.attrs.clone(),
+            pat: self.pat.clone(),
+            if_token: self.if_token.clone(),
+            guard: self.guard.clone(),
         }
     }
 }

--- a/src/gen/debug.rs
+++ b/src/gen/debug.rs
@@ -38,7 +38,6 @@ impl Debug for crate::Arm {
         let mut formatter = formatter.debug_struct("Arm");
         formatter.field("attrs", &self.attrs);
         formatter.field("pat", &self.pat);
-        formatter.field("guard", &self.guard);
         formatter.field("fat_arrow_token", &self.fat_arrow_token);
         formatter.field("body", &self.body);
         formatter.field("comma", &self.comma);
@@ -2216,6 +2215,7 @@ impl Debug for crate::Pat {
         formatter.write_str("Pat::")?;
         match self {
             crate::Pat::Const(v0) => v0.debug(formatter, "Const"),
+            crate::Pat::Guard(v0) => v0.debug(formatter, "Guard"),
             crate::Pat::Ident(v0) => v0.debug(formatter, "Ident"),
             crate::Pat::Lit(v0) => v0.debug(formatter, "Lit"),
             crate::Pat::Macro(v0) => v0.debug(formatter, "Macro"),
@@ -2237,6 +2237,24 @@ impl Debug for crate::Pat {
             }
             crate::Pat::Wild(v0) => v0.debug(formatter, "Wild"),
         }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Debug for crate::PatGuard {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.debug(formatter, "PatGuard")
+    }
+}
+#[cfg(feature = "full")]
+impl crate::PatGuard {
+    fn debug(&self, formatter: &mut fmt::Formatter, name: &str) -> fmt::Result {
+        let mut formatter = formatter.debug_struct(name);
+        formatter.field("attrs", &self.attrs);
+        formatter.field("pat", &self.pat);
+        formatter.field("if_token", &self.if_token);
+        formatter.field("guard", &self.guard);
+        formatter.finish()
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/eq.rs
+++ b/src/gen/eq.rs
@@ -32,8 +32,8 @@ impl Eq for crate::Arm {}
 #[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
 impl PartialEq for crate::Arm {
     fn eq(&self, other: &Self) -> bool {
-        self.attrs == other.attrs && self.pat == other.pat && self.guard == other.guard
-            && self.body == other.body && self.comma == other.comma
+        self.attrs == other.attrs && self.pat == other.pat && self.body == other.body
+            && self.comma == other.comma
     }
 }
 #[cfg(any(feature = "derive", feature = "full"))]
@@ -1529,6 +1529,7 @@ impl PartialEq for crate::Pat {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (crate::Pat::Const(self0), crate::Pat::Const(other0)) => self0 == other0,
+            (crate::Pat::Guard(self0), crate::Pat::Guard(other0)) => self0 == other0,
             (crate::Pat::Ident(self0), crate::Pat::Ident(other0)) => self0 == other0,
             (crate::Pat::Lit(self0), crate::Pat::Lit(other0)) => self0 == other0,
             (crate::Pat::Macro(self0), crate::Pat::Macro(other0)) => self0 == other0,
@@ -1553,6 +1554,16 @@ impl PartialEq for crate::Pat {
             (crate::Pat::Wild(self0), crate::Pat::Wild(other0)) => self0 == other0,
             _ => false,
         }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Eq for crate::PatGuard {}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl PartialEq for crate::PatGuard {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.pat == other.pat && self.guard == other.guard
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/fold.rs
+++ b/src/gen/fold.rs
@@ -702,6 +702,11 @@ pub trait Fold {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn fold_pat_guard(&mut self, i: crate::PatGuard) -> crate::PatGuard {
+        fold_pat_guard(self, i)
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn fold_pat_ident(&mut self, i: crate::PatIdent) -> crate::PatIdent {
         fold_pat_ident(self, i)
     }
@@ -1120,7 +1125,6 @@ where
     crate::Arm {
         attrs: f.fold_attributes(node.attrs),
         pat: f.fold_pat(node.pat),
-        guard: (node.guard).map(|it| ((it).0, Box::new(f.fold_expr(*(it).1)))),
         fat_arrow_token: node.fat_arrow_token,
         body: Box::new(f.fold_expr(*node.body)),
         comma: node.comma,
@@ -3051,6 +3055,7 @@ where
 {
     match node {
         crate::Pat::Const(_binding_0) => crate::Pat::Const(f.fold_expr_const(_binding_0)),
+        crate::Pat::Guard(_binding_0) => crate::Pat::Guard(f.fold_pat_guard(_binding_0)),
         crate::Pat::Ident(_binding_0) => crate::Pat::Ident(f.fold_pat_ident(_binding_0)),
         crate::Pat::Lit(_binding_0) => crate::Pat::Lit(f.fold_expr_lit(_binding_0)),
         crate::Pat::Macro(_binding_0) => crate::Pat::Macro(f.fold_expr_macro(_binding_0)),
@@ -3075,6 +3080,19 @@ where
             crate::Pat::Verbatim(f.fold_token_stream(_binding_0))
         }
         crate::Pat::Wild(_binding_0) => crate::Pat::Wild(f.fold_pat_wild(_binding_0)),
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn fold_pat_guard<F>(f: &mut F, node: crate::PatGuard) -> crate::PatGuard
+where
+    F: Fold + ?Sized,
+{
+    crate::PatGuard {
+        attrs: f.fold_attributes(node.attrs),
+        pat: Box::new(f.fold_pat(*node.pat)),
+        if_token: node.if_token,
+        guard: Box::new(f.fold_expr(*node.guard)),
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/hash.rs
+++ b/src/gen/hash.rs
@@ -36,7 +36,6 @@ impl Hash for crate::Arm {
     {
         self.attrs.hash(state);
         self.pat.hash(state);
-        self.guard.hash(state);
         self.body.hash(state);
         self.comma.hash(state);
     }
@@ -1927,71 +1926,87 @@ impl Hash for crate::Pat {
                 state.write_u8(0u8);
                 v0.hash(state);
             }
-            crate::Pat::Ident(v0) => {
+            crate::Pat::Guard(v0) => {
                 state.write_u8(1u8);
                 v0.hash(state);
             }
-            crate::Pat::Lit(v0) => {
+            crate::Pat::Ident(v0) => {
                 state.write_u8(2u8);
                 v0.hash(state);
             }
-            crate::Pat::Macro(v0) => {
+            crate::Pat::Lit(v0) => {
                 state.write_u8(3u8);
                 v0.hash(state);
             }
-            crate::Pat::Or(v0) => {
+            crate::Pat::Macro(v0) => {
                 state.write_u8(4u8);
                 v0.hash(state);
             }
-            crate::Pat::Paren(v0) => {
+            crate::Pat::Or(v0) => {
                 state.write_u8(5u8);
                 v0.hash(state);
             }
-            crate::Pat::Path(v0) => {
+            crate::Pat::Paren(v0) => {
                 state.write_u8(6u8);
                 v0.hash(state);
             }
-            crate::Pat::Range(v0) => {
+            crate::Pat::Path(v0) => {
                 state.write_u8(7u8);
                 v0.hash(state);
             }
-            crate::Pat::Reference(v0) => {
+            crate::Pat::Range(v0) => {
                 state.write_u8(8u8);
                 v0.hash(state);
             }
-            crate::Pat::Rest(v0) => {
+            crate::Pat::Reference(v0) => {
                 state.write_u8(9u8);
                 v0.hash(state);
             }
-            crate::Pat::Slice(v0) => {
+            crate::Pat::Rest(v0) => {
                 state.write_u8(10u8);
                 v0.hash(state);
             }
-            crate::Pat::Struct(v0) => {
+            crate::Pat::Slice(v0) => {
                 state.write_u8(11u8);
                 v0.hash(state);
             }
-            crate::Pat::Tuple(v0) => {
+            crate::Pat::Struct(v0) => {
                 state.write_u8(12u8);
                 v0.hash(state);
             }
-            crate::Pat::TupleStruct(v0) => {
+            crate::Pat::Tuple(v0) => {
                 state.write_u8(13u8);
                 v0.hash(state);
             }
-            crate::Pat::Type(v0) => {
+            crate::Pat::TupleStruct(v0) => {
                 state.write_u8(14u8);
                 v0.hash(state);
             }
-            crate::Pat::Verbatim(v0) => {
+            crate::Pat::Type(v0) => {
                 state.write_u8(15u8);
+                v0.hash(state);
+            }
+            crate::Pat::Verbatim(v0) => {
+                state.write_u8(16u8);
                 TokenStreamHelper(v0).hash(state);
             }
             crate::Pat::Wild(v0) => {
-                state.write_u8(16u8);
+                state.write_u8(17u8);
                 v0.hash(state);
             }
         }
+    }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "extra-traits")))]
+impl Hash for crate::PatGuard {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.attrs.hash(state);
+        self.pat.hash(state);
+        self.guard.hash(state);
     }
 }
 #[cfg(feature = "full")]

--- a/src/gen/visit.rs
+++ b/src/gen/visit.rs
@@ -652,6 +652,11 @@ pub trait Visit<'ast> {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_pat_guard(&mut self, i: &'ast crate::PatGuard) {
+        visit_pat_guard(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_pat_ident(&mut self, i: &'ast crate::PatIdent) {
         visit_pat_ident(self, i);
     }
@@ -1026,10 +1031,6 @@ where
         v.visit_attribute(it);
     }
     v.visit_pat(&node.pat);
-    if let Some(it) = &node.guard {
-        skip!((it).0);
-        v.visit_expr(&*(it).1);
-    }
     skip!(node.fat_arrow_token);
     v.visit_expr(&*node.body);
     skip!(node.comma);
@@ -3023,6 +3024,9 @@ where
         crate::Pat::Const(_binding_0) => {
             v.visit_expr_const(_binding_0);
         }
+        crate::Pat::Guard(_binding_0) => {
+            v.visit_pat_guard(_binding_0);
+        }
         crate::Pat::Ident(_binding_0) => {
             v.visit_pat_ident(_binding_0);
         }
@@ -3072,6 +3076,19 @@ where
             v.visit_pat_wild(_binding_0);
         }
     }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_pat_guard<'ast, V>(v: &mut V, node: &'ast crate::PatGuard)
+where
+    V: Visit<'ast> + ?Sized,
+{
+    for it in &node.attrs {
+        v.visit_attribute(it);
+    }
+    v.visit_pat(&*node.pat);
+    skip!(node.if_token);
+    v.visit_expr(&*node.guard);
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]

--- a/src/gen/visit_mut.rs
+++ b/src/gen/visit_mut.rs
@@ -662,6 +662,11 @@ pub trait VisitMut {
     }
     #[cfg(feature = "full")]
     #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    fn visit_pat_guard_mut(&mut self, i: &mut crate::PatGuard) {
+        visit_pat_guard_mut(self, i);
+    }
+    #[cfg(feature = "full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
     fn visit_pat_ident_mut(&mut self, i: &mut crate::PatIdent) {
         visit_pat_ident_mut(self, i);
     }
@@ -1034,10 +1039,6 @@ where
 {
     v.visit_attributes_mut(&mut node.attrs);
     v.visit_pat_mut(&mut node.pat);
-    if let Some(it) = &mut node.guard {
-        skip!((it).0);
-        v.visit_expr_mut(&mut *(it).1);
-    }
     skip!(node.fat_arrow_token);
     v.visit_expr_mut(&mut *node.body);
     skip!(node.comma);
@@ -2886,6 +2887,9 @@ where
         crate::Pat::Const(_binding_0) => {
             v.visit_expr_const_mut(_binding_0);
         }
+        crate::Pat::Guard(_binding_0) => {
+            v.visit_pat_guard_mut(_binding_0);
+        }
         crate::Pat::Ident(_binding_0) => {
             v.visit_pat_ident_mut(_binding_0);
         }
@@ -2935,6 +2939,17 @@ where
             v.visit_pat_wild_mut(_binding_0);
         }
     }
+}
+#[cfg(feature = "full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+pub fn visit_pat_guard_mut<V>(v: &mut V, node: &mut crate::PatGuard)
+where
+    V: VisitMut + ?Sized,
+{
+    v.visit_attributes_mut(&mut node.attrs);
+    v.visit_pat_mut(&mut *node.pat);
+    skip!(node.if_token);
+    v.visit_expr_mut(&mut *node.guard);
 }
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,8 +498,9 @@ mod pat;
 #[cfg(feature = "full")]
 #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
 pub use crate::pat::{
-    FieldPat, Pat, PatConst, PatIdent, PatLit, PatMacro, PatOr, PatParen, PatPath, PatRange,
-    PatReference, PatRest, PatSlice, PatStruct, PatTuple, PatTupleStruct, PatType, PatWild,
+    FieldPat, Pat, PatConst, PatGuard, PatIdent, PatLit, PatMacro, PatOr, PatParen, PatPath,
+    PatRange, PatReference, PatRest, PatSlice, PatStruct, PatTuple, PatTupleStruct, PatType,
+    PatWild,
 };
 
 #[cfg(any(feature = "full", feature = "derive"))]

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -1,5 +1,5 @@
 use crate::attr::Attribute;
-use crate::expr::Member;
+use crate::expr::{Expr, Member};
 use crate::ident::Ident;
 use crate::path::{Path, QSelf};
 use crate::punctuated::Punctuated;
@@ -28,6 +28,9 @@ ast_enum_of_structs! {
     pub enum Pat {
         /// A const block: `const { ... }`.
         Const(PatConst),
+
+        /// A pattern with guard predicate: `Some(x) if x > 0`.
+        Guard(PatGuard),
 
         /// A pattern that binds a new variable: `ref mut binding @ SUBPATTERN`.
         Ident(PatIdent),
@@ -115,6 +118,17 @@ ast_struct! {
         pub mutability: Option<Token![mut]>,
         pub ident: Ident,
         pub subpat: Option<(Token![@], Box<Pat>)>,
+    }
+}
+
+ast_struct! {
+    /// A pattern with guard predicate: `Some(x) if x > 0`.
+    #[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+    pub struct PatGuard {
+        pub attrs: Vec<Attribute>,
+        pub pat: Box<Pat>,
+        pub if_token: Token![if],
+        pub guard: Box<Expr>,
     }
 }
 
@@ -813,8 +827,8 @@ pub(crate) mod parsing {
 mod printing {
     use crate::attr::FilterAttrs;
     use crate::pat::{
-        FieldPat, Pat, PatIdent, PatOr, PatParen, PatReference, PatRest, PatSlice, PatStruct,
-        PatTuple, PatTupleStruct, PatType, PatWild,
+        FieldPat, Pat, PatGuard, PatIdent, PatOr, PatParen, PatReference, PatRest, PatSlice,
+        PatStruct, PatTuple, PatTupleStruct, PatType, PatWild,
     };
     use crate::path;
     use crate::path::printing::PathStyle;
@@ -832,6 +846,16 @@ mod printing {
                 at_token.to_tokens(tokens);
                 subpat.to_tokens(tokens);
             }
+        }
+    }
+
+    #[cfg_attr(docsrs, doc(cfg(feature = "printing")))]
+    impl ToTokens for PatGuard {
+        fn to_tokens(&self, tokens: &mut TokenStream) {
+            tokens.append_all(self.attrs.outer());
+            self.pat.to_tokens(tokens);
+            self.if_token.to_tokens(tokens);
+            self.guard.to_tokens(tokens);
         }
     }
 

--- a/syn.json
+++ b/syn.json
@@ -66,20 +66,6 @@
         "pat": {
           "syn": "Pat"
         },
-        "guard": {
-          "option": {
-            "tuple": [
-              {
-                "token": "If"
-              },
-              {
-                "box": {
-                  "syn": "Expr"
-                }
-              }
-            ]
-          }
-        },
         "fat_arrow_token": {
           "token": "FatArrow"
         },
@@ -3826,6 +3812,11 @@
             "syn": "ExprConst"
           }
         ],
+        "Guard": [
+          {
+            "syn": "PatGuard"
+          }
+        ],
         "Ident": [
           {
             "syn": "PatIdent"
@@ -3908,6 +3899,34 @@
         ]
       },
       "exhaustive": false
+    },
+    {
+      "ident": "PatGuard",
+      "features": {
+        "any": [
+          "full"
+        ]
+      },
+      "fields": {
+        "attrs": {
+          "vec": {
+            "syn": "Attribute"
+          }
+        },
+        "pat": {
+          "box": {
+            "syn": "Pat"
+          }
+        },
+        "if_token": {
+          "token": "If"
+        },
+        "guard": {
+          "box": {
+            "syn": "Expr"
+          }
+        }
+      }
     },
     {
       "ident": "PatIdent",

--- a/tests/debug/gen.rs
+++ b/tests/debug/gen.rs
@@ -44,20 +44,6 @@ impl Debug for Lite<syn::Arm> {
             formatter.field("attrs", Lite(&self.value.attrs));
         }
         formatter.field("pat", Lite(&self.value.pat));
-        if let Some(val) = &self.value.guard {
-            #[derive(RefCast)]
-            #[repr(transparent)]
-            struct Print((syn::token::If, Box<syn::Expr>));
-            impl Debug for Print {
-                fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("Some(")?;
-                    Debug::fmt(Lite(&self.0.1), formatter)?;
-                    formatter.write_str(")")?;
-                    Ok(())
-                }
-            }
-            formatter.field("guard", Print::ref_cast(val));
-        }
         formatter.field("body", Lite(&self.value.body));
         if self.value.comma.is_some() {
             formatter.field("comma", &Present);
@@ -3132,6 +3118,15 @@ impl Debug for Lite<syn::Pat> {
                 formatter.write_str(")")?;
                 Ok(())
             }
+            syn::Pat::Guard(_val) => {
+                let mut formatter = formatter.debug_struct("Pat::Guard");
+                if !_val.attrs.is_empty() {
+                    formatter.field("attrs", Lite(&_val.attrs));
+                }
+                formatter.field("pat", Lite(&_val.pat));
+                formatter.field("guard", Lite(&_val.guard));
+                formatter.finish()
+            }
             syn::Pat::Ident(_val) => {
                 let mut formatter = formatter.debug_struct("Pat::Ident");
                 if !_val.attrs.is_empty() {
@@ -3336,6 +3331,17 @@ impl Debug for Lite<syn::Pat> {
             }
             _ => unreachable!(),
         }
+    }
+}
+impl Debug for Lite<syn::PatGuard> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let mut formatter = formatter.debug_struct("PatGuard");
+        if !self.value.attrs.is_empty() {
+            formatter.field("attrs", Lite(&self.value.attrs));
+        }
+        formatter.field("pat", Lite(&self.value.pat));
+        formatter.field("guard", Lite(&self.value.guard));
+        formatter.finish()
     }
 }
 impl Debug for Lite<syn::PatIdent> {

--- a/tests/test_expr.rs
+++ b/tests/test_expr.rs
@@ -32,8 +32,9 @@ use syn::{
     ExprIf, ExprIndex, ExprLet, ExprLit, ExprLoop, ExprMacro, ExprMatch, ExprMethodCall, ExprPath,
     ExprRange, ExprRawAddr, ExprReference, ExprReturn, ExprStruct, ExprTry, ExprTryBlock,
     ExprTuple, ExprUnary, ExprUnsafe, ExprWhile, ExprYield, GenericArgument, Label, Lifetime, Lit,
-    LitInt, Macro, MacroDelimiter, Member, Pat, PatWild, Path, PathArguments, PathSegment,
-    PointerMutability, QSelf, RangeLimits, ReturnType, Stmt, Token, Type, TypePath, UnOp,
+    LitInt, Macro, MacroDelimiter, Member, Pat, PatGuard, PatWild, Path, PathArguments,
+    PathSegment, PointerMutability, QSelf, RangeLimits, ReturnType, Stmt, Token, Type, TypePath,
+    UnOp,
 };
 
 #[test]
@@ -1497,7 +1498,6 @@ fn test_permutations() -> ExitCode {
                             attrs: Vec::new(),
                             underscore_token: Token![_](span),
                         }),
-                        guard: None,
                         fat_arrow_token: Token![=>](span),
                         body: Box::new(expr.clone()),
                         comma: None,
@@ -1515,11 +1515,15 @@ fn test_permutations() -> ExitCode {
                     brace_token: token::Brace(span),
                     arms: Vec::from([Arm {
                         attrs: Vec::new(),
-                        pat: Pat::Wild(PatWild {
+                        pat: Pat::Guard(PatGuard {
                             attrs: Vec::new(),
-                            underscore_token: Token![_](span),
+                            pat: Box::new(Pat::Wild(PatWild {
+                                attrs: Vec::new(),
+                                underscore_token: Token![_](span),
+                            })),
+                            if_token: Token![if](span),
+                            guard: Box::new(expr),
                         }),
-                        guard: Some((Token![if](span), Box::new(expr))),
                         fat_arrow_token: Token![=>](span),
                         body: Box::new(Expr::Block(ExprBlock {
                             attrs: Vec::new(),


### PR DESCRIPTION
Creates space for future syntax in #1793.