### PR TITLE
Permit keyword lifetimes in most positions

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2783,7 +2783,7 @@ pub(crate) mod parsing {
     impl Parse for Label {
         fn parse(input: ParseStream) -> Result<Self> {
             Ok(Label {
-                name: input.parse()?,
+                name: Lifetime::parse_any(input)?,
                 colon_token: input.parse()?,
             })
         }
@@ -2808,7 +2808,7 @@ pub(crate) mod parsing {
             Ok(ExprContinue {
                 attrs: Vec::new(),
                 continue_token: input.parse()?,
-                label: input.parse()?,
+                label: Lifetime::parse_optional_any(input),
             })
         }
     }
@@ -2818,7 +2818,7 @@ pub(crate) mod parsing {
         let break_token: Token![break] = input.parse()?;
 
         let ahead = input.fork();
-        let label: Option<Lifetime> = ahead.parse()?;
+        let label = Lifetime::parse_optional_any(&ahead);
         if label.is_some() && ahead.peek(Token![:]) {
             // Not allowed: `break 'label: loop {...}`
             // Parentheses are required. `break ('label: loop {...})`

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -655,7 +655,7 @@ pub(crate) mod parsing {
             let has_colon;
             Ok(LifetimeParam {
                 attrs: input.call(Attribute::parse_outer)?,
-                lifetime: input.parse()?,
+                lifetime: Lifetime::parse_any(input)?,
                 colon_token: {
                     if input.peek(Token![:]) {
                         has_colon = true;
@@ -672,7 +672,7 @@ pub(crate) mod parsing {
                             if input.is_empty() || input.peek(Token![,]) || input.peek(Token![>]) {
                                 break;
                             }
-                            let value = input.parse()?;
+                            let value = Lifetime::parse_any(input)?;
                             bounds.push_value(value);
                             if !input.peek(Token![+]) {
                                 break;
@@ -782,7 +782,7 @@ pub(crate) mod parsing {
             allow_const: bool,
         ) -> Result<Self> {
             if input.peek(Lifetime) {
-                return input.parse().map(TypeParamBound::Lifetime);
+                return Lifetime::parse_any(input).map(TypeParamBound::Lifetime);
             }
 
             #[cfg(feature = "full")]
@@ -994,7 +994,7 @@ pub(crate) mod parsing {
             if input.peek(Lifetime) && input.peek2(Token![:]) {
                 Ok(WherePredicate::Lifetime(PredicateLifetime {
                     attrs,
-                    lifetime: input.parse()?,
+                    lifetime: Lifetime::parse_any(input)?,
                     colon_token: input.parse()?,
                     bounds: {
                         let mut bounds = Punctuated::new();
@@ -1008,7 +1008,7 @@ pub(crate) mod parsing {
                             {
                                 break;
                             }
-                            let value = input.parse()?;
+                            let value = Lifetime::parse_any(input)?;
                             bounds.push_value(value);
                             if !input.peek(Token![+]) {
                                 break;
@@ -1103,7 +1103,7 @@ pub(crate) mod parsing {
         fn parse(input: ParseStream) -> Result<Self> {
             let lookahead = input.lookahead1();
             if lookahead.peek(Lifetime) {
-                input.parse().map(CapturedParam::Lifetime)
+                Lifetime::parse_any(input).map(CapturedParam::Lifetime)
             } else if lookahead.peek(Ident) || input.peek(Token![Self]) {
                 input.call(Ident::parse_any).map(CapturedParam::Ident)
             } else {

--- a/src/item.rs
+++ b/src/item.rs
@@ -1967,7 +1967,7 @@ pub(crate) mod parsing {
     )> {
         let reference = if input.peek(Token![&]) {
             let ampersand: Token![&] = input.parse()?;
-            let lifetime: Option<Lifetime> = input.parse()?;
+            let lifetime = Lifetime::parse_optional_any(input);
             Some((ampersand, lifetime))
         } else {
             None

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -162,6 +162,18 @@ pub(crate) mod parsing {
             })
         }
     }
+
+    impl Lifetime {
+        #[cfg(any(feature = "full", feature = "derive"))]
+        pub(crate) fn parse_optional_any(input: ParseStream) -> Option<Self> {
+            input
+                .step(|cursor| match cursor.lifetime() {
+                    Some((lifetime, rest)) => Ok((Some(lifetime), rest)),
+                    None => Ok((None, *cursor)),
+                })
+                .unwrap()
+        }
+    }
 }
 
 #[cfg(feature = "printing")]

--- a/src/path.rs
+++ b/src/path.rs
@@ -316,7 +316,7 @@ pub(crate) mod parsing {
     impl Parse for GenericArgument {
         fn parse(input: ParseStream) -> Result<Self> {
             if input.peek(Lifetime) && !input.peek2(Token![+]) {
-                return Ok(GenericArgument::Lifetime(input.parse()?));
+                return Ok(GenericArgument::Lifetime(Lifetime::parse_any(input)?));
             }
 
             if input.peek(Lit) || input.peek(token::Brace) {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -721,7 +721,7 @@ pub(crate) mod parsing {
             Ok(TypeReference {
                 attrs: Vec::new(),
                 and_token: input.parse()?,
-                lifetime: input.parse()?,
+                lifetime: Lifetime::parse_optional_any(input),
                 mutability: input.parse()?,
                 // & binds tighter than +, so we don't allow + here.
                 elem: Box::new(input.call(Type::without_plus)?),


### PR DESCRIPTION
A macro should be able to parse and rewrite syntax involving keyword lifetimes according to its own rules. Previously this would have failed to parse.

```rust
struct Struct {
    f: &'self u8,
}
```