### PR TITLE
Delete old const impl syntax

### DIFF
--- a/src/item.rs
+++ b/src/item.rs
@@ -2946,13 +2946,6 @@ pub(crate) mod parsing {
             Generics::default()
         };
 
-        let is_const_impl = allow_verbatim_impl
-            && (input.peek(Token![const]) || input.peek(Token![?]) && input.peek2(Token![const]));
-        if is_const_impl {
-            input.parse::<Option<Token![?]>>()?;
-            input.parse::<Token![const]>()?;
-        }
-
         let polarity = if input.peek(Token![!]) && !input.peek2(token::Brace) {
             Some(input.parse::<Token![!]>()?)
         } else {
@@ -3022,7 +3015,7 @@ pub(crate) mod parsing {
             items.push(content.parse()?);
         }
 
-        if has_visibility || is_const_impl || is_impl_for && trait_.is_none() {
+        if has_visibility || is_impl_for && trait_.is_none() {
             Ok(None)
         } else {
             Ok(Some(ItemImpl {

--- a/tests/repo/mod.rs
+++ b/tests/repo/mod.rs
@@ -631,6 +631,10 @@ static EXCLUDE_FILES: &[&str] = &[
     "src/tools/rustfmt/tests/target/negative-bounds.rs",
     "tests/ui/traits/negative-bounds/supertrait.rs",
 
+    // Outdated const impl syntax: `impl const Trait for Type`
+    "src/tools/rust-analyzer/crates/parser/test_data/parser/inline/ok/impl_item_const.rs",
+    "src/tools/rust-analyzer/crates/test-utils/src/minicore.rs",
+
     // Const impl that is not a trait impl: `impl ~const T {}`
     "tests/ui/traits/const-traits/syntax.rs",
 


### PR DESCRIPTION
In preparation for https://github.com/dtolnay/syn/issues/1980.