### PR TITLE
In LitStr::parse_with, report correct span for lex errors

### DIFF
--- a/src/lit.rs
+++ b/src/lit.rs
@@ -246,7 +246,8 @@ impl LitStr {
         // Parse string literal into a token stream with every span equal to the
         // original literal's span.
         let span = self.span();
-        let mut tokens = TokenStream::from_str(&self.value())?;
+        let mut tokens =
+            TokenStream::from_str(&self.value()).map_err(|err| Error::new(span, err))?;
         tokens = respan_token_stream(tokens, span);
 
         let result = crate::parse::parse_scoped(parser, span, tokens)?;


### PR DESCRIPTION
In proc macros, we were previously falling back to `Span::call_site` in this case. The other errors in this function return correct spans, so match that here.

(Not sure how to write a test for this in this repo, but I patched it into a dependency and it seems to work.)