### PR TITLE
Add Error::new_range constructor taking Range<Cursor>

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -364,7 +364,6 @@ impl<'a> Cursor<'a> {
 
     /// Returns the `Span` of the token immediately prior to the position of
     /// this cursor, or of the current token if there is no previous one.
-    #[cfg(any(feature = "full", feature = "derive"))]
     pub(crate) fn prev_span(mut self) -> Span {
         if start_of_buffer(self) < self.ptr {
             self.ptr = unsafe { self.ptr.sub(1) };

--- a/src/data.rs
+++ b/src/data.rs
@@ -276,7 +276,7 @@ impl<'a> Clone for Members<'a> {
 pub(crate) mod parsing {
     use crate::attr::Attribute;
     use crate::data::{Field, FieldModifiers, Fields, FieldsNamed, FieldsUnnamed, Variant};
-    use crate::error::Result;
+    use crate::error::{Error, Result};
     use crate::expr::Expr;
     use crate::ext::IdentExt as _;
     use crate::ident::Ident;
@@ -410,12 +410,11 @@ pub(crate) mod parsing {
 
             if input.peek(Token![=]) {
                 input.parse::<Token![=]>()?;
-                let start_span = input.span();
+                let expr_start = input.cursor();
                 input.parse::<Expr>()?;
-                let end_span = input.cursor().prev_span();
-                return Err(crate::error::new2(
-                    start_span,
-                    end_span,
+                let expr_end = input.cursor();
+                return Err(Error::new_range(
+                    expr_start..expr_end,
                     "field default value is only supported in structs with named fields",
                 ));
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display};
+#[cfg(feature = "parsing")]
+use core::ops::Range;
 use core::slice;
 use proc_macro2::{
     Delimiter, Group, Ident, LexError, Literal, Punct, Spacing, Span, TokenStream, TokenTree,
@@ -201,6 +203,79 @@ impl Error {
             Error {
                 messages: vec![ErrorMessage {
                     span: ThreadBound::new(SpanRange { start, end }),
+                    message,
+                }],
+            }
+        }
+    }
+
+    /// Creates an error spanning the given cursor range.
+    ///
+    /// # Example
+    ///
+    /// This parses a sequence of '+'-separated lifetimes and types like
+    /// `Vec<u8> + dyn Display + 'static`, at least one of which must be a type.
+    ///
+    /// ```
+    /// use syn::{Lifetime, Token, Type};
+    /// use syn::parse::{Error, ParseStream, Result};
+    ///
+    /// enum Thing {
+    ///     Lifetime(Lifetime),
+    ///     Type(Type),
+    /// }
+    ///
+    /// fn parse_things(input: ParseStream) -> Result<Vec<Thing>> {
+    ///     let things_begin = input.cursor();
+    ///     let things_end;
+    ///     let mut things = Vec::new();
+    ///     let mut has_type = false;
+    ///     loop {
+    ///         if input.peek(Lifetime) {
+    ///             let lifetime: Lifetime = input.parse()?;
+    ///             things.push(Thing::Lifetime(lifetime));
+    ///         } else {
+    ///             let ty = input.call(Type::without_plus)?;
+    ///             things.push(Thing::Type(ty));
+    ///             has_type = true;
+    ///         }
+    ///         let plus_token: Option<Token![+]> = input.parse()?;
+    ///         if plus_token.is_none() {
+    ///             things_end = input.cursor();
+    ///             break;
+    ///         }
+    ///     }
+    ///
+    ///     if has_type {
+    ///         Ok(things)
+    ///     } else {
+    ///         let msg = "things must not be all lifetimes, at least one type is required";
+    ///         Err(Error::new_range(things_begin..things_end, msg))
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ```text
+    /// error: things must not be all lifetimes, at least one type is required
+    ///  --> example.rs:4:23
+    ///   |
+    /// 4 |     example!(THINGS = 'a + 'b, ...);
+    ///   |                       ^^^^^^^
+    /// ```
+    #[cfg(feature = "parsing")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
+    pub fn new_range<'a>(span: impl Into<Range<Cursor<'a>>>, message: impl Display) -> Self {
+        return new_range(span.into(), message.to_string());
+
+        fn new_range(span: Range<Cursor>, message: String) -> Error {
+            assert!(crate::buffer::same_buffer(span.start, span.end));
+            assert!(span.start < span.end);
+            Error {
+                messages: vec![ErrorMessage {
+                    span: ThreadBound::new(SpanRange {
+                        start: span.start.span(),
+                        end: span.end.prev_span(),
+                    }),
                     message,
                 }],
             }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -2817,16 +2817,14 @@ pub(crate) mod parsing {
         let break_token: Token![break] = input.parse()?;
 
         let ahead = input.fork();
+        let label_begin = ahead.cursor();
         let label = Lifetime::parse_optional_any(&ahead);
         if label.is_some() && ahead.peek(Token![:]) {
             // Not allowed: `break 'label: loop {...}`
             // Parentheses are required. `break ('label: loop {...})`
             let _: Expr = input.parse()?;
-            let start_span = label.unwrap().apostrophe;
-            let end_span = input.cursor().prev_span();
-            return Err(crate::error::new2(
-                start_span,
-                end_span,
+            return Err(Error::new_range(
+                label_begin..input.cursor(),
                 "parentheses required",
             ));
         }

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -540,8 +540,6 @@ ast_struct! {
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::Attribute;
-    #[cfg(feature = "full")]
-    use crate::error;
     use crate::error::{Error, Result};
     use crate::ext::IdentExt as _;
     use crate::generics::{
@@ -788,16 +786,13 @@ pub(crate) mod parsing {
             #[cfg(feature = "full")]
             {
                 if input.peek(Token![use]) {
+                    let precise_capture_begin = input.cursor();
                     let precise_capture: PreciseCapture = input.parse()?;
                     return if allow_precise_capture {
                         Ok(TypeParamBound::PreciseCapture(precise_capture))
                     } else {
                         let msg = "`use<...>` precise capturing syntax is not allowed here";
-                        Err(error::new2(
-                            precise_capture.use_token.span,
-                            precise_capture.gt_token.span,
-                            msg,
-                        ))
+                        Err(Error::new_range(precise_capture_begin..input.cursor(), msg))
                     };
                 }
             }

--- a/src/item.rs
+++ b/src/item.rs
@@ -3065,9 +3065,8 @@ pub(crate) mod parsing {
                     unreachable!();
                 }
             } else if !allow_verbatim_impl {
-                return Err(crate::error::new2(
-                    first_ty_begin.span(),
-                    first_ty_end.prev_span(),
+                return Err(Error::new_range(
+                    first_ty_begin..first_ty_end,
                     "expected trait path",
                 ));
             } else {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -309,7 +309,8 @@ ast_enum! {
 #[cfg(feature = "parsing")]
 pub(crate) mod parsing {
     use crate::attr::Attribute;
-    use crate::error::{self, Result};
+    use crate::buffer::Cursor;
+    use crate::error::{Error, Result};
     use crate::ext::IdentExt as _;
     use crate::generics::{BoundLifetimes, TraitBound, TraitBoundModifiers, TypeParamBound};
     use crate::ident::Ident;
@@ -328,7 +329,7 @@ pub(crate) mod parsing {
     use crate::verbatim;
     use alloc::boxed::Box;
     use alloc::vec::Vec;
-    use proc_macro2::{Span, TokenStream};
+    use proc_macro2::TokenStream;
 
     #[cfg_attr(docsrs, doc(cfg(feature = "parsing")))]
     impl Parse for Type {
@@ -641,10 +642,10 @@ pub(crate) mod parsing {
 
             Ok(Type::Path(ty))
         } else if lookahead.peek(Token![dyn]) {
+            let dyn_begin = input.cursor();
             let dyn_token: Token![dyn] = input.parse()?;
-            let dyn_span = dyn_token.span;
             let star_token: Option<Token![*]> = input.parse()?;
-            let bounds = TypeTraitObject::parse_bounds(dyn_span, input, allow_plus)?;
+            let bounds = TypeTraitObject::parse_bounds(dyn_begin, input, allow_plus)?;
             Ok(if star_token.is_some() {
                 Type::Verbatim(verbatim::between(begin, input.cursor()))
             } else {
@@ -912,12 +913,9 @@ pub(crate) mod parsing {
 
         // Only allow multiple trait references if allow_plus is true.
         pub(crate) fn parse(input: ParseStream, allow_plus: bool) -> Result<Self> {
+            let dyn_begin = input.cursor();
             let dyn_token: Option<Token![dyn]> = input.parse()?;
-            let dyn_span = match &dyn_token {
-                Some(token) => token.span,
-                None => input.span(),
-            };
-            let bounds = Self::parse_bounds(dyn_span, input, allow_plus)?;
+            let bounds = Self::parse_bounds(dyn_begin, input, allow_plus)?;
             Ok(TypeTraitObject {
                 attrs: Vec::new(),
                 dyn_token,
@@ -926,7 +924,7 @@ pub(crate) mod parsing {
         }
 
         fn parse_bounds(
-            dyn_span: Span,
+            dyn_begin: Cursor,
             input: ParseStream,
             allow_plus: bool,
         ) -> Result<Punctuated<TypeParamBound, Token![+]>> {
@@ -938,7 +936,6 @@ pub(crate) mod parsing {
                 allow_precise_capture,
                 allow_const,
             )?;
-            let mut last_lifetime_span = None;
             let mut at_least_one_trait = false;
             for bound in &bounds {
                 match bound {
@@ -946,9 +943,7 @@ pub(crate) mod parsing {
                         at_least_one_trait = true;
                         break;
                     }
-                    TypeParamBound::Lifetime(lifetime) => {
-                        last_lifetime_span = Some(lifetime.ident.span());
-                    }
+                    TypeParamBound::Lifetime(_) => {}
                     TypeParamBound::PreciseCapture(_) | TypeParamBound::Verbatim(_) => {
                         unreachable!()
                     }
@@ -957,7 +952,7 @@ pub(crate) mod parsing {
             // Just lifetimes like `'a + 'b` is not a TraitObject.
             if !at_least_one_trait {
                 let msg = "at least one trait is required for an object type";
-                return Err(error::new2(dyn_span, last_lifetime_span.unwrap(), msg));
+                return Err(Error::new_range(dyn_begin..input.cursor(), msg));
             }
             Ok(bounds)
         }
@@ -979,6 +974,7 @@ pub(crate) mod parsing {
         }
 
         pub(crate) fn parse(input: ParseStream, allow_plus: bool) -> Result<Self> {
+            let impl_begin = input.cursor();
             let impl_token: Token![impl] = input.parse()?;
             let allow_precise_capture = true;
             let allow_const = true;
@@ -988,7 +984,6 @@ pub(crate) mod parsing {
                 allow_precise_capture,
                 allow_const,
             )?;
-            let mut last_nontrait_span = None;
             let mut at_least_one_trait = false;
             for bound in &bounds {
                 match bound {
@@ -996,20 +991,7 @@ pub(crate) mod parsing {
                         at_least_one_trait = true;
                         break;
                     }
-                    TypeParamBound::Lifetime(lifetime) => {
-                        last_nontrait_span = Some(lifetime.ident.span());
-                    }
-                    TypeParamBound::PreciseCapture(precise_capture) => {
-                        #[cfg(feature = "full")]
-                        {
-                            last_nontrait_span = Some(precise_capture.gt_token.span);
-                        }
-                        #[cfg(not(feature = "full"))]
-                        {
-                            _ = precise_capture;
-                            unreachable!();
-                        }
-                    }
+                    TypeParamBound::Lifetime(_) | TypeParamBound::PreciseCapture(_) => {}
                     TypeParamBound::Verbatim(_) => {
                         // `[const] Trait`
                         at_least_one_trait = true;
@@ -1019,11 +1001,7 @@ pub(crate) mod parsing {
             }
             if !at_least_one_trait {
                 let msg = "at least one trait must be specified";
-                return Err(error::new2(
-                    impl_token.span,
-                    last_nontrait_span.unwrap(),
-                    msg,
-                ));
+                return Err(Error::new_range(impl_begin..input.cursor(), msg));
             }
             Ok(TypeImplTrait {
                 attrs: Vec::new(),


### PR DESCRIPTION
**Example:** This parses a sequence of '+'-separated lifetimes and types like `Vec<u8> + dyn Display + 'static`, at least one of which must be a type.

```rust
use syn::{Lifetime, Token, Type};
use syn::parse::{Error, ParseStream, Result};

enum Thing {
    Lifetime(Lifetime),
    Type(Type),
}

fn parse_things(input: ParseStream) -> Result<Vec<Thing>> {
    let things_begin = input.cursor();
    let things_end;
    let mut things = Vec::new();
    let mut has_type = false;
    loop {
        if input.peek(Lifetime) {
            let lifetime: Lifetime = input.parse()?;
            things.push(Thing::Lifetime(lifetime));
        } else {
            let ty = input.call(Type::without_plus)?;
            things.push(Thing::Type(ty));
            has_type = true;
        }
        let plus_token: Option<Token![+]> = input.parse()?;
        if plus_token.is_none() {
            things_end = input.cursor();
            break;
        }
    }

    if has_type {
        Ok(things)
    } else {
        let msg = "things must not be all lifetimes, at least one type is required";
        Err(Error::new_range(things_begin..things_end, msg))
    }
}
```

```console
error: things must not be all lifetimes, at least one type is required
 --> example.rs:4:23
  |
4 |     example!(THINGS = 'a + 'b, ...);
  |                       ^^^^^^^
```