### PR TITLE
Add explanation of compatibility strategy

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -288,6 +288,12 @@ ast_enum_of_structs! {
         Unsafe(ExprUnsafe),
 
         /// Tokens in expression position not interpreted by Syn.
+        ///
+        /// <div class="warning">
+        ///
+        /// Important: see [Compatibility notes][crate#verbatim-variants].
+        ///
+        /// </div>
         Verbatim(TokenStream),
 
         /// A while loop: `while expr { ... }`.

--- a/src/generics.rs
+++ b/src/generics.rs
@@ -403,6 +403,14 @@ ast_enum_of_structs! {
         Trait(TraitBound),
         Lifetime(Lifetime),
         PreciseCapture(PreciseCapture),
+
+        /// Tokens in bound position not interpreted by Syn.
+        ///
+        /// <div class="warning">
+        ///
+        /// Important: see [Compatibility notes][crate#verbatim-variants].
+        ///
+        /// </div>
         Verbatim(TokenStream),
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -80,25 +80,13 @@ ast_enum_of_structs! {
         Use(ItemUse),
 
         /// Tokens forming an item not interpreted by Syn.
+        ///
+        /// <div class="warning">
+        ///
+        /// Important: see [Compatibility notes][crate#verbatim-variants].
+        ///
+        /// </div>
         Verbatim(TokenStream),
-
-        // For testing exhaustiveness in downstream code, use the following idiom:
-        //
-        //     match item {
-        //         #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
-        //
-        //         Item::Const(item) => {...}
-        //         Item::Enum(item) => {...}
-        //         ...
-        //         Item::Verbatim(item) => {...}
-        //
-        //         _ => { /* some sane fallback */ }
-        //     }
-        //
-        // This way we fail your tests but don't break your library when adding
-        // a variant. You will be notified by a test failure when a variant is
-        // added, so that you can add code to handle it, but your library will
-        // continue to compile and work for downstream users in the interim.
     }
 }
 
@@ -729,25 +717,13 @@ ast_enum_of_structs! {
         Macro(ForeignItemMacro),
 
         /// Tokens in an `extern` block not interpreted by Syn.
+        ///
+        /// <div class="warning">
+        ///
+        /// Important: see [Compatibility notes][crate#verbatim-variants].
+        ///
+        /// </div>
         Verbatim(TokenStream),
-
-        // For testing exhaustiveness in downstream code, use the following idiom:
-        //
-        //     match item {
-        //         #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
-        //
-        //         ForeignItem::Fn(item) => {...}
-        //         ForeignItem::Static(item) => {...}
-        //         ...
-        //         ForeignItem::Verbatim(item) => {...}
-        //
-        //         _ => { /* some sane fallback */ }
-        //     }
-        //
-        // This way we fail your tests but don't break your library when adding
-        // a variant. You will be notified by a test failure when a variant is
-        // added, so that you can add code to handle it, but your library will
-        // continue to compile and work for downstream users in the interim.
     }
 }
 
@@ -829,25 +805,13 @@ ast_enum_of_structs! {
         Macro(TraitItemMacro),
 
         /// Tokens within the definition of a trait not interpreted by Syn.
+        ///
+        /// <div class="warning">
+        ///
+        /// Important: see [Compatibility notes][crate#verbatim-variants].
+        ///
+        /// </div>
         Verbatim(TokenStream),
-
-        // For testing exhaustiveness in downstream code, use the following idiom:
-        //
-        //     match item {
-        //         #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
-        //
-        //         TraitItem::Const(item) => {...}
-        //         TraitItem::Fn(item) => {...}
-        //         ...
-        //         TraitItem::Verbatim(item) => {...}
-        //
-        //         _ => { /* some sane fallback */ }
-        //     }
-        //
-        // This way we fail your tests but don't break your library when adding
-        // a variant. You will be notified by a test failure when a variant is
-        // added, so that you can add code to handle it, but your library will
-        // continue to compile and work for downstream users in the interim.
     }
 }
 
@@ -932,25 +896,13 @@ ast_enum_of_structs! {
         Macro(ImplItemMacro),
 
         /// Tokens within an impl block not interpreted by Syn.
+        ///
+        /// <div class="warning">
+        ///
+        /// Important: see [Compatibility notes][crate#verbatim-variants].
+        ///
+        /// </div>
         Verbatim(TokenStream),
-
-        // For testing exhaustiveness in downstream code, use the following idiom:
-        //
-        //     match item {
-        //         #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
-        //
-        //         ImplItem::Const(item) => {...}
-        //         ImplItem::Fn(item) => {...}
-        //         ...
-        //         ImplItem::Verbatim(item) => {...}
-        //
-        //         _ => { /* some sane fallback */ }
-        //     }
-        //
-        // This way we fail your tests but don't break your library when adding
-        // a variant. You will be notified by a test failure when a variant is
-        // added, so that you can add code to handle it, but your library will
-        // continue to compile and work for downstream users in the interim.
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,6 +262,106 @@
 //!   types.
 //! - **`proc-macro`** *(enabled by default)* — Runtime dependency on the
 //!   dynamic library libproc_macro from rustc toolchain.
+//!
+//! <br>
+//!
+//! # Compatibility notes
+//!
+//! Syn is able to accommodate most kinds of Rust grammar changes without a new
+//! major release through the following mechanisms.
+//!
+//! #### Modifiers
+//!
+//! Syntax tree structs which are expected to grow over the course of future
+//! releases of the Rust language, such as [`ItemTrait`], contain a `modifiers`
+//! field of one of several "Modifiers" types, in that case [`TraitModifiers`].
+//!
+//! All modifiers structs have the following commonalities:
+//!
+//! - Type name ending with "Modifiers".
+//!
+//! - Implements [`Default`]. The default value is guaranteed to comprise no
+//!   tokens.
+//!
+//! - Non-exhaustive. Can only be instantiated by Syn's parser or by creating
+//!   and then mutating an empty default value.
+//!
+//! - Does not implement [`Parse`][parse::Parse]. When parsing, they are parsed
+//!   by the enclosing syntax tree node.
+//!
+//! - Does not implement [`ToTokens`][quote::ToTokens]. In some cases the syntax
+//!   that might be held in modifiers in the future is not necessarily
+//!   contiguous tokens.
+//!
+//! - Provides `.require_empty() -> Result<()>` which returns a meaningfully
+//!   spanned error if the modifiers are different from the empty default. This
+//!   enables a caller to reject syntax it does not recognize without knowing
+//!   what that syntax may be.
+//!
+//! Across major versions, fields may be promoted out of a "Modifiers" struct
+//! into the enclosing syntax tree node(s), typically for syntax that has
+//! already been incorporated into a stable release of Rust or is deemed
+//! sufficiently on track for stabilization.
+//!
+//! #### Verbatim variants
+//!
+//! Syntax tree enums which are expected to grow over the course of future
+//! releases of the Rust language are declared non-exhaustive and may contain a
+//! variant named `Verbatim` that holds [`TokenStream`]. For example
+//! [`Expr::Verbatim`].
+//!
+//! Unstable language syntax for which a dedicated syntax tree node does not yet
+//! exist will get parsed to `Verbatim`, thus allowing unstable syntax to
+//! round-trip through parsing and printing of a syntax tree. For example you
+//! might parse token input to [`ItemTrait`] (a trait definition) in order to
+//! read or modify its method signatures, or insert associated types, or insert
+//! default function bodies. All of this would work even if there is some
+//! `Expr::Verbatim` syntax somewhere in one of the function bodies in the macro
+//! input.
+//!
+//! Verbatim variants are not intended to be constructed other than by Syn's
+//! parser. Do not rely on passing one containing arbitrary tokens through Syn's
+//! `ToTokens` implementations or through any other library, as it may panic or
+//! otherwise misbehave, such as failing to accurately parenthesize
+//! subexpressions to preserve precedence.
+//!
+//! It is important not to write code that expects Syn's parser to continue to
+//! produce `Verbatim` when parsing some particular syntax construct, as that
+//! behavior changes across patch releases of Syn. Patch releases can promote
+//! something that used to be parsed as `Verbatim` into a new dedicated syntax
+//! tree node. Verbatim variants are specifically only for round-tripping code
+//! not acted on by the caller.
+//!
+//! #### Non-exhaustive enums
+//!
+//! Some enums in the syntax tree are declared #\[non_exhaustive\] and cannot
+//! be pattern-matched using an exhaustive match; a default case (`_ => ...`) is
+//! required. New variants of these enums will be added over time corresponding
+//! to new Rust syntax.
+//!
+//! For testing the exhaustiveness of a match on such an enum in downstream
+//! code, it is recommended to use the following idiom.
+//!
+//! ```
+//! # use syn::Expr;
+//! #
+//! # fn example(expr: Expr) {
+//! match expr {
+//!     #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
+//!
+//!     Expr::Array(expr) => { /*...*/ }
+//!     Expr::Assign(expr) => { /*...*/ }
+#![cfg_attr(not(doctest), doc = "     ...")]
+//!     Expr::Yield(expr) => { /*...*/ }
+//!
+//!     _ => { /* some sane fallback */ }
+//! }
+//! # }
+//! ```
+//!
+//! This way you will be notified by a test failure when a variant is added, so
+//! that you can add code to handle it, but your library will continue to
+//! compile and work for downstream users in the interim.
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/syn/3.0.2")]

--- a/src/pat.rs
+++ b/src/pat.rs
@@ -81,28 +81,16 @@ ast_enum_of_structs! {
         Type(PatType),
 
         /// Tokens in pattern position not interpreted by Syn.
+        ///
+        /// <div class="warning">
+        ///
+        /// Important: see [Compatibility notes][crate#verbatim-variants].
+        ///
+        /// </div>
         Verbatim(TokenStream),
 
         /// A pattern that matches any value: `_`.
         Wild(PatWild),
-
-        // For testing exhaustiveness in downstream code, use the following idiom:
-        //
-        //     match pat {
-        //         #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
-        //
-        //         Pat::Box(pat) => {...}
-        //         Pat::Ident(pat) => {...}
-        //         ...
-        //         Pat::Wild(pat) => {...}
-        //
-        //         _ => { /* some sane fallback */ }
-        //     }
-        //
-        // This way we fail your tests but don't break your library when adding
-        // a variant. You will be notified by a test failure when a variant is
-        // added, so that you can add code to handle it, but your library will
-        // continue to compile and work for downstream users in the interim.
     }
 }
 

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -69,25 +69,13 @@ ast_enum_of_structs! {
         Tuple(TypeTuple),
 
         /// Tokens in type position not interpreted by Syn.
+        ///
+        /// <div class="warning">
+        ///
+        /// Important: see [Compatibility notes][crate#verbatim-variants].
+        ///
+        /// </div>
         Verbatim(TokenStream),
-
-        // For testing exhaustiveness in downstream code, use the following idiom:
-        //
-        //     match ty {
-        //         #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
-        //
-        //         Type::Array(ty) => {...}
-        //         Type::FnPtr(ty) => {...}
-        //         ...
-        //         Type::Verbatim(ty) => {...}
-        //
-        //         _ => { /* some sane fallback */ }
-        //     }
-        //
-        // This way we fail your tests but don't break your library when adding
-        // a variant. You will be notified by a test failure when a variant is
-        // added, so that you can add code to handle it, but your library will
-        // continue to compile and work for downstream users in the interim.
     }
 }
 


### PR DESCRIPTION
Rendered:

---

## Compatibility notes

Syn is able to accommodate most kinds of Rust grammar changes without a new major release through the following mechanisms.

### Modifiers

Syntax tree structs which are expected to grow over the course of future releases of the Rust language, such as [`ItemTrait`], contain a `modifiers` field of one of several "Modifiers" types, in that case [`TraitModifiers`].

All modifiers structs have the following commonalities:

- Type name ending with "Modifiers".

- Implements [`Default`]. The default value is guaranteed to comprise no tokens.

- Non-exhaustive. Can only be instantiated by Syn's parser or by creating and then mutating an empty default value.

- Does not implement [`Parse`][parse::Parse]. When parsing, they are parsed by the enclosing syntax tree node.

- Does not implement [`ToTokens`][quote::ToTokens]. In some cases the syntax that might be held in modifiers in the future is not necessarily contiguous tokens.

- Provides `.require_empty() -> Result<()>` which returns a meaningfully spanned error if the modifiers are different from the empty default. This enables a caller to reject syntax it does not recognize without knowing what that syntax may be.

Across major versions, fields may be promoted out of a "Modifiers" struct into the enclosing syntax tree node(s), typically for syntax that has already been incorporated into a stable release of Rust or is deemed sufficiently on track for stabilization.

### Verbatim variants

Syntax tree enums which are expected to grow over the course of future releases of the Rust language are declared non-exhaustive and may contain a variant named `Verbatim` that holds [`TokenStream`]. For example [`Expr::Verbatim`].

Unstable language syntax for which a dedicated syntax tree node does not yet exist will get parsed to `Verbatim`, thus allowing unstable syntax to round-trip through parsing and printing of a syntax tree. For example you might parse token input to [`ItemTrait`] (a trait definition) in order to read or modify its method signatures, or insert associated types, or insert default function bodies. All of this would work even if there is some `Expr::Verbatim` syntax somewhere in one of the function bodies in the macro input.

Verbatim variants are not intended to be constructed other than by Syn's parser. Do not rely on passing one containing arbitrary tokens through Syn's `ToTokens` implementations or through any other library, as it may panic or otherwise misbehave, such as failing to accurately parenthesize subexpressions to preserve precedence.

It is important not to write code that expects Syn's parser to continue to produce `Verbatim` when parsing some particular syntax construct, as that behavior changes across patch releases of Syn. Patch releases can promote something that used to be parsed as `Verbatim` into a new dedicated syntax tree node. Verbatim variants are specifically only for round-tripping code not acted on by the caller.

### Non-exhaustive enums

Some enums in the syntax tree are declared #\[non_exhaustive\] and cannot be pattern-matched using an exhaustive match; a default case (`_ => ...`) is required. New variants of these enums will be added over time corresponding to new Rust syntax.

For testing the exhaustiveness of a match on such an enum in downstream code, it is recommended to use the following idiom.

```rust
match expr {
    #![cfg_attr(test, deny(non_exhaustive_omitted_patterns))]

    Expr::Array(expr) => { /*...*/ }
    Expr::Assign(expr) => { /*...*/ }
    ...
    Expr::Yield(expr) => { /*...*/ }

    _ => { /* some sane fallback */ }
}
```

This way you will be notified by a test failure when a variant is added, so that you can add code to handle it, but your library will continue to compile and work for downstream users in the interim.